### PR TITLE
Add progressive loading to the homepage post grid

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,7 +46,7 @@ Filenames follow `YYYY-MM-DD-slug.md`; that date is just for ordering files on d
 ### Client-side JS (`src/js/`, passthrough-copied, no bundler/build step)
 
 - `theme.js`: light/dark mode via `localStorage['theme-preference']` + `.dark` class on `<html>`, toggled by `#theme-toggle`, synced across tabs via the `storage` event.
-- `tag-filter-checkboxes.js`: client-side filter of `#posts-grid .post-card` elements against checked `.tag-checkbox` inputs - **OR logic** (a post shows if it matches *any* checked tag), persists selection to the URL hash (`#tags=...`) and restores it on load.
+- `tag-filter-checkboxes.js`: client-side filter of `#posts-grid .post-card` elements against checked `.tag-checkbox` inputs - **OR logic** (a post shows if it matches *any* checked tag), persists selection to the URL hash (`#tags=...`) and restores it on load. Also owns progressive rendering of the (already fully server-rendered) grid: only the first 10 matching posts are shown at a time; the `#posts-load-more` button reveals 10 more per click and auto-triggers via `IntersectionObserver` as it scrolls into view. Filter changes reset back to the first 10.
 - `code-copy.js`: adds copy-to-clipboard buttons to Prism-highlighted code blocks.
 
 ### Styling (`src/styles/input.css` -> `_site/styles/output.css`)

--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ A modern, responsive blog built with Eleventy and Tailwind CSS, featuring light/
 - 🚀 Fast static site generation with Eleventy
 - 🎯 SEO-friendly
 - 🖼️ Blog post cards with images, author, date, and summary
+- 📜 Progressive post loading - homepage grid loads 10 posts at a time, with more revealed as you scroll
+- 🏷️ Client-side tag filtering with OR logic and URL-hash persistence
 
 ## Getting Started
 

--- a/src/index.njk
+++ b/src/index.njk
@@ -153,6 +153,16 @@ description: Welcome to Tech Notes where I share thoughts on technology, program
     </a>
     {% endfor %}
   </div>
+
+  <div id="posts-load-more-wrap" class="mt-8 flex justify-center">
+    <button
+      id="posts-load-more"
+      type="button"
+      class="btn btn-primary hidden"
+    >
+      Load more posts
+    </button>
+  </div>
   {% else %}
   <div class="text-center py-12">
     <p class="text-xl text-gray-600 dark:text-gray-400">No posts yet. Check back soon!</p>

--- a/src/js/tag-filter-checkboxes.js
+++ b/src/js/tag-filter-checkboxes.js
@@ -1,65 +1,94 @@
-// Multi-tag filtering with checkboxes
+// Multi-tag filtering with checkboxes + progressive ("load more") rendering
 document.addEventListener('DOMContentLoaded', function() {
   const checkboxes = document.querySelectorAll('.tag-checkbox');
   const clearButton = document.getElementById('clear-filters');
   const postsGrid = document.getElementById('posts-grid');
   const filterStatus = document.getElementById('filter-status');
+  const loadMoreButton = document.getElementById('posts-load-more');
 
   if (!postsGrid) return;
 
-  // Update the display based on selected tags
-  function updatePosts() {
-    const selectedTags = Array.from(checkboxes)
+  const PAGE_SIZE = 10;
+  const allPosts = Array.from(postsGrid.querySelectorAll('.post-card'));
+  let visibleLimit = PAGE_SIZE;
+
+  function getSelectedTags() {
+    return Array.from(checkboxes)
       .filter(cb => cb.checked)
       .map(cb => cb.dataset.tag);
+  }
 
-    const posts = postsGrid.querySelectorAll('.post-card');
-    let visibleCount = 0;
+  function matchesTags(post, selectedTags) {
+    if (selectedTags.length === 0) return true;
+    const postTags = post.dataset.tags ? post.dataset.tags.split(',') : [];
+    return selectedTags.some(tag => postTags.includes(tag));
+  }
 
-    posts.forEach(post => {
-      const postTags = post.dataset.tags ? post.dataset.tags.split(',') : [];
+  // Show/hide posts based on the active tag filter and how many pages have
+  // been revealed so far. Does not reset visibleLimit - call updatePosts()
+  // for that (e.g. when the filter selection changes).
+  function render() {
+    const selectedTags = getSelectedTags();
+    const matching = allPosts.filter(post => matchesTags(post, selectedTags));
+    const matchingIndex = new Map(matching.map((post, i) => [post, i]));
 
-      // Show post if it has ANY of the selected tags (OR logic)
-      // Or if no tags are selected, show all posts
-      let shouldShow = selectedTags.length === 0;
+    let shownCount = 0;
+    allPosts.forEach(post => {
+      const index = matchingIndex.get(post);
+      const isWithinLimit = index !== undefined && index < visibleLimit;
 
-      if (selectedTags.length > 0) {
-        shouldShow = selectedTags.some(tag => postTags.includes(tag));
-      }
-
-      if (shouldShow) {
+      if (isWithinLimit) {
         post.style.display = '';
         post.classList.add('fadeIn');
-        visibleCount++;
+        shownCount++;
       } else {
         post.style.display = 'none';
         post.classList.remove('fadeIn');
       }
     });
 
-    // Update filter status message
+    const totalMatching = matching.length;
+
     if (selectedTags.length === 0) {
-      filterStatus.textContent = `Showing all ${visibleCount} posts`;
+      filterStatus.textContent = `Showing ${shownCount} of ${totalMatching} posts`;
     } else if (selectedTags.length === 1) {
-      filterStatus.textContent = `Filtered by "${selectedTags[0]}" (${visibleCount} ${visibleCount === 1 ? 'post' : 'posts'})`;
+      filterStatus.textContent = `Filtered by "${selectedTags[0]}" - showing ${shownCount} of ${totalMatching}`;
     } else {
-      filterStatus.textContent = `Filtered by ${selectedTags.length} tags (${visibleCount} ${visibleCount === 1 ? 'post' : 'posts'})`;
+      filterStatus.textContent = `Filtered by ${selectedTags.length} tags - showing ${shownCount} of ${totalMatching}`;
     }
 
-    // Update URL hash with selected tags
     if (selectedTags.length > 0) {
       window.history.replaceState(null, '', '#tags=' + selectedTags.join(','));
     } else {
       window.history.replaceState(null, '', window.location.pathname);
     }
+
+    if (loadMoreButton) {
+      const remaining = totalMatching - shownCount;
+      if (remaining > 0) {
+        loadMoreButton.textContent = `Load more posts (${remaining} remaining)`;
+        loadMoreButton.classList.remove('hidden');
+      } else {
+        loadMoreButton.classList.add('hidden');
+      }
+    }
   }
 
-  // Add event listeners to all checkboxes
+  // Recompute from the first page - used when the filter selection changes.
+  function updatePosts() {
+    visibleLimit = PAGE_SIZE;
+    render();
+  }
+
+  function loadMore() {
+    visibleLimit += PAGE_SIZE;
+    render();
+  }
+
   checkboxes.forEach(checkbox => {
     checkbox.addEventListener('change', updatePosts);
   });
 
-  // Clear all filters button
   if (clearButton) {
     clearButton.addEventListener('click', function() {
       checkboxes.forEach(cb => cb.checked = false);
@@ -67,7 +96,24 @@ document.addEventListener('DOMContentLoaded', function() {
     });
   }
 
-  // Handle URL hash on load (restore filter state)
+  if (loadMoreButton) {
+    loadMoreButton.addEventListener('click', loadMore);
+
+    // Auto-load as the button scrolls into view, so posts load
+    // progressively while scrolling rather than requiring a click.
+    if ('IntersectionObserver' in window) {
+      const observer = new IntersectionObserver(entries => {
+        entries.forEach(entry => {
+          if (entry.isIntersecting && !loadMoreButton.classList.contains('hidden')) {
+            loadMore();
+          }
+        });
+      }, { rootMargin: '300px' });
+      observer.observe(loadMoreButton);
+    }
+  }
+
+  // Restore filter state from the URL hash on load, then render.
   function restoreFilterState() {
     const hash = window.location.hash;
     if (hash.startsWith('#tags=')) {
@@ -77,12 +123,8 @@ document.addEventListener('DOMContentLoaded', function() {
           cb.checked = true;
         }
       });
-      updatePosts();
-    } else {
-      // Show initial count
-      const totalPosts = postsGrid.querySelectorAll('.post-card').length;
-      filterStatus.textContent = `Showing all ${totalPosts} posts`;
     }
+    render();
   }
 
   restoreFilterState();


### PR DESCRIPTION
## Summary
- Homepage post grid now shows only the first 10 posts initially instead of rendering all posts visible at once
- A "Load more" button reveals 10 more posts per click and also auto-triggers via `IntersectionObserver` as it scrolls into view, so it behaves like infinite scroll while remaining keyboard/no-JS accessible
- Tag filtering (`tag-filter-checkboxes.js`) now resets pagination back to the first page whenever the filter selection changes, and the filter status text reports "Showing X of Y posts"
- All posts are still fully server-rendered at build time (required for GitHub Pages, which has no backend) — this is purely client-side progressive *display*, not server-side pagination

## Test plan
- [x] `npm run deploy` builds cleanly
- [x] Verified in a headless browser against the built `_site`: 30 posts render in the DOM, only 10 visible initially, "Load more" button shows correct remaining count
- [x] Clicking "Load more" reveals the next 10 posts
- [x] Scrolling to the bottom auto-loads remaining posts via `IntersectionObserver`
- [x] Selecting a tag filter resets to the first page and shows only matching posts

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>


---
_Generated by [Claude Code](https://claude.ai/code/session_01WKyNF7L5qzrfct8cec6A32)_