### PR TITLE
docs: bootstrap docs/ with real repo content

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -76,6 +76,17 @@ node scripts/a11y-check.js
 
 `playwright`/`axe-core` are deliberately **not** in `package.json` - adding them would make `npm ci` download a full Chromium browser on every `build-check.yml`/`deploy.yml` run for a check that isn't wired into CI. Install them on-demand per session instead.
 
+## Documentation
+
+**At the end of any development work, update whichever of these are now stale - don't leave it for a later session to rediscover:**
+
+- `CLAUDE.md` (this file) - architecture/convention changes, new scripts or workflow rules, anything a future session would otherwise have to re-derive from the code
+- `README.md` - anything a human contributor setting up or extending the project would need (setup steps, front-matter conventions, project structure)
+- `editorial-plan.md` - per-post `Status`/`File` fields as posts move `idea` → `draft` → `published`
+- `docs/` - `docs/context/gaps.md` if the change resolves or introduces an open question, `docs/decisions/` for a new durable implementation choice worth explaining later, `docs/patterns/` if a reusable approach changed. See `docs/README.md` for what belongs where.
+
+Verify claims against the actual repo state (grep the code, check the workflow file, run the command) rather than writing what should be true from memory - several stale/incorrect doc claims found and fixed this way already (a `README.md` describing manual `gh-pages` deployment when `deploy.yml` already automated it; a `tailwind.config.js` reference for a file that doesn't exist under Tailwind v4's CSS-native config).
+
 ## CI/CD (`.github/workflows/`)
 
 - `build-check.yml`: PR gate against `main` - `npm ci` then `npm run deploy` must succeed

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -1,59 +1,50 @@
 # Architecture Overview
 
-Document the actual runtime shape of this repo.
-
-Prefer concrete file paths, execution flow, and integration boundaries over abstract architecture language.
-
-Exclude target-state redesign ideas, generic architecture filler, and untouched sample content that has not been adapted to this repo.
-
 ## System Shape
 
-Describe the current system or runtime surface:
+A static site: Eleventy v2 compiles Markdown/Nunjucks under `src/` into plain HTML in `_site/`, Tailwind v4 compiles `src/styles/input.css` into `_site/styles/output.css` as a separate build step, and GitHub Pages serves the result. No server, no database, no runtime backend of any kind - `_site/` is disposable build output, never committed.
 
-- what kind of software this repo contains
-- the primary execution entrypoints
-- the main user, maintainer, or automation flow
+Primary execution entrypoints are npm scripts in `package.json` (`dev`, `build`, `build:css`, `deploy`) and two GitHub Actions workflows (`build-check.yml`, `deploy.yml`). There is no CLI or API surface beyond that.
 
 ## Key Modules and Responsibilities
 
-List the major files, directories, or components and what each one owns.
-
-Use real repo paths where possible.
+- **`.eleventy.js`**: Eleventy config - input/output dirs, `templateFormats`, the `posts` and `tagListWithCounts` collections (both date-filtered, see `docs/product/overview.md`), the `readableDate` and `findByUrl` filters. `findByUrl` exists specifically so `sitemap.njk` can pull each static page's own git-derived `date` for an accurate `<lastmod>`.
+- **`src/_layouts/base.njk`**: the entire HTML shell - nav, footer, all `<head>` metadata (SEO/OG/Twitter/JSON-LD), Prism.js + per-language CDN components, Clarity/GA4 analytics. Every page in the site extends this, directly or via `post.njk`.
+- **`src/_layouts/post.njk`**: extends `base.njk`; renders the post hero (full-bleed image or gradient fallback) and wraps content in `.prose`.
+- **`src/js/`** (passthrough-copied, no bundler): `theme.js` (dark mode), `tag-filter-checkboxes.js` (tag filtering + homepage progressive-loading pagination, both owned by the same file), `code-copy.js` (copy-to-clipboard buttons + keyboard-accessibility attributes on scrollable code blocks).
+- **`scripts/a11y-check.js`**: the only automated verification in the repo. Spins up a static file server, drives headless Chromium via Playwright, runs axe-core against 6 representative pages in light + dark mode. Not wired into CI (see `docs/decisions/`).
+- **`src/_data/site.json`**: global template data (site title, description, canonical URL, author contact info).
 
 ## Important Flows
 
-Capture the highest-signal flow or two, such as:
+**Local dev**: `npm run dev` runs `npm-run-all --parallel start watch:css` - Eleventy's dev server plus a Tailwind watcher, both writing into a live `_site/`.
 
-- startup or invocation path
-- request or job processing flow
-- action or CLI execution flow
-- test or packaging flow
+**Production build**: `npm run deploy` = `npm run build && npm run build:css` - Eleventy build first, Tailwind CSS build second (Tailwind reads the already-built `_site/` structure for content scanning). This exact two-step order matters and is what both CI workflows run.
 
-Call out notable edge cases when code or tests prove them.
+**PR flow**: `build-check.yml` runs `npm ci && npm run deploy` against every PR targeting `main`. No deployment, no accessibility check - it's a build-succeeds gate only.
+
+**Deploy flow**: `deploy.yml` runs on push to `main`, on a daily cron, and via manual dispatch. Builds the same way as `build-check.yml`, uploads `_site/` as a Pages artifact, deploys via `actions/deploy-pages`, then runs Lighthouse CI against the live deployed URL per `.lighthouserc.json` (performance ≥0.8 warn, accessibility ≥0.9 error, best-practices/SEO ≥0.9 warn - accessibility is the only category that fails the build).
+
+**Accessibility flow** (agent-driven, not CI-enforced): `npm run deploy && node scripts/a11y-check.js` - CLAUDE.md requires this after any change touching shared templates/layouts/`input.css`, or after adding a new post. Violations found this way get fixed in the same work session, not just reported (real example: this workflow found and fixed a site-wide `scrollable-region-focusable` violation in `code-copy.js`, and three separate `color-contrast` violations traced back to `primary-600`/`primary-500` failing WCAG AA's 4.5:1 minimum - see git history around 2026-07-11/12 for the fixes).
 
 ## Integrations and Platform Surfaces
 
-Record the important external or platform-facing boundaries, such as:
-
-- APIs
-- CI workflows
-- action metadata
-- environment variables
-- generated artifacts
+- **GitHub Pages**: the only deployment target. `actions/deploy-pages`, not a `gh-pages` branch.
+- **GitHub Actions**: `build-check.yml`, `deploy.yml` (both real, active); `squad-*.yml` (separate, likely-dormant automation - see `docs/product/overview.md`).
+- **External CDNs loaded at runtime**: Google Fonts (`fonts.googleapis.com`), Prism.js + language components (`cdnjs.cloudflare.com`), Microsoft Clarity, Google Analytics (`gtag.js`). **Observed operational note**: in this Claude Code sandbox specifically, both `cdnjs.cloudflare.com` and `api.openai.com` have been hit with hard `403` proxy-policy denials during this session (confirmed via `curl` and via an attempted MCP image-generation server) - this is a sandbox network-policy characteristic, not a defect in the site. `scripts/a11y-check.js` works around exactly this by blocking all non-localhost requests during its scan.
+- **Azure AI Foundry / Azure AI Search / GitHub Packages / GitHub Rulesets, etc.**: these are *subjects of blog posts*, not integrations this repo actually has - the code examples in `src/posts/*.md` are illustrative content, not executed by anything in this repository.
 
 ## Build, Test, and Delivery
 
-Document the commands, scripts, and workflow files that matter for:
-
-- install
-- build or packaging
-- automated tests
-- release or deployment
+- Install: `npm ci` (Node 24 - see `docs/context/gaps.md` for a version-pin inconsistency worth resolving).
+- Build: `npm run deploy` (`build` + `build:css`, in that order).
+- Test: none in the conventional sense. `scripts/a11y-check.js` is real but manual/agent-invoked, not part of `npm ci`'s dependency graph (deliberately - see `docs/decisions/`).
+- Release: push to `main` → `deploy.yml` → GitHub Pages, fully automated, no manual deployment step.
 
 ## Observed Evidence
 
-List the source files, tests, scripts, manifests, and workflow files that support this architecture summary.
+`.eleventy.js`, `package.json` scripts, `.github/workflows/build-check.yml`, `.github/workflows/deploy.yml`, `.lighthouserc.json`, `scripts/a11y-check.js`, `src/_layouts/base.njk`, `CLAUDE.md`.
 
 ## Assumptions and Open Questions
 
-If the repo leaves something ambiguous, record it explicitly so a reviewer can confirm or correct it.
+See `docs/context/gaps.md`.

--- a/docs/context/bootstrap-report.md
+++ b/docs/context/bootstrap-report.md
@@ -1,43 +1,58 @@
 # Bootstrap Report
 
-Use this file to record what happened during the latest AI-SDLC bootstrap pass.
-
-This file is a review artifact. Keep durable product, architecture, glossary, and constitution guidance in their canonical docs instead of duplicating it here.
-
 ## Repo Classification
 
-- `existing-project` or `new-project`
+`existing-project` - active blog with 38+ published/drafted posts, working CI/CD, and a maintained (non-Squad) editorial process, as of this pass.
 
 ## Evidence Sources Used
 
-List the main files or directories you relied on, for example:
-
-- `src/...`
-- `tests/...`
-- manifest files
-- CI workflows
-- existing docs
+- `.eleventy.js`, `package.json`, `.nvmrc`, `.lighthouserc.json`
+- `.github/workflows/build-check.yml`, `deploy.yml`, `squad-*.yml`
+- `src/_layouts/base.njk`, `post.njk`; `src/js/*.js`; `src/styles/input.css`
+- `src/_data/site.json`
+- `scripts/a11y-check.js`
+- `editorial-plan.md`, `CLAUDE.md`, `README.md`
+- `.squad/decisions.md`, `.squad/WORKFLOW.md`
+- `src/posts/*.md` (grepped for code-fence languages, Prism component coverage, and cross-post SDK/convention consistency)
+- Direct conversation history from this session: the SEO audit (2026-07-11), accessibility remediation (2026-07-11/12), the September editorial batch (#126-129, 2026-07-12), and two explicit maintainer decisions (future-dated posts stay `noindex`-free; image generation via ChatGPT, not an MCP/API integration)
 
 ## Durable Docs Reviewed
 
-List the durable docs you inspected before editing them.
+`CLAUDE.md` (primary - kept current every session, treated as more authoritative than anything below it), `README.md`, `editorial-plan.md`. This `docs/` tree was entirely scaffold-only before this pass - nothing here to reconcile against yet.
 
 ## Created or Updated
 
-List the files created or updated in this bootstrap run.
+All previously-scaffold files, populated with real repo content:
+
+- `docs/product/overview.md`
+- `docs/architecture/overview.md`
+- `docs/product/glossary.md`
+- `docs/context/repo-map.md`
+- `docs/context/gaps.md`
+- `docs/context/index.yaml`
+- `docs/context/bootstrap-report.md` (this file)
+- `docs/patterns/blog-post-authoring.md` (new)
+- `docs/decisions/2026-07-12-hero-images-are-a-manual-handoff.md` (new)
+- `docs/decisions/2026-07-12-axe-core-and-playwright-stay-uncommitted.md` (new)
+
+Left untouched, deliberately: `docs/architecture/adr/` (sample scaffold - no decision in this repo rises to ADR scale; no database exists), `docs/architecture/database-schema-example.md` (sample scaffold - no database).
 
 ## Support Files Refreshed
 
-Call out whether `docs/context/index.yaml` and `docs/context/gaps.md` were created or updated.
+Both `docs/context/index.yaml` and `docs/context/gaps.md` were fully rewritten from scaffold to real content in this pass (see above).
 
 ## Assumptions and Risks
 
-Call out any inferred product, architecture, or workflow facts that still need confirmation.
+- **The Squad framework's operational status is inferred, not confirmed.** Evidence (disabled heartbeat cron, one stale decision-log entry) points to dormant, but this wasn't asked of the maintainer directly during this session - flagged in `docs/context/gaps.md` rather than stated as settled fact.
+- **`package.json` engines/`.nvmrc` mismatch** is real and observed, but whether it's intentional (loose floor for local dev) or an oversight is unconfirmed.
+- Glossary and pattern docs draw on this session's work (September posts, a11y fixes, SEO pass) as the primary evidence base, since it's the most recent and best-documented slice of the repo's history available in this conversation. Older posts (pre-2026-06) were spot-checked for consistency but not exhaustively re-read.
 
 ## Missing, Stale, or Conflicting Context
 
-Record gaps or contradictions a human reviewer should resolve.
+See `docs/context/gaps.md` for the full list. Highest-signal items: the Node version pin mismatch, the Squad framework's unclear status, and incomplete Prism.js language coverage (6 of ~19 languages actually used in post code fences are highlighted).
 
 ## Follow-up Questions
 
-Capture the questions that would most improve the quality of the project context.
+1. Is the Squad framework meant to be reactivated, or should `squad-*.yml` / `.squad/` be formally retired?
+2. Should `package.json#engines` be tightened to `24` to match `.nvmrc` and CI exactly?
+3. Is there a plan to close the remaining Prism.js syntax-highlighting gap (csharp/sql/hcl/graphql/typescript/etc.) in one pass, or continue fixing it incrementally as each language comes up in new content (the pattern followed so far)?

--- a/docs/context/gaps.md
+++ b/docs/context/gaps.md
@@ -1,29 +1,37 @@
 # Context Gaps
 
-Use this file to record important things the repo does not yet prove clearly enough.
-
-Keep unresolved or weak-signal context here so later feature work does not quietly guess through it.
-
-## What Belongs Here
-
-- product or architecture questions that still need a human answer
-- stale docs or conflicting evidence discovered during bootstrap or promotion
-- important source areas that have not been reviewed yet
-- repo conventions that seem real but are not verified strongly enough to treat as durable guidance
-
-## What Does Not Belong Here
-
-- feature task lists
-- implementation TODOs that belong in `specs/`
-- temporary scratch notes better kept in `specs/<feature>/context/scratch/`
-
 ## Current Gaps
 
-Use one short entry per unresolved item:
+- **Area**: `package.json` `engines.node` (`>=20`) vs. `.nvmrc`/CI (`24`)
+  - **Why it matters**: A contributor on Node 20-23 would pass npm's engine check but potentially hit different behavior than CI, which pins exactly `24` in both `build-check.yml` and `deploy.yml`. `CLAUDE.md` states "Node 24 is required," which is accurate to what CI actually enforces but slightly stronger than what `package.json` itself declares.
+  - **Evidence checked**: `.nvmrc` (`24`), `package.json#engines` (`>=20`), `.github/workflows/build-check.yml` and `deploy.yml` (`node-version: '24'`).
+  - **Next best reviewer or source**: The maintainer - either tighten `engines.node` to `24` for consistency, or confirm `>=20` is intentional (broader local-dev compatibility) and note that explicitly somewhere.
 
-- **Area**: Replace me
-  - **Why it matters**: Replace me
-  - **Evidence checked**: Replace me
-  - **Next best reviewer or source**: Replace me
+- **Area**: The Squad automation framework's real operational status
+  - **Why it matters**: `.squad/` and `.github/workflows/squad-*.yml` describe an active multi-agent editorial workflow with routing rules, session rituals, and issue labels - but the heartbeat cron is commented out in `squad-heartbeat.yml`, and `.squad/decisions.md` has exactly one session entry, dated 2026-03-11, with nothing recorded since. It's unclear whether this is dormant-but-still-intended, or fully superseded by direct Claude Code sessions (which is how all editorial work has actually happened in this session).
+  - **Evidence checked**: `.squad/decisions.md`, `.squad/WORKFLOW.md`, `squad-heartbeat.yml`'s disabled cron trigger, absence of any Squad-persona commits in recent `git log`.
+  - **Next best reviewer or source**: The maintainer. If dormant, consider whether `squad-*.yml` workflows should be disabled/removed to avoid confusing future contributors; if still intended, the decision log needs to actually be used.
 
-Remove this starter entry once real repo-specific gaps are recorded.
+- **Area**: Future-dated posts are publicly buildable, unlinked, and not `noindex`-gated
+  - **Why it matters**: Eleventy builds a real HTML page for every file in `src/posts/*.md` regardless of front-matter `date`; only the homepage/RSS/sitemap listing is date-filtered. A crawler that discovers a future-dated post's URL by other means (e.g. browsing the GitHub repo) could index it before its listed publish date.
+  - **Evidence checked**: `.eleventy.js` collection filter logic; confirmed the built output includes future-dated post pages (e.g. `2026-08-14-github-environments-deep-dive` was live in `_site/` weeks before its listed date during this session).
+  - **Next best reviewer or source**: Already raised with the maintainer directly (2026-07-11) - explicitly declined a `noindex` fix at that time ("leave as-is"). Re-confirm if this decision should change; don't silently "fix" it without asking again, per that earlier conversation.
+
+- **Area**: Missing hero image for post #128 (RAG in Production)
+  - **Why it matters**: The first ChatGPT-generated image for #128 had garbled/nonsensical text labels ("Seranker," repeated "1eranker" rows) and a 1:1 aspect ratio instead of the site's 3:2 convention. The maintainer opted to regenerate manually later rather than ship it or crop the flawed version.
+  - **Evidence checked**: Direct visual review of the generated image (2026-07-12); `src/posts/2026-09-18-rag-in-production-*.md` currently has no `image` front-matter field, so the post falls back to the gradient header.
+  - **Next best reviewer or source**: The maintainer will send a regenerated image; the `image_prompt` is already in the post's front matter unchanged.
+
+- **Area**: Prism.js syntax highlighting is loaded for only 6 of ~19 languages actually used in post code fences
+  - **Why it matters**: `csharp`, `sql`, `hcl`, `graphql`, `typescript`/`ts`, `regex`, `ql`, `rego` code blocks across several existing posts render as plain unhighlighted text. `yaml`/`bash`/`javascript`/`json`/`python`/`markup` were added incrementally this session as each was directly needed for new content, not as a deliberate full audit.
+  - **Evidence checked**: `grep -ohE '\`\`\`[a-z]+' src/posts/*.md | sort | uniq -c` (run 2026-07-12) showed the full language distribution; `src/_layouts/base.njk`'s Prism `<script>` tags show what's actually loaded.
+  - **Next best reviewer or source**: Whoever next touches a post using one of the unhighlighted languages - cheap to fix incrementally (one CDN `<script>` line per language), same pattern as the `python`/`markup` additions.
+
+- **Area**: No Twitter/X handle configured for `twitter:site`/`twitter:creator`
+  - **Why it matters**: The site's Twitter Card meta tags (`twitter:card`, `twitter:title`, `twitter:description`, `twitter:image`) are complete, but `twitter:site`/`twitter:creator` were explicitly skipped during the SEO pass (2026-07-11) because no handle was available at the time.
+  - **Evidence checked**: `src/_layouts/base.njk` Twitter meta block; conversation record from the SEO audit session.
+  - **Next best reviewer or source**: The maintainer, if/when a handle exists.
+
+## Notes
+
+- Gaps here reflect the repo as of 2026-07-12 (end of the September-2026-editorial-batch + accessibility-remediation + docs-bootstrap work in this session). Several were surfaced by direct maintainer conversation, not just code inspection - re-check this file's "Next best reviewer" pointers before assuming a gap is still open.

--- a/docs/context/index.yaml
+++ b/docs/context/index.yaml
@@ -1,46 +1,45 @@
 # Context manifest for later AI-SDLC phases.
-# Replace these scaffold summaries with repo-specific content during bootstrap.
 
 version: 1
-last_bootstrapped: null
+last_bootstrapped: 2026-07-12
 entries:
   - id: product-overview
     category: product
     path: docs/product/overview.md
-    summary: Scaffold only. Bootstrap this file before relying on it for product context.
-    source_paths: []
-    confidence: low
-    last_verified: null
-    status: scaffold-only
+    summary: Static Eleventy/Tailwind blog on GitHub Pages, single author, no backend. Covers user/actor roles (reader, maintainer, Claude Code sessions, dormant Squad framework) and implementation-relevant rules (date-gated visibility, manual hero-image handoff, mandatory a11y-check).
+    source_paths: [".eleventy.js", "CLAUDE.md", "editorial-plan.md", ".squad/"]
+    confidence: high
+    last_verified: 2026-07-12
+    status: bootstrapped
   - id: architecture-overview
     category: architecture
     path: docs/architecture/overview.md
-    summary: Scaffold only. Bootstrap this file before relying on it for architecture context.
-    source_paths: []
-    confidence: low
-    last_verified: null
-    status: scaffold-only
+    summary: Pure static site - Eleventy build + Tailwind build, no server/database. Covers key modules, the dev/PR/deploy/accessibility flows, and CDN/network-policy characteristics observed in this sandbox.
+    source_paths: [".eleventy.js", "src/_layouts/base.njk", "package.json", ".github/workflows/build-check.yml", ".github/workflows/deploy.yml", ".lighthouserc.json", "scripts/a11y-check.js"]
+    confidence: high
+    last_verified: 2026-07-12
+    status: bootstrapped
   - id: product-glossary
     category: product
     path: docs/product/glossary.md
-    summary: Scaffold only. Bootstrap this file before relying on it for terminology.
-    source_paths: []
-    confidence: low
-    last_verified: null
-    status: scaffold-only
+    summary: Repo-specific terms - hero image handoff, Ruleset vs. classic branch protection, zero-baseline permissions, the Squad framework, editorial calendar conventions.
+    source_paths: ["CLAUDE.md", "src/posts/2026-05-08-github-branch-protection-rules-vs-rulesets.md", ".squad/"]
+    confidence: medium
+    last_verified: 2026-07-12
+    status: bootstrapped
   - id: repo-map
     category: context
     path: docs/context/repo-map.md
-    summary: Scaffold only. Replace starter paths with the repo entrypoints future work should read first.
-    source_paths: []
-    confidence: low
-    last_verified: null
-    status: scaffold-only
+    summary: Read-order and key/supporting entry points for fast orientation - CLAUDE.md and editorial-plan.md first, then the Eleventy/layout/JS/CI files.
+    source_paths: [".eleventy.js", "src/_layouts/base.njk", "src/js/", "package.json", ".github/workflows/"]
+    confidence: high
+    last_verified: 2026-07-12
+    status: bootstrapped
   - id: constitution
     category: governance
     path: .claude/memory/constitution.md
-    summary: Bootstrap or review this file before depending on it as project-specific guidance.
+    summary: File does not exist in this repo - the /constitution Spec Kit command has not been run. Not bootstrapped here; out of scope for a docs/ content pass.
     source_paths: []
     confidence: low
-    last_verified: null
-    status: scaffold-only
+    last_verified: 2026-07-12
+    status: not-created

--- a/docs/context/repo-map.md
+++ b/docs/context/repo-map.md
@@ -1,48 +1,41 @@
 # Repo Map
 
-Use this file to orient humans and agents quickly.
-
-Capture the highest-signal entrypoints in this repository, not a full file tree dump.
-
-## How to Use This File
-
-- Start with the files that define product behavior or the main runtime flow.
-- Include the tests that best explain expected behavior.
-- Include the config, manifests, CI, and scripts that shape build, verification, and release behavior.
-- Add one short note for why each path matters.
-- Prefer repo-specific paths over broad directories whenever possible.
-
 ## Read Order
 
-When future work needs fast orientation, the usual order is:
-
-1. core runtime entrypoints
-2. highest-signal tests
-3. manifests and workflow files
-4. durable docs and ADRs that are already repo-specific
-
-Do not list untouched sample files here unless the team has explicitly adapted them for this repo.
+1. `CLAUDE.md` - the canonical, actively-maintained project brief. Read this before anything else; it's kept current every session.
+2. `editorial-plan.md` - what's published, drafted, or queued. Check before writing a new post so you don't duplicate work.
+3. `.eleventy.js` + `src/_layouts/base.njk` - the whole site's runtime shape lives in these two files.
+4. `scripts/a11y-check.js` - the only automated check; run it, don't just read it.
+5. This `docs/` tree, for anything CLAUDE.md doesn't cover in enough depth.
 
 ## Key Entry Points
 
 | Path | Why it matters |
 |---|---|
-| `src/...` | Replace with the main runtime or feature entrypoints |
-| `tests/...` or `__tests__/...` | Replace with the highest-signal behavior checks |
-| `package.json`, `pyproject.toml`, etc. | Replace with the main build or dependency manifest |
-| `.github/workflows/...` | Replace with the important CI/CD workflow files |
+| `.eleventy.js` | Collections (`posts`, `tagListWithCounts`), filters (`readableDate`, `findByUrl`), build config. The date-filtering logic here is why future-dated posts don't appear on the homepage but still build a real page. |
+| `src/_layouts/base.njk` | Every page's HTML shell. All SEO (JSON-LD, OG/Twitter), all CDN script tags (Prism, fonts, analytics), nav/footer. Most site-wide changes touch this file. |
+| `src/_layouts/post.njk` | Post-specific rendering: hero image/gradient fallback, `.prose` wrapper. |
+| `src/js/tag-filter-checkboxes.js` | Owns both tag filtering *and* homepage progressive loading/pagination - not two separate concerns despite the filename. |
+| `src/js/code-copy.js` | Copy buttons *and* the keyboard-accessibility fix for scrollable code blocks (`tabindex`/`aria-label`) - same file, two responsibilities. |
+| `scripts/a11y-check.js` | The repo's only automated verification. Not a committed dependency (`playwright`/`axe-core` install on-demand) - see `docs/decisions/`. |
+| `package.json` | Build scripts (`dev`, `build`, `build:css`, `deploy`). No test script. `engines.node` says `>=20` but CI/`.nvmrc` pin `24` - see `docs/context/gaps.md`. |
+| `.github/workflows/build-check.yml` | PR gate: `npm ci && npm run deploy` must succeed. No accessibility or deploy step. |
+| `.github/workflows/deploy.yml` | The real deploy path: build → `actions/deploy-pages` → Lighthouse CI against the live URL. Runs on push to `main`, daily cron, and manual dispatch. |
+| `.lighthouserc.json` | Lighthouse CI thresholds. Accessibility is the only category set to `error` (≥0.9); performance/best-practices/SEO are `warn`. |
+| `editorial-plan.md` | Editorial source of truth - per-post `Status`/`Scheduled`/`Issue`/`File`, organized into monthly batches plus a rolling `## Pipeline` section covering June-December 2026. |
+| `CLAUDE.md` | The living project brief - architecture, conventions, and explicit workflow rules (hero image handoff, accessibility-check requirement). Updated every session; treat as more current than this `docs/` tree if they ever disagree. |
 
 ## Supporting Paths
 
-Use this section for high-value secondary paths such as:
-
-- generated artifacts that matter
-- shared utilities
-- framework or integration configuration
-- durable docs that future work should read early
+| Path | Why it matters |
+|---|---|
+| `src/_data/site.json` | Global template data - site title/description/URL/author contact. |
+| `src/styles/input.css` | Tailwind v4 CSS-native config (`@theme`, `@utility`, `@variant`) - there is no `tailwind.config.js`. |
+| `src/images/posts/` | Hero image asset convention: `<slug>-hero.png` source + `.webp` + `-400w`/`-600w`/`-800w` variants at quality 95. |
+| `.squad/` | Dormant multi-agent automation framework - see `docs/product/overview.md` before assuming it's active. |
+| `docs/architecture/adr/`, `docs/architecture/database-schema-example.md` | Untouched sample scaffolds. This repo has no database and no decision yet at ADR scale - leave these as marked samples, don't treat as real content. |
 
 ## Notes
 
-- Prefer the files future feature work should read first.
-- Do not mirror a full directory tree.
-- Remove this starter text once the repo-specific map is in place.
+- This repo has no `tests/` directory and no test framework. Don't go looking for one.
+- Last verified against the repo as of 2026-07-12 (through PR #155 and the accessibility/September-content work in this session).

--- a/docs/decisions/2026-07-12-axe-core-and-playwright-stay-uncommitted.md
+++ b/docs/decisions/2026-07-12-axe-core-and-playwright-stay-uncommitted.md
@@ -1,0 +1,25 @@
+# axe-core and Playwright stay out of package.json, installed on-demand instead
+
+## Date
+2026-07-12
+
+## Context
+An accessibility scan (`scripts/a11y-check.js`) needed a real browser to check color-contrast and other computed-style-dependent WCAG rules - axe-core alone, without a real rendering engine, can't do this accurately. Playwright + axe-core were the obvious choice, already available in this sandbox with a pre-installed Chromium.
+
+The question: commit `playwright`/`axe-core` as `devDependencies` so `npm ci` always has them, or install on-demand per session?
+
+## Decision
+`scripts/a11y-check.js` is committed to the repo and fully functional, but `playwright`/`axe-core` are **not** added to `package.json`. They're installed on-demand (`npm install --no-save axe-core playwright`) whenever the script actually needs to run.
+
+## Rationale
+`build-check.yml` and `deploy.yml` both run `npm ci` on every PR and every push to `main`. Adding Playwright as a `devDependency` means `npm ci` would also trigger a full Chromium browser download in CI - meaningful time added to *every* build, for a check that isn't (and, as of this decision, isn't planned to be) wired into either CI workflow. The accessibility scan is agent/maintainer-invoked, not CI-enforced.
+
+## Consequences
+- Every session that needs to run the a11y scan pays a one-time `npm install --no-save` cost first - documented as an explicit step in `CLAUDE.md`, not assumed.
+- `npm ci` and both CI workflows stay exactly as fast as before this script existed.
+- If accessibility checks are ever promoted to a CI gate, this decision should be revisited - at that point the CI-time cost becomes deliberate rather than incidental, and committing the dependency would make sense.
+- Playwright's Chromium binary resolution needed a small accommodation in the script itself: this sandbox pre-installs Chromium outside Playwright's default cache path (`/opt/pw-browsers/chromium`), so `scripts/a11y-check.js` checks for that path and uses it directly when present, falling back to Playwright's default resolution otherwise (portable to a contributor's own machine, where `npx playwright install` would be the normal path).
+
+## Related
+- `CLAUDE.md` Accessibility section
+- `scripts/a11y-check.js`

--- a/docs/decisions/2026-07-12-hero-images-are-a-manual-handoff.md
+++ b/docs/decisions/2026-07-12-hero-images-are-a-manual-handoff.md
@@ -1,0 +1,28 @@
+# Hero images are a manual ChatGPT handoff, not an automated/API integration
+
+## Date
+2026-07-12
+
+## Context
+Post hero images are generated from a prompt (`image_prompt` front matter) using an AI image model. The question: can this be automated from inside a Claude Code session working on this repo?
+
+Two approaches were tried and both failed the same way:
+1. Direct `curl` to `api.openai.com` - `403`, proxy-level policy denial (`gateway answered 403 to CONNECT`).
+2. Installing and registering an MCP server (`openai-gpt-image-mcp`) with the user's own OpenAI API key - once properly connected (required a session reconnect to load the new tool), calling `create-image` returned `403 Host not in allowlist: api.openai.com` - same underlying network policy, just a cleaner error message.
+
+## Decision
+Image generation happens outside the Claude Code session entirely. The maintainer runs the `image_prompt` text through ChatGPT manually and sends the resulting image back into the session. Claude's job starts *after* that: convert to the standard asset set (`.png` source, full-size `.webp`, `-400w`/`-600w`/`-800w` responsive variants at quality 95) and wire up the post's `image` front-matter field.
+
+The MCP server was removed after confirming it couldn't work (`claude mcp remove openai-gpt-image`) rather than left registered and unusable.
+
+## Rationale
+The blocker is this environment's egress allowlist, not the MCP integration itself - the MCP server would work identically to a direct API call if `api.openai.com` were allowlisted. There was no remaining technical path to try; per this environment's proxy documentation, a `403` policy denial should be reported, not retried or routed around.
+
+## Consequences
+- Every new post needs an explicit reminder to the maintainer when it's ready for a hero image - now codified in `CLAUDE.md` so future sessions don't have to rediscover this.
+- Posts can ship, build, and even go live without a hero image - `post.njk`/`index.njk` both have a gradient fallback for exactly this case.
+- If this environment's network policy ever allowlists `api.openai.com`, the MCP path is fully validated and ready to re-enable (setup steps recorded in this session's history, not duplicated here since they'd need to be re-verified against the policy change anyway).
+
+## Related
+- `CLAUDE.md` "Hero images" note
+- `docs/patterns/blog-post-authoring.md`

--- a/docs/patterns/blog-post-authoring.md
+++ b/docs/patterns/blog-post-authoring.md
@@ -1,0 +1,39 @@
+# Blog Post Authoring
+
+**Status**: Established
+**Last Updated**: 2026-07-12
+
+## Overview
+
+The repeatable process for taking an editorial-calendar entry from `idea` to a merged, published post. Established over the March-September 2026 posts; most recently exercised drafting #126-129 (the September 2026 batch) in this session.
+
+## Structure
+
+1. Pull the entry from `editorial-plan.md` (`Pitch`/`Angle`/`Tags`/`Scheduled` date/`Issue` number).
+2. Check 1-2 topically-related prior posts and reuse their established conventions rather than inventing new ones - SDK class names and call patterns for Azure AI Foundry posts (`AIProjectClient`, `FunctionTool`, `ToolSet`, `MessageRole`, etc.), Ruleset JSON schema for GitHub-Rulesets-adjacent posts, `permissions: {}` zero-baseline for any workflow YAML. Cross-link the prior post with a relative URL in the intro.
+3. Write the post: front matter (`author`, `date`, `image_prompt`, `layout: post.njk`, `site_title`, `summary`, `tags`, `title` - alphabetical, `image` added later once a hero exists), then prose sections separated by `***`, `##`/`###` headings, code fences.
+4. **Verify technical claims, don't just assert them.** Real regex patterns get tested against real match/no-match strings (Python `re`) before being written into a post. Real SDK class/parameter names get cross-checked against sibling posts already using that SDK, or against training-data confidence, not invented on the spot.
+5. Build (`npm run deploy`) and check structure: heading count, code-block count/language, title tag - `grep -c "<h2"` / `grep -oE 'language-[a-z]+'` against the built `_site/posts/<slug>/index.html`.
+6. Run the accessibility scan (`node scripts/a11y-check.js`, after `npm install --no-save axe-core playwright` if not already installed this session) - both the standard 6-page sweep and a direct check of the new post's own page, since the standard sweep only tests one arbitrarily-picked existing post.
+7. Update the `editorial-plan.md` entry: `Status: idea` → `draft`, add the `File:` line.
+8. Commit content and any incidental infra fixes (e.g. a missing Prism language component) as **separate commits** - keeps `git log`/PR history reviewable.
+9. Open or update a PR. If a PR from the same branch already exists and is still open, new commits land on it automatically - update the PR title/body to summarize everything currently included, since these PRs tend to accumulate multiple posts/fixes across a working session.
+10. Hero image is a separate, later step - see `docs/decisions/2026-07-12-hero-images-are-a-manual-handoff.md`. A post ships and can even go live without one; it falls back to a gradient header/card.
+
+## Example
+
+`src/posts/2026-09-04-azure-ai-foundry-agents-memory-tool-calling-rag.md` cross-links and reuses conventions from two prior posts (`2026-07-24-multi-agent-patterns-...` for the `AIProjectClient`/`FunctionTool` SDK vocabulary, `2026-08-21-evaluating-llm-outputs-in-ci-cd` for `GroundednessEvaluator`/`RelevanceEvaluator` usage) rather than introducing new patterns for concepts already established.
+
+## When to Use
+
+- Every new post drafted against the editorial calendar.
+
+## When NOT to Use
+
+- One-off site changes (SEO, accessibility, template work) - those follow the change-then-`a11y-check` pattern documented in `CLAUDE.md` directly, not this content-authoring flow.
+
+## Related
+
+- `CLAUDE.md` Content model and Accessibility sections
+- `docs/decisions/2026-07-12-hero-images-are-a-manual-handoff.md`
+- `editorial-plan.md`

--- a/docs/product/glossary.md
+++ b/docs/product/glossary.md
@@ -1,33 +1,36 @@
 # Glossary
 
-Use this file to keep repo-specific terminology consistent across code, docs, prompts, and team communication.
-
-Only include terms that help future feature work. Skip generic programming vocabulary.
-
-Every retained term should have evidence or notes strong enough to explain why it belongs here.
+Repo-specific terminology. Generic Eleventy/Tailwind/GitHub Actions vocabulary is skipped unless this repo uses it in a non-obvious way.
 
 ## Terms
 
 | Term | Meaning | Evidence / Notes |
 |------|---------|------------------|
-| Replace me | Short definition | Point to the code, config, tests, or workflow where the term matters |
+| Hero image | A post's full-bleed header image, `.webp`, with `-400w`/`-600w`/`-800w` responsive variants alongside the full-size file and a `.png` source. Optional - posts without one get a gradient fallback. | `CLAUDE.md` Content model section; `src/_layouts/post.njk` |
+| `image_prompt` | Front-matter field documenting the AI image-gen prompt for a post's hero. Not rendered anywhere - kept purely for provenance so the maintainer can regenerate the image later. | `CLAUDE.md`; every post in `src/posts/` |
+| The handoff | Shorthand for the manual hero-image workflow: Claude writes `image_prompt`, the maintainer runs it through ChatGPT (not automatable in-session - `api.openai.com` is network-blocked here), sends the image back, Claude converts it to the standard asset set. | `docs/decisions/`, `CLAUDE.md` |
+| Ruleset | GitHub's newer branch/tag protection system (as opposed to "classic branch protection"). Supports org-level enforcement, bypass actors, tag protection, evaluation mode, and the `merge_queue` rule type. This repo's blog covers Rulesets extensively; the repo's own branch protection setup is not verified against this glossary entry. | `src/posts/2026-05-08-github-branch-protection-rules-vs-rulesets.md`, `src/posts/2026-09-11-github-merge-queues.md` |
+| Zero-baseline permissions | The `permissions: {}` pattern at workflow level, with every job declaring exactly the scopes it needs, as opposed to `permissions: read-all` or the (dangerous) unset default. Established convention this blog's own example workflows follow. | `src/posts/2026-03-25-github-actions-permissions-block.md`; reused in `src/posts/2026-09-11-github-merge-queues.md` and `src/posts/2026-09-25-github-packages-internal-registry.md` |
+| The Squad | A dormant multi-agent editorial-automation framework with named personas (Trenton/content, Mr. Robot/build, Darlene/CI, Romero/deploy, Elliot/architecture, Ralph/monitoring, Scribe/decision-logging). Not the same thing as a Claude Code session working on this repo. | `.squad/`, `.github/workflows/squad-*.yml` |
+| Editorial calendar | `editorial-plan.md` - the single source of truth for what content is planned/drafted/published, organized into monthly batches plus a rolling `Pipeline` section. Each entry tracks `Status` (`idea` → `draft` → `published`), `Scheduled` date, GitHub `Issue`, and `File` once drafted. | `editorial-plan.md`; `.squad/WORKFLOW.md` describes the intended (Squad-era) editing ritual |
+| a11y-check | Shorthand used in this repo's own working conventions for running `scripts/a11y-check.js` - an axe-core WCAG scan, not a generic term. | `CLAUDE.md` Accessibility section |
 
 ## Synonyms to Avoid
 
-Capture any naming choices that matter for precision.
-
 | Preferred | Avoid |
 |-----------|-------|
-| Replace me | Replace me |
+| Ruleset | "branch protection rule" (ambiguous - classic branch protection and Rulesets are different GitHub systems, both discussed in this blog) |
+| `merge_queue` rule type | "merge queue feature" (the blog post is precise that it's a Ruleset *rule type*, not a separate GitHub feature) |
 
 ## Abbreviations and Acronyms
 
 | Abbreviation | Full Term | Meaning / Context |
 |--------------|-----------|-------------------|
-| Replace me | Replace me | Replace me |
+| GHAS | GitHub Advanced Security | Referenced across several posts (secret scanning, code scanning); not something this repo itself has enabled - it's blog subject matter |
+| RAG | Retrieval-Augmented Generation | Central topic of two September posts; also unrelated to this repo's own (nonexistent) retrieval infrastructure |
+| WCAG | Web Content Accessibility Guidelines | The standard `scripts/a11y-check.js` verifies against (2.1 A/AA) |
 
 ## Notes
 
-- Prefer terminology that appears in code, tests, config, or platform metadata.
-- Remove terms that are generic, redundant, or unsupported by repo evidence.
-- Remove this starter text once the glossary is repo-specific.
+- Terms specific to *blog post subject matter* (Azure AI Foundry SDK classes, GitHub Packages registry formats, etc.) are intentionally excluded here - they're documented within their respective posts and don't affect how this repo itself is built or maintained.
+- This glossary reflects the repo as of 2026-07-12. Re-verify entries tied to `.squad/` if that framework becomes active again.

--- a/docs/product/overview.md
+++ b/docs/product/overview.md
@@ -1,52 +1,29 @@
 # Product Overview
 
-Document the implementation-relevant product context for this repo.
-
-Keep this grounded in repo evidence. If the repo does not prove a product fact directly, label it as an assumption instead of presenting it as settled truth.
-
-Exclude roadmap copy, marketing language, and speculative intent that the repo does not support.
-
 ## What This Project Does Today
 
-Summarize the current product or workflow in one short section.
+`steve-kaschimer.github.io` is a personal technical blog ("Tech Notes") - a static site built with Eleventy v2 and Tailwind v4, deployed to GitHub Pages. Content is DevOps/security/cloud/AI-agent-focused markdown posts, published on a weekly (Friday) cadence per `editorial-plan.md`. There is no backend, no database, and no user accounts - every page is pre-rendered HTML served directly by GitHub Pages.
 
-Focus on:
-
-- the outcome the software delivers
-- the primary user, operator, or maintainer workflow
-- the repo’s current scope, not aspirational roadmap copy
+The site's outcome is straightforward: give one author (Steve Kaschimer) a fast, low-maintenance publishing surface with the production concerns a "real" site needs - SEO (JSON-LD, OG/Twitter cards, sitemap), accessibility (axe-core-verified WCAG 2.1 AA), an RSS/Atom feed, tag-based discovery, dark mode - without introducing a CMS, a database, or server-side code.
 
 ## Users, Actors, or Consumers
 
-List the people, systems, or workflows this repo primarily serves.
-
-For each one, capture:
-
-- what they are trying to accomplish
-- what this repo is responsible for
-- any constraints or expectations that show up in code or tests
+- **Readers**: consume posts via the homepage grid (progressively loaded, tag-filterable), direct post URLs, or the Atom feed at `/feed/`. No accounts, no comments, no server-side personalization.
+- **Steve Kaschimer (author/maintainer)**: writes and reviews content, generates hero images externally via ChatGPT (this repo's Claude Code sessions cannot call `api.openai.com` directly - see `docs/decisions/`), reviews and merges PRs.
+- **Claude Code sessions** (this session included): draft posts against the editorial calendar, maintain the build/template/CSS layer, run accessibility and SEO passes, and open PRs. Session-specific instructions live in `CLAUDE.md`.
+- **The "Squad" framework** (`.squad/`, `.github/workflows/squad-*.yml`): a dormant multi-agent editorial-automation framework (named personas - Trenton for content, Mr. Robot for Eleventy/build, Darlene for CI, Romero for deployment, Elliot for architecture, Ralph for status monitoring). Its scheduled heartbeat is commented out (`squad-heartbeat.yml`), and its decision log (`.squad/decisions.md`) has one entry from 2026-03-11 with nothing since - **assumption**: not in active use, but its labels (`squad:trenton`, `type:feature`, etc.) are still applied to the editorial-calendar GitHub Issues, so `taskstoissues`-style tooling should keep using them.
 
 ## Implementation-Relevant Rules
 
-Capture only the domain or product rules that materially affect implementation, validation, behavior, or support.
-
-Examples:
-
-- inputs that are required or invalid
-- behavior that must remain backward compatible
-- business logic that tests or code enforce
-- constraints implied by platform metadata, workflows, or integrations
+- **Front-matter `date` gates visibility, not the filename.** Filenames follow `YYYY-MM-DD-slug.md` for on-disk ordering only. The `posts` collection (`.eleventy.js`) filters out any post whose front-matter `date` is in the future from the homepage/RSS/sitemap - but Eleventy still builds a real, public HTML page for every post file regardless of date. A future-dated post's URL is live (unlinked, not indexed via sitemap, no `noindex` meta) before its listed publish date. This is a known, intentional tradeoff - explicitly confirmed with the maintainer (see `docs/context/gaps.md`), not something to "fix" unprompted.
+- **Hero images require a manual handoff.** This environment's outbound network policy blocks direct calls to `api.openai.com` (confirmed via both `curl` and an MCP-based `openai-gpt-image-mcp` server - both hit a `403`/proxy-level policy denial). Image generation cannot be automated from inside a Claude Code session here. The maintainer generates images via ChatGPT from the post's `image_prompt` front-matter field and hands the result back for conversion into the standard asset set.
+- **Every new post or template/CSS change requires an accessibility scan** (`npm run deploy && node scripts/a11y-check.js`) before being considered done - documented in `CLAUDE.md`, and this is not optional per explicit maintainer instruction (2026-07-12).
+- **No test suite exists.** `scripts/a11y-check.js` is the closest thing to an automated correctness check; everything else is `npm run deploy` succeeding plus manual/agent-driven review.
 
 ## Observed Evidence
 
-List the repo artifacts that support this overview, for example:
-
-- source files
-- tests
-- manifests
-- workflow files
-- existing docs
+- `.eleventy.js` (posts collection date filtering), `CLAUDE.md` (hero image / accessibility workflow rules), `editorial-plan.md` (publishing cadence and per-post status tracking), `.squad/` + `.github/workflows/squad-*.yml` (dormant automation framework), `scripts/a11y-check.js` (the only automated check in the repo).
 
 ## Assumptions and Open Questions
 
-Call out anything that still needs a human reviewer to confirm.
+See `docs/context/gaps.md` for the full list - notably the Squad framework's real-world usage status and a `package.json` engines/`​.nvmrc` version mismatch are inferred from evidence, not confirmed with the maintainer.


### PR DESCRIPTION
## Summary

The `docs/` tree (`docs/README.md`'s own stated purpose: "durable repo context that later AI-SDLC, Spec Kit, and agent workflows should read instead of rediscovering the same information on every task") was entirely unfilled Spec-Kit bootstrap scaffolding - every file still had its template instructions rather than real content, and the bootstrap workflow it points to (`.agents/prompts/bootstrap-context-repo.md`) doesn't actually exist in this repo. This PR does that bootstrap pass manually.

**Populated with real content:**
- `docs/product/overview.md`, `docs/architecture/overview.md` - system shape, key modules, the dev/PR/deploy/accessibility flows, actors (including the dormant Squad framework)
- `docs/product/glossary.md` - repo-specific terms (hero image handoff, Ruleset vs. classic branch protection, zero-baseline permissions, etc.)
- `docs/context/repo-map.md` - real entry points and read order
- `docs/context/gaps.md` - six concrete, evidence-backed open questions (Node version pin mismatch between `package.json`/`.nvmrc`, the Squad framework's unclear operational status, the future-dated-post `noindex` decision already declined by the maintainer, the still-missing #128 hero image, incomplete Prism.js language coverage, no Twitter handle configured)
- `docs/context/index.yaml` - bootstrapped manifest with real summaries/sources/confidence per entry
- `docs/context/bootstrap-report.md` - evidence trail for this pass

**New:**
- `docs/decisions/2026-07-12-hero-images-are-a-manual-handoff.md` - why (both a direct `api.openai.com` call and an MCP server hit the same network-policy 403)
- `docs/decisions/2026-07-12-axe-core-and-playwright-stay-uncommitted.md` - why they're not `package.json` dependencies
- `docs/patterns/blog-post-authoring.md` - the repeatable draft-to-PR flow used for the September 2026 batch

**Deliberately left as unadapted samples:** `docs/architecture/adr/` and `database-schema-example.md` - this repo has no database and nothing at ADR scale yet, and both files already say to leave them marked as samples in that case.

## Test plan
- [x] Confirmed `docs/` is outside Eleventy's `src/` input dir - `npm run deploy` unaffected, verified build still succeeds
- [x] Every claim cross-checked against actual repo files (workflows, `.eleventy.js`, `package.json`, `.nvmrc`, `.squad/`) rather than asserted from memory

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>


---
_Generated by [Claude Code](https://claude.ai/code/session_01WKyNF7L5qzrfct8cec6A32)_