### PR TITLE
Improve SEO: structured data, complete OG/article tags, 404 page

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -18,6 +18,12 @@ module.exports = function(eleventyConfig) {
     });
   });
 
+  // Find a page in a collection by its output URL (used by sitemap.njk to
+  // pull an accurate <lastmod> for the static top-level pages)
+  eleventyConfig.addFilter("findByUrl", (collection, url) => {
+    return collection.find(page => page.url === url);
+  });
+
   // Sort posts by date (newest first) and filter out future posts
   eleventyConfig.addCollection("posts", function(collectionApi) {
     const now = new Date();

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,9 +24,10 @@ There is no test suite and no lint script in this repo. Node 24 is required (`.n
 - `input: src`, `output: _site`, includes/layouts dirs under `src/_includes` / `src/_layouts`
 - `templateFormats: ["md", "njk", "html"]`; `markdownTemplateEngine: false` (markdown is rendered as-is, then wrapped by the `njk` layout named in front matter)
 - Passthrough copy: `src/images/**` and `src/js/**` go straight to `_site` unprocessed
-- `posts` collection: globs `src/posts/*.md`, **filters out posts whose front-matter `date` is in the future**, sorted newest-first
+- `posts` collection: globs `src/posts/*.md`, **filters out posts whose front-matter `date` is in the future**, sorted newest-first. Note: this only gates the homepage/RSS/sitemap listing - Eleventy still builds a real, public, unauthenticated HTML page for every post file regardless of date, so a future-dated post's URL is live (just unlinked) before its listed publish date. This is a known, intentional tradeoff (not currently gated with `noindex`).
 - `tagListWithCounts` collection: aggregates tag counts across non-future posts (excludes the `posts`/`all` tags), drives the homepage tag-filter sidebar
 - `readableDate` filter formats dates for display
+- `findByUrl` filter: `collection | findByUrl(url)` - finds a page in a collection by its output `url`; used by `sitemap.njk` to read each static page's own `date` for `<lastmod>`
 
 ### Content model (`src/posts/*.md`)
 
@@ -37,11 +38,12 @@ Filenames follow `YYYY-MM-DD-slug.md`; that date is just for ordering files on d
 ### Layouts (`src/_layouts/`)
 
 - `base.njk`: full HTML shell - nav, theme toggle, footer, all `<head>` metadata (OG/Twitter cards fall back to `/images/og-default.png` if a post has no `image`), Clarity + GA4 analytics, loads `/styles/output.css`. Loads `theme.js` synchronously in `<head>` (avoids flash-of-wrong-theme) and `tag-filter-checkboxes.js` / `code-copy.js` at the end of `<body>`, plus Prism.js + per-language components via CDN (currently yaml/bash/javascript/json - add another `<script src=".../prism-<lang>.min.js">` here if a post needs highlighting for another language).
+  - SEO: `og:type` is `article` (with `article:published_time`/`article:author`) on `/posts/*` URLs and `website` elsewhere, detected via `page.url.startsWith('/posts/')`. JSON-LD is emitted in `<head>` - `BlogPosting` + `BreadcrumbList` (`@graph`) on posts, `WebSite` elsewhere - built as a Nunjucks object literal and serialized with the `dump` filter (`| dump | safe`, not manual string interpolation, so titles/descriptions containing quotes don't break the JSON). Any page can opt into `<meta name="robots">` by setting a `robots` front-matter value (used by `404.njk` for `noindex`).
 - `post.njk`: extends `base.njk`. Renders a hero - full-bleed image with `<picture>`/webp source if `image` is set, otherwise a gradient fallback - then post content inside `.prose`, then a "Back to all posts" link.
 
 ### Top-level pages (`src/*.njk`)
 
-`index.njk` (homepage post grid + tag-filter sidebar over `collections.posts` / `collections.tagListWithCounts`), `feed.njk` (Atom feed at `/feed/` via `@11ty/eleventy-plugin-rss`), `about.njk`, `privacy.njk`, `terms.njk`, `robots.njk`, `sitemap.njk`.
+`index.njk` (homepage post grid + tag-filter sidebar over `collections.posts` / `collections.tagListWithCounts`), `feed.njk` (Atom feed at `/feed/` via `@11ty/eleventy-plugin-rss`), `about.njk`, `privacy.njk`, `terms.njk`, `robots.njk`, `sitemap.njk` (uses the custom `findByUrl` Eleventy filter to pull each static page's own git-derived `date` for an accurate `<lastmod>`), `404.njk` (permalink `/404.html` - GitHub Pages serves this automatically for unmatched URLs; sets `robots: noindex`).
 
 ### Client-side JS (`src/js/`, passthrough-copied, no bundler/build step)
 

--- a/src/404.njk
+++ b/src/404.njk
@@ -1,0 +1,21 @@
+---
+layout: base.njk
+title: Page Not Found
+description: The page you're looking for doesn't exist.
+permalink: /404.html
+eleventyExcludeFromCollections: true
+robots: noindex
+---
+
+<div class="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 py-24 text-center">
+  <p class="text-primary-600 dark:text-primary-400 text-lg font-semibold mb-2">404</p>
+  <h1 class="text-4xl md:text-5xl font-bold text-gray-900 dark:text-white mb-4">
+    Page not found
+  </h1>
+  <p class="text-xl text-gray-600 dark:text-gray-400 mb-8">
+    The link might be broken, or the page may have moved.
+  </p>
+  <a href="/" class="btn btn-primary inline-block">
+    Back to Home
+  </a>
+</div>

--- a/src/_layouts/base.njk
+++ b/src/_layouts/base.njk
@@ -5,6 +5,8 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>{% if title %}{{ title }} | {{ site.title }}{% else %}{{ site.title }}{% endif %}</title>
   <meta name="description" content="{{ description or summary or site.description }}">
+  <meta name="author" content="{{ author or site.author.name }}">
+  {% if robots %}<meta name="robots" content="{{ robots }}">{% endif %}
 
   <!-- Favicon -->
   <link rel="icon" type="image/svg+xml" href="/images/favicon.svg">
@@ -15,12 +17,19 @@
   <!-- Canonical -->
   <link rel="canonical" href="{{ site.url }}{{ page.url }}">
 
+  {% set isPost = page.url.startsWith('/posts/') %}
+
   <!-- Open Graph / Facebook -->
-  <meta property="og:type" content="website">
+  <meta property="og:type" content="{% if isPost %}article{% else %}website{% endif %}">
+  <meta property="og:site_name" content="{{ site.title }}">
   <meta property="og:url" content="{{ site.url }}{{ page.url }}">
   <meta property="og:title" content="{% if title %}{{ title }} | {{ site.title }}{% else %}{{ site.title }}{% endif %}">
   <meta property="og:description" content="{{ description or summary or site.description }}">
   <meta property="og:image" content="{{ site.url }}{{ image or '/images/og-default.png' }}">
+  {% if isPost %}
+  <meta property="article:published_time" content="{{ date | dateToRfc3339 }}">
+  <meta property="article:author" content="{{ author or site.author.name }}">
+  {% endif %}
 
   <!-- Twitter -->
   <meta property="twitter:card" content="summary_large_image">
@@ -28,6 +37,46 @@
   <meta name="twitter:title" content="{% if title %}{{ title }} | {{ site.title }}{% else %}{{ site.title }}{% endif %}">
   <meta name="twitter:description" content="{{ description or summary or site.description }}">
   <meta name="twitter:image" content="{{ site.url }}{{ image or '/images/og-default.png' }}">
+
+  <!-- Structured Data (JSON-LD) -->
+  {% if isPost %}
+    {% set structuredData = {
+      "@context": "https://schema.org",
+      "@graph": [
+        {
+          "@type": "BlogPosting",
+          "headline": title,
+          "description": description or summary or site.description,
+          "image": site.url + (image or '/images/og-default.png'),
+          "datePublished": date | dateToRfc3339,
+          "dateModified": date | dateToRfc3339,
+          "author": { "@type": "Person", "name": author or site.author.name },
+          "publisher": {
+            "@type": "Organization",
+            "name": site.title,
+            "logo": { "@type": "ImageObject", "url": site.url + "/images/favicon.svg" }
+          },
+          "mainEntityOfPage": { "@type": "WebPage", "@id": site.url + page.url }
+        },
+        {
+          "@type": "BreadcrumbList",
+          "itemListElement": [
+            { "@type": "ListItem", "position": 1, "name": "Home", "item": site.url + "/" },
+            { "@type": "ListItem", "position": 2, "name": title, "item": site.url + page.url }
+          ]
+        }
+      ]
+    } %}
+  {% else %}
+    {% set structuredData = {
+      "@context": "https://schema.org",
+      "@type": "WebSite",
+      "name": site.title,
+      "url": site.url,
+      "description": site.description
+    } %}
+  {% endif %}
+  <script type="application/ld+json">{{ structuredData | dump | safe }}</script>
 
   <!-- Theme Color -->
   <meta name="theme-color" content="#0284c7" media="(prefers-color-scheme: light)">

--- a/src/sitemap.njk
+++ b/src/sitemap.njk
@@ -7,24 +7,28 @@ eleventyExcludeFromCollections: true
 
   <url>
     <loc>{{ site.url }}/</loc>
+    <lastmod>{{ (collections.all | findByUrl("/")).date | dateToRfc3339 }}</lastmod>
     <changefreq>daily</changefreq>
     <priority>1.0</priority>
   </url>
 
   <url>
     <loc>{{ site.url }}/about/</loc>
+    <lastmod>{{ (collections.all | findByUrl("/about/")).date | dateToRfc3339 }}</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.5</priority>
   </url>
 
   <url>
     <loc>{{ site.url }}/privacy/</loc>
+    <lastmod>{{ (collections.all | findByUrl("/privacy/")).date | dateToRfc3339 }}</lastmod>
     <changefreq>yearly</changefreq>
     <priority>0.2</priority>
   </url>
 
   <url>
     <loc>{{ site.url }}/terms/</loc>
+    <lastmod>{{ (collections.all | findByUrl("/terms/")).date | dateToRfc3339 }}</lastmod>
     <changefreq>yearly</changefreq>
     <priority>0.2</priority>
   </url>


### PR DESCRIPTION
## Summary
- Add JSON-LD structured data to every page: `BlogPosting` + `BreadcrumbList` (via `@graph`) on post pages, `WebSite` elsewhere. Built as a Nunjucks object literal and serialized with the `dump` filter (not manual string interpolation), so post titles/descriptions containing quotes can't break the embedded JSON.
- `og:type` is now `article` on post pages (was hardcoded `website` everywhere), with `article:published_time` / `article:author`. Added `og:site_name` and a page-level `<meta name="author">`.
- `sitemap.xml` now includes `<lastmod>` for the static top-level pages (home/about/privacy/terms), via a new `findByUrl` Eleventy filter that reads each page's own git-derived date instead of only posts having accurate `lastmod`.
- Added a custom 404 page (`src/404.njk`, permalink `/404.html`) that GitHub Pages serves automatically for unmatched URLs, styled to match the site and marked `noindex` via a new generic `robots` front-matter hook in `base.njk`.

This was scoped from an SEO audit: Lighthouse CI's `seo` category already passes on the live site (confirmed from the last deploy run's logs), but Lighthouse's SEO check is shallow and doesn't catch missing structured data or incomplete Open Graph/article metadata, which is what this PR addresses. Two items surfaced by the audit were explicitly deferred by request: adding `noindex` to future-dated draft posts (left as-is), and Twitter `site`/`creator` handles (no handle available).

## Test plan
- [x] `npm run deploy` builds cleanly
- [x] Verified in a headless browser against the built `_site`:
  - Homepage JSON-LD parses as valid `WebSite` schema
  - Post-page JSON-LD parses as valid `BlogPosting` + `BreadcrumbList` schema.org data
  - `og:type=article`, `article:published_time`, `article:author` present on post pages; `og:type=website` elsewhere
  - `sitemap.xml` is well-formed XML with accurate per-page `<lastmod>`
  - `/404.html` renders on-brand with nav, "Back to Home" link, and `noindex` meta
  - Homepage/post pages render unchanged visually (no regression from the shared `base.njk` edit)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>


---
_Generated by [Claude Code](https://claude.ai/code/session_01WKyNF7L5qzrfct8cec6A32)_