### PR TITLE
December posts #139-142 (December complete - 2026 calendar done)

### DIFF
--- a/editorial-plan.md
+++ b/editorial-plan.md
@@ -398,33 +398,37 @@ One post per Friday through end of year. Topics rotate across the established De
 ---
 
 ### GitHub Advanced Security at the Org Level: Rolling Out GHAS Across 100+ Repos
-- **Status:** `idea`
+- **Status:** `draft`
 - **Scheduled:** 2026-12-04
 - **Issue:** [#139](https://github.com/steve-kaschimer/steve-kaschimer.github.io/issues/139)
+- **File:** `src/posts/2026-12-04-github-advanced-security-org-rollout.md`
 - **Pitch:** Enabling GHAS on one repo is easy; rolling it out consistently across a large org without alert fatigue or developer friction requires a deliberate strategy.
 - **Angle:** Covers the rollout sequence (secret scanning first, then code scanning, then Dependabot alerts with auto-dismiss rules), using the GitHub REST API and `gh` CLI to audit enablement status across repos, setting org-level default setup for CodeQL, and building a compliance dashboard with GitHub Actions that reports on coverage weekly.
 - **Tags:** `github-advanced-security`, `devsecops`, `platform-engineering`, `codeql`, `secret-scanning`
 
 ### Azure AI Foundry MCP Servers: Building and Registering Custom Tools for Your Agents
-- **Status:** `idea`
+- **Status:** `draft`
 - **Scheduled:** 2026-12-11
 - **Issue:** [#140](https://github.com/steve-kaschimer/steve-kaschimer.github.io/issues/140)
+- **File:** `src/posts/2026-12-11-azure-ai-foundry-mcp-servers-custom-tools.md`
 - **Pitch:** The Model Context Protocol lets agents call external tools over a standard interface - Azure AI Foundry's MCP server support means you can extend your agents with custom capabilities without forking the runtime.
 - **Angle:** Builds an MCP server that exposes two tools (a GitHub API wrapper and an internal knowledge base query), registers it with a Foundry agent, and shows the agent routing tool calls correctly. Covers the MCP schema, authentication between the agent and the server, and deploying the MCP server as an Azure Container App alongside the agent.
 - **Tags:** `azure-ai-foundry`, `mcp`, `ai-agents`, `agentic-development`, `azure`
 
 ### The DevSecOps Year in Review 2026: What Shipped, What Mattered, What's Next
-- **Status:** `idea`
+- **Status:** `draft`
 - **Scheduled:** 2026-12-18
 - **Issue:** [#141](https://github.com/steve-kaschimer/steve-kaschimer.github.io/issues/141)
+- **File:** `src/posts/2026-12-18-devsecops-year-in-review-2026.md`
 - **Pitch:** A retrospective on the year's most significant shifts in developer security, CI/CD, and AI-assisted development - written for practitioners who want signal, not press releases.
 - **Angle:** Structured as three sections: what shipped (concrete features from GitHub, Azure, and the ecosystem), what actually mattered in practice (the things teams adopted vs. the things that stayed theoretical), and what to watch in 2027 (agentic pipelines, AI-native security tooling, platform engineering consolidation). Personal and opinionated.
 - **Tags:** `devsecops`, `year-in-review`, `github`, `azure-ai-foundry`, `editorial`
 
 ### Async-First Development: Writing Code and Processes That Work Across Time Zones
-- **Status:** `idea`
+- **Status:** `draft`
 - **Scheduled:** 2026-12-25
 - **Issue:** [#142](https://github.com/steve-kaschimer/steve-kaschimer.github.io/issues/142)
+- **File:** `src/posts/2026-12-25-async-first-development-across-time-zones.md`
 - **Pitch:** The best remote engineering teams aren't just distributed - they're async-first, which means their code, processes, and tooling are designed to work without real-time coordination.
 - **Angle:** Covers the practices that separate async-capable teams from ones that just have standup on Zoom: commit message discipline, ADR-driven decision-making, self-documenting PRs, GitHub Discussions for async deliberation, and using GitHub Actions to automate the status updates that would otherwise require a Slack message. Light enough for the holiday week, substantive enough to be worth reading.
 - **Tags:** `developer-productivity`, `remote-work`, `writing-for-engineers`, `git`, `async`

--- a/src/posts/2026-12-04-github-advanced-security-org-rollout.md
+++ b/src/posts/2026-12-04-github-advanced-security-org-rollout.md
@@ -1,0 +1,149 @@
+---
+author: Steve Kaschimer
+date: 2026-12-04
+image_prompt: "A dark-mode technical editorial illustration on a near-black background with cobalt blue, amber, and teal accents. A vertical rollout sequence of three stages, each a labeled panel with a small progress bar filling left to right: 'Secret Scanning' (fully filled, green), 'Code Scanning / CodeQL' (partially filled, teal), 'Dependabot Alerts' (just starting, amber). To the right, a grid of small repository icons - most showing a green checkmark, a handful showing a grey question mark, implying partial org-wide coverage. Below, a small dashboard panel with a bar chart labeled 'Weekly Coverage Report' and a single summary line 'furniture co: 87% of repos covered'. The mood is systematic and gradual - a phased rollout across a large surface area, not a single switch flipped everywhere at once."
+layout: post.njk
+site_title: Tech Notes
+summary: "Turning on GitHub Advanced Security for one repository is a five-minute settings change. Doing it consistently across a hundred-plus repos without burying developers in alert fatigue on day one is a rollout strategy, not a toggle. This post covers the sequencing that actually works - secret scanning first, then code scanning, then Dependabot alerts with auto-dismiss rules - auditing enablement across an org with the REST API and gh CLI, setting org-level default CodeQL setup, and building a lightweight GitHub Actions dashboard that reports coverage weekly."
+tags: ["github-advanced-security", "devsecops", "platform-engineering", "codeql", "secret-scanning"]
+title: "GitHub Advanced Security at the Org Level: Rolling Out GHAS Across 100+ Repos"
+---
+
+Enabling GitHub Advanced Security (GHAS) on a single repository is a checkbox in repo settings. Rolling it out across an org with a hundred-plus repos, most with different languages, different maintenance levels, and different teams' tolerance for new noise in their PR checks, is an entirely different problem - and the version of this rollout that fails is the one where every feature gets flipped on everywhere simultaneously, developers wake up to hundreds of new alerts across repos nobody's actively triaging, and GHAS gets tagged internally as "the thing that broke everyone's Monday."
+
+The rollout that works is sequenced, not simultaneous - each layer proven out and tuned before the next one goes on, so alert volume grows at a rate teams can actually absorb.
+
+***
+
+## The Rollout Sequence, and Why This Order
+
+**Secret scanning first.** It's the highest-signal, lowest-noise GHAS feature - a detected secret is close to unambiguously something to act on, unlike a code-scanning finding that might be a false positive or an accepted risk. [The custom-patterns post](/posts/2026-08-28-github-secret-scanning-custom-patterns/) covers extending detection beyond the built-in partner patterns; at the org level, start with just the built-in patterns everywhere, prove out the response process (who gets paged, how a real secret gets rotated), and layer custom patterns in per-repo once that process is solid.
+
+**Code scanning (CodeQL) second.** This is the layer most likely to generate a rollout-day flood if enabled everywhere at once - a repo with years of accumulated code and no prior static analysis can produce dozens or hundreds of findings the first time CodeQL runs against it. Enabling it repo-by-repo, or in waves grouped by language and team capacity, keeps that flood from hitting everyone simultaneously.
+
+**Dependabot alerts (with auto-dismiss rules) third.** Dependency vulnerability alerts are the noisiest layer by volume - a single repo can accumulate dozens of transitive-dependency alerts, many for versions never actually reachable in the runtime path. Auto-dismiss rules (covered below) are what make this layer survivable at scale; without them, this is the feature most likely to get muted org-wide out of alert fatigue within the first month.
+
+***
+
+## Auditing Current Enablement Across the Org
+
+Before rolling anything out further, know what's actually enabled today - GHAS adoption in most orgs is uneven, with some repos fully covered from an earlier push and others never touched:
+
+```bash
+#!/usr/bin/env bash
+# audit-ghas-enablement.sh
+gh api "orgs/your-org/repos" --paginate --jq '.[].name' | while read -r repo; do
+  secret_scanning=$(gh api "repos/your-org/$repo" --jq '.security_and_analysis.secret_scanning.status // "disabled"')
+  code_scanning=$(gh api "repos/your-org/$repo/code-scanning/alerts" --silent 2>/dev/null && echo "enabled" || echo "disabled")
+  dependabot=$(gh api "repos/your-org/$repo" --jq '.security_and_analysis.dependabot_security_updates.status // "disabled"')
+  echo "$repo,$secret_scanning,$code_scanning,$dependabot"
+done > ghas-enablement-audit.csv
+```
+
+Running this before touching anything turns "let's roll out GHAS" from a vague initiative into a concrete list: which repos are already fully covered, which have partial coverage worth completing, and which have never been touched and need the full sequence from scratch.
+
+***
+
+## Org-Level Default Setup for CodeQL
+
+Rather than configuring CodeQL per-repo, GitHub's **default setup** at the org level (**Settings → Code security → Configure code scanning → Default setup**) applies a sensible baseline configuration automatically to every repo matching a language filter, without a workflow file to maintain in each one:
+
+```bash
+gh api --method PATCH "orgs/your-org/code-security-configurations/default" \
+  -f code_scanning_default_setup='enabled' \
+  -f code_scanning_default_setup_languages[]='javascript-typescript' \
+  -f code_scanning_default_setup_languages[]='python'
+```
+
+Default setup is deliberately less configurable than a hand-written CodeQL workflow - it doesn't support custom query suites or unusual build steps for compiled languages. That's the correct tradeoff for the bulk of an org's repos; reserve a custom `.github/workflows/codeql.yml` for the specific repos that actually need it (custom queries, a non-standard build process), rather than hand-configuring all hundred-plus.
+
+***
+
+## Dependabot Auto-Dismiss Rules
+
+The single highest-leverage tuning for surviving Dependabot alert volume at scale: auto-dismiss rules that close alerts for a vulnerability class the org has already decided isn't actionable in context (a `low`-severity alert in a `devDependencies`-only package, for instance, never reaches production):
+
+```yaml
+# .github/dependabot-auto-dismiss.yml (consumed by a scheduled workflow, not a native Dependabot config key)
+rules:
+  - severity: low
+    dependency_scope: development
+    action: dismiss
+    reason: "tolerable_risk"
+  - ecosystem: npm
+    ghsa_id_pattern: "GHSA-*-test-only-*"
+    action: dismiss
+    reason: "not_used"
+```
+
+```yaml
+name: Auto-Dismiss Low-Risk Dependabot Alerts
+
+on:
+  schedule:
+    - cron: '0 6 * * 1'
+
+permissions:
+  contents: read
+  security-events: write
+
+jobs:
+  dismiss:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Apply dismiss rules
+        run: python scripts/dependabot_auto_dismiss.py --config .github/dependabot-auto-dismiss.yml
+        env:
+          GITHUB_TOKEN: ${{ secrets.ORG_ADMIN_TOKEN }}
+```
+
+This is a deliberate, reviewable policy - the rules file goes through the same PR review as any other config change - not a blanket suppression. The goal is removing noise the org has already decided isn't worth a human's attention, so the alerts that remain are the ones people actually look at instead of triaging through a wall of low-severity dev-dependency notices.
+
+***
+
+## A Weekly Coverage Dashboard
+
+Rollout doesn't end when every repo has GHAS features turned on - coverage drifts as new repos get created without them, so a lightweight recurring check keeps the rollout from quietly regressing:
+
+```yaml
+name: GHAS Coverage Report
+
+on:
+  schedule:
+    - cron: '0 9 * * 1'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  report:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Audit enablement
+        run: ./scripts/audit-ghas-enablement.sh
+
+      - name: Generate coverage summary
+        run: python scripts/summarize_ghas_coverage.py ghas-enablement-audit.csv > coverage-summary.md
+
+      - name: Post to Slack
+        run: |
+          curl -X POST "${{ secrets.SLACK_WEBHOOK_URL }}" \
+            -H 'Content-Type: application/json' \
+            -d "{\"text\": \"$(cat coverage-summary.md)\"}"
+```
+
+A weekly "87% of repos have secret scanning, 62% have code scanning, 3 new repos created this week without either" summary is what keeps GHAS rollout from being a one-time project that quietly decays - new repos are the leak in any org-wide security baseline, and this is the check that catches them before they've been unmonitored for months.
+
+***
+
+## Closing
+
+The rollout sequence here isn't about being cautious for its own sake - it's about matching the pace of new alert volume to the org's actual capacity to triage it, which is exactly the constraint that determines whether GHAS becomes a trusted signal or a wall of noise everyone learns to ignore. Secret scanning first because it's unambiguous and builds trust in the process. Code scanning next, in waves sized to what a team can actually work through. Dependabot last, with auto-dismiss rules doing the noise reduction that makes the remaining alerts worth reading. And a standing coverage check after all of it, because a rollout that isn't actively maintained against new repos is a rollout that's already started decaying the day it finished.
+
+***
+
+Questions or corrections? Reach out.
+
+[steve.kaschimer@slalom.com](mailto:steve.kaschimer@slalom.com)

--- a/src/posts/2026-12-11-azure-ai-foundry-mcp-servers-custom-tools.md
+++ b/src/posts/2026-12-11-azure-ai-foundry-mcp-servers-custom-tools.md
@@ -1,0 +1,164 @@
+---
+author: Steve Kaschimer
+date: 2026-12-11
+image_prompt: "A dark-mode technical editorial illustration on a near-black background with cobalt blue, electric teal, and amber accents. In the center, a hexagonal node labeled 'MCP Server' with two small tool icons plugged into it: a GitHub-mark icon labeled 'github_search' and a database icon labeled 'kb_query'. A dashed connection line runs from the MCP Server node to an agent-brain icon on the right labeled 'Foundry Agent', with a small padlock icon on the connection line labeled 'auth token'. Below, a container icon labeled 'Azure Container App' encloses the MCP Server node, with a small scale-icon suggesting it runs alongside the agent. The mood is modular and interoperable - a standard plug-in interface for agent tools, not a bespoke integration per capability."
+layout: post.njk
+site_title: Tech Notes
+summary: "Giving an agent a new capability usually means writing a bespoke FunctionTool and redeploying the agent runtime - the Model Context Protocol (MCP) offers a standard interface instead, letting agents call external tools over a well-defined schema without the tool's implementation living inside the agent's own code. This post builds an MCP server exposing two tools (a GitHub API wrapper and an internal knowledge-base query), registers it with an Azure AI Foundry agent, and covers the MCP schema, authentication between agent and server, and deploying the server as an Azure Container App alongside the agent."
+tags: ["azure-ai-foundry", "mcp", "ai-agents", "agentic-development", "azure"]
+title: "Azure AI Foundry MCP Servers: Building and Registering Custom Tools for Your Agents"
+---
+
+Every agent post on this blog so far has reached for `FunctionTool` - a Python function, decorated and registered directly with the agent, living in the same codebase and deployed as part of the same runtime. That pattern works well for capabilities specific to one agent. It breaks down the moment two different agents - or two different teams - need the same capability: a GitHub API wrapper, an internal knowledge-base query, gets copy-pasted and reimplemented per agent, drifting slightly each time someone tweaks one copy and not the others.
+
+The Model Context Protocol (MCP) is Anthropic's open standard for exactly this seam: a tool is implemented once, as its own server, exposing a standard schema over a standard transport - and any MCP-compatible agent runtime, Azure AI Foundry included, can register it and call it without the tool's implementation living inside the agent's own code at all.
+
+***
+
+## Why a Standard Protocol Instead of More `FunctionTool`s
+
+The tradeoff is genuinely a tradeoff, not a strict upgrade - a `FunctionTool` is simpler to reach for when a capability is truly one agent's alone, since it skips the extra deployment surface an MCP server introduces. MCP earns its complexity when a tool is meant to be shared: the GitHub API wrapper this post builds is useful to any agent that needs repository data, not just one specific agent's use case, and implementing it as an MCP server means every agent that needs it registers the same tested, versioned server rather than each maintaining its own copy.
+
+***
+
+## The MCP Schema
+
+An MCP server exposes tools as JSON-RPC methods with a declared schema - the same shape as `FunctionTool`'s parameter schema, but served over a protocol any compliant client can discover and call, not defined inline in agent code:
+
+```python
+# mcp_server.py
+from mcp.server import Server
+from mcp.types import Tool, TextContent
+import httpx
+
+server = Server("internal-tools")
+
+@server.list_tools()
+async def list_tools() -> list[Tool]:
+    return [
+        Tool(
+            name="github_search",
+            description="Search code, issues, or PRs across the org's GitHub repositories.",
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "query": {"type": "string"},
+                    "search_type": {"type": "string", "enum": ["code", "issues", "pull_requests"]},
+                },
+                "required": ["query", "search_type"],
+            },
+        ),
+        Tool(
+            name="kb_query",
+            description="Query the internal knowledge base for documentation relevant to a question.",
+            inputSchema={
+                "type": "object",
+                "properties": {"question": {"type": "string"}},
+                "required": ["question"],
+            },
+        ),
+    ]
+
+@server.call_tool()
+async def call_tool(name: str, arguments: dict) -> list[TextContent]:
+    if name == "github_search":
+        results = await search_github(arguments["query"], arguments["search_type"])
+        return [TextContent(type="text", text=results)]
+    if name == "kb_query":
+        results = await query_knowledge_base(arguments["question"])
+        return [TextContent(type="text", text=results)]
+    raise ValueError(f"Unknown tool: {name}")
+```
+
+`list_tools` is what makes this discoverable rather than hardcoded - any client that connects to the server can enumerate what it offers without prior knowledge of its capabilities, the same way a REST API's OpenAPI spec lets a client discover endpoints it wasn't written against in advance.
+
+***
+
+## Registering the MCP Server with a Foundry Agent
+
+```python
+from azure.ai.agents.models import McpTool
+
+mcp_tool = McpTool(
+    server_label="internal-tools",
+    server_url="https://internal-tools-mcp.your-org.azurecontainerapps.io/mcp",
+    allowed_tools=["github_search", "kb_query"],
+)
+
+agent = await agents_client.create_agent(
+    model="gpt-4o",
+    name="platform-support-agent",
+    instructions=(
+        "You help engineers find information across GitHub and internal documentation. "
+        "Use github_search for questions about code, issues, or PRs. Use kb_query for "
+        "questions about internal processes or documentation. Always cite which tool "
+        "produced an answer."
+    ),
+    tools=[mcp_tool],
+)
+```
+
+`allowed_tools` is worth being deliberate about even when the server exposes more than two tools eventually - an agent should register only the specific tools its task requires, not every capability the server happens to offer, for the same least-privilege reason [the permissions-block post](/posts/2026-03-25-github-actions-permissions-block/) applied to workflow tokens. A support agent that only ever needs read access to GitHub search and the knowledge base shouldn't be handed a hypothetical future `github_write` tool just because it lives on the same server.
+
+***
+
+## Authentication Between Agent and Server
+
+The MCP server is a separate deployable with its own network exposure, which means the agent-to-server call needs its own auth layer, distinct from whatever credentials the server itself uses to reach GitHub or the knowledge base:
+
+```python
+mcp_tool = McpTool(
+    server_label="internal-tools",
+    server_url="https://internal-tools-mcp.your-org.azurecontainerapps.io/mcp",
+    allowed_tools=["github_search", "kb_query"],
+    headers={"Authorization": f"Bearer {mcp_server_access_token}"},
+)
+```
+
+On the server side, validate that token before executing any tool call - an MCP server reachable without authentication is a network-exposed capability to search your org's GitHub repos and internal docs, available to anyone who finds the URL, not just the agents meant to use it:
+
+```python
+from mcp.server import Server
+from fastapi import FastAPI, Request, HTTPException
+
+app = FastAPI()
+
+@app.middleware("http")
+async def verify_token(request: Request, call_next):
+    token = request.headers.get("Authorization", "").removeprefix("Bearer ")
+    if not await is_valid_agent_token(token):
+        raise HTTPException(status_code=401, detail="Invalid or missing agent token")
+    return await call_next(request)
+```
+
+***
+
+## Deploying the MCP Server as an Azure Container App
+
+```bash
+az containerapp create \
+  --name internal-tools-mcp \
+  --resource-group rg-ai-platform \
+  --environment ai-agents-env \
+  --image ghcr.io/your-org/internal-tools-mcp:latest \
+  --target-port 8080 \
+  --ingress internal \
+  --min-replicas 1 \
+  --max-replicas 5 \
+  --secrets "github-token=keyvaultref:https://your-vault.vault.azure.net/secrets/github-pat,identityref:system" \
+  --env-vars "GITHUB_TOKEN=secretref:github-token"
+```
+
+`--ingress internal` matters here - the MCP server only needs to be reachable from other resources inside the same Container Apps environment (the Foundry agent's runtime), not from the public internet. Scoping ingress this way removes an entire class of "found the URL, no auth required" exposure before the token-validation middleware above is even relevant, the same defense-in-depth instinct as network egress controls on a self-hosted runner.
+
+***
+
+## Closing
+
+MCP's value isn't that it makes any single tool call work differently than a `FunctionTool` would - from the agent's perspective, calling `github_search` looks similar either way. It's that the tool now exists as its own versioned, independently deployable, independently authenticated service that any compliant agent can register, instead of logic copy-pasted into every agent that needs it. For a genuinely single-agent capability, a `FunctionTool` is still the simpler, correct choice. For a capability more than one agent or team needs - which is most of the useful ones, over enough time - an MCP server is the version that doesn't drift into three subtly different implementations six months later.
+
+***
+
+Questions or corrections? Reach out.
+
+[steve.kaschimer@slalom.com](mailto:steve.kaschimer@slalom.com)

--- a/src/posts/2026-12-18-devsecops-year-in-review-2026.md
+++ b/src/posts/2026-12-18-devsecops-year-in-review-2026.md
@@ -1,0 +1,58 @@
+---
+author: Steve Kaschimer
+date: 2026-12-18
+image_prompt: "A dark-mode technical editorial illustration on a near-black background with cobalt blue, amber, and teal accents, styled like an annual report cover. A large '2026' rendered in a clean geometric font across the center, with small orbiting icons around it: a GitHub Octocat-style branch icon, a small agent/brain icon, a shield icon, and a policy-document icon, each connected to the numerals by thin light-trail arcs. Below, a minimalist three-column footer of small bar-chart glyphs labeled 'Shipped', 'Mattered', '2027', each with a short upward or flat trend line. The mood is reflective and confident - a year-end retrospective, not a product launch."
+layout: post.njk
+site_title: Tech Notes
+summary: "A personal, opinionated retrospective on the year in developer security, CI/CD, and AI-assisted development - structured as what shipped, what actually mattered in practice versus what stayed theoretical, and what's worth watching going into 2027. Written for practitioners who lived through the year's actual rollouts, not the press releases."
+tags: ["devsecops", "year-in-review", "github", "azure-ai-foundry", "editorial"]
+title: "The DevSecOps Year in Review 2026: What Shipped, What Mattered, What's Next"
+---
+
+Every year-in-review risks being a list of announcements dressed up as insight. This one tries to avoid that by being explicit about the distinction: a lot shipped in 2026, a meaningfully smaller subset of it actually changed how teams work day to day, and an even smaller subset is worth carrying real attention into 2027. What follows is opinionated on purpose - a year spent writing about most of this in detail earns a strong opinion about which parts of it were real.
+
+***
+
+## What Shipped
+
+**GitHub's security surface kept consolidating.** Rulesets matured into the default way to enforce branch and tag standards, [replacing branch protection rules](/posts/2026-05-08-github-branch-protection-rules-vs-rulesets/) as the more powerful, more auditable option. Merge queues went from a nice-to-have to [genuinely load-bearing infrastructure](/posts/2026-09-11-github-merge-queues/) for any repo with real PR volume. GitHub Advanced Security kept expanding what it covers by default, to the point where [rolling it out across a large org](/posts/2026-12-04-github-advanced-security-org-rollout/) became a sequencing problem worth its own playbook rather than a single settings toggle.
+
+**Azure AI Foundry went from "first look" to genuinely production-shaped.** The year started with [an introductory look at agentic workflows](/posts/2026-06-19-azure-ai-foundry-first-look-agentic-ai-workflows/) and by year's end had accumulated the full stack a production agent actually needs: [evaluation in CI](/posts/2026-08-21-evaluating-llm-outputs-in-ci-cd/), [memory and RAG](/posts/2026-09-04-azure-ai-foundry-agents-memory-tool-calling-rag/), [multi-agent orchestration](/posts/2026-07-24-multi-agent-patterns-azure-ai-foundry-orchestration-handoff-shared-state/), [fine-tuning decision frameworks](/posts/2026-11-06-azure-ai-foundry-fine-tuning-customize-vs-prompt/), [prompt versioning as a first-class deployment artifact](/posts/2026-10-30-llmops-versioning-testing-deploying-prompts/), and [MCP-based tool servers](/posts/2026-12-11-azure-ai-foundry-mcp-servers-custom-tools/) that let agents share capabilities instead of each reimplementing them. That's a genuinely complete LLMOps toolchain that didn't fully exist at the start of the year.
+
+**Agentic tooling started showing up inside the development process itself, not just as a feature teams build.** [Copilot doing PR review](/posts/2026-06-05-github-copilot-in-ci/) was the early version; by year's end that had extended to [agents enforcing specific architecture rules](/posts/2026-10-16-agentic-code-review-architecture-rules/) and [agents drafting test suites](/posts/2026-11-27-agentic-qa-ai-test-generation-exploratory-testing/) - the tooling turning inward, on the process that builds software, not just the AI features that software ships.
+
+***
+
+## What Actually Mattered in Practice
+
+The honest signal on adoption, from a year of writing about this stuff in enough depth to see which posts described something teams were genuinely doing versus something that sounded good in a keynote:
+
+**Merge queues and Rulesets mattered immediately and obviously**, because they solve a problem every team with more than a few contributors already has - a broken `main` from a race condition between two passing PRs, or a branch protection rule with a bypass nobody remembered granting. Adoption here wasn't a hard sell.
+
+**Policy as code and [agentic architecture enforcement](/posts/2026-10-16-agentic-code-review-architecture-rules/) mattered more slowly, and more selectively**, than the pitch for either suggested it would. Both are genuinely valuable, and both require an org to already have its standards written down clearly enough to encode - which turned out to be the actual bottleneck more often than the tooling. A team without a settled answer to "what's our dependency-direction rule" doesn't get more clarity from an [OPA policy](/posts/2026-11-13-policy-as-code-opa-github-actions/) or an enforcement agent; it gets a tool with nothing correct to enforce yet.
+
+**Fine-tuning stayed a narrow, deliberate tool, not the default upgrade path** it's often pitched as. The [decision framework](/posts/2026-11-06-azure-ai-foundry-fine-tuning-customize-vs-prompt/) - try better prompting, then RAG, then fine-tune only for the residual problem neither solves - held up in practice. Teams that reached for fine-tuning first, skipping that sequence, mostly rediscovered that the real problem was a retrieval gap or an under-iterated prompt.
+
+**Agentic QA stayed genuinely early**, exactly as [that post predicted](/posts/2026-11-27-agentic-qa-ai-test-generation-exploratory-testing/) - useful as a fast first draft for the tedious 80% of test-writing, not yet trustworthy unsupervised, and the "augmentation, not replacement" framing turned out to be load-bearing rather than a hedge.
+
+***
+
+## What to Watch in 2027
+
+**Agentic pipelines becoming the default shape of CI, not an add-on to it.** 2026 was the year agents got added to existing pipelines - a review step here, a test-generation step there. 2027 is likely the year some teams start designing the pipeline around an agent's involvement from the start, rather than bolting one onto a pipeline that was designed for purely deterministic steps.
+
+**AI-native security tooling maturing past "LLM wrapped around a scanner."** Most of what shipped in 2026 under this label was existing static/dynamic analysis with an LLM summarizing or triaging the output - genuinely useful, but not a different category of tool yet. The interesting open question for 2027 is whether tooling emerges that reasons about vulnerability classes the way an agent reasons about a codebase, rather than just narrating a traditional scanner's findings in friendlier language.
+
+**Platform engineering consolidation continuing**, with [internal developer platforms wired directly to GitHub as the source of truth](/posts/2026-11-20-internal-developer-platforms-backstage-github-api/) rather than a separately maintained catalog - the pattern that actually solves staleness, versus the pattern that just adds a UI on top of a problem that isn't fixed. Expect more of the ecosystem to follow that same "read from the source of truth, don't duplicate it" shape, because the alternative keeps failing the same way it failed before agents and IDPs were part of the conversation.
+
+***
+
+## Closing
+
+The throughline across this whole year, more than any single feature: the tools that mattered were the ones that removed a step a human used to do from memory - remembering a rule, remembering to update a catalog, remembering to test an edge case - and replaced it with something that runs the same way every time. The tools that didn't move the needle as fast as their pitch suggested were mostly the ones that assumed the hard organizational work (writing the rule down clearly, deciding what "good" actually means) was already done. Going into 2027, that's still the actual bottleneck worth watching - not whether the tooling gets more capable, which it reliably will, but whether teams do the unglamorous work of making their own standards explicit enough for any of it to enforce.
+
+***
+
+Questions or corrections? Reach out.
+
+[steve.kaschimer@slalom.com](mailto:steve.kaschimer@slalom.com)

--- a/src/posts/2026-12-25-async-first-development-across-time-zones.md
+++ b/src/posts/2026-12-25-async-first-development-across-time-zones.md
@@ -1,0 +1,88 @@
+---
+author: Steve Kaschimer
+date: 2026-12-25
+image_prompt: "A dark-mode technical editorial illustration on a near-black background with cobalt blue, teal, and amber accents. A horizontal world-clock strip across the top showing four time zone dials at different hours, connected below to a shared timeline of small artifact icons: a well-formed commit message card, an ADR document icon, a PR with a long descriptive body, and a GitHub Discussions speech-bubble icon - all sitting on the timeline independent of any single clock. No meeting/video-call icon appears anywhere in the composition. The mood is calm and asynchronous - work products that stand on their own across time zones, not a real-time meeting rescheduled four times."
+layout: post.njk
+site_title: Tech Notes
+summary: "Distributed teams that just move standup to Zoom are still a synchronous team that happens to work from different buildings. Async-first is a different discipline entirely - one where the code, the process, and the tooling are built so nobody has to be online at the same moment to move work forward. This lighter, holiday-week post covers the practices that actually separate async-capable teams from ones that only look distributed: commit message discipline, ADR-driven decisions, self-documenting PRs, GitHub Discussions for deliberation, and using GitHub Actions to automate the status updates a synchronous team would otherwise get from a Slack message."
+tags: ["developer-productivity", "remote-work", "writing-for-engineers", "git", "async"]
+title: "Async-First Development: Writing Code and Processes That Work Across Time Zones"
+---
+
+A team spread across four time zones that still runs a daily standup is a synchronous team with a scheduling problem, not an async team. The tell is what happens when someone's asleep during a decision that needed to get made: a genuinely async-first team already wrote down enough context that the decision doesn't need them in the room, and a team that only looks distributed waits until everyone's awake again, quietly synchronous the whole time behind a Zoom link.
+
+The actual discipline isn't about tooling that lets people work at different hours - Slack and GitHub already do that. It's about producing work artifacts complete enough that someone eight time zones away can pick up where you left off without a meeting to fill in what didn't make it into the artifact.
+
+***
+
+## Commit Messages as the Unit of Context Transfer
+
+A commit message that says `fix bug` transfers no context to the next person who runs `git blame` on that line - which, on an async team, might be someone in a time zone that never overlapped with the author's working hours, with no way to just ask. [The commit-message post](/posts/2026-04-24-writing-commit-messages-that-make-code-review-faster/) covers this in depth; the async-specific stake is higher than it looks for a co-located team, because a co-located team can always fall back to walking over and asking. An async team's fallback is nothing - the commit message, or the absence of one, is the only context that will ever exist for that change unless someone explicitly writes more later.
+
+***
+
+## ADRs as Decisions That Don't Require the Room
+
+[Architecture Decision Records](/posts/2026-05-01-architecture-decision-records/) matter more on an async team than a co-located one for the same reason - a decision made in a synchronous meeting and never written down is fine for the people who were in the meeting and a mystery for everyone else, forever, on a team where "everyone else" might be most of the team depending on the hour a decision got made. An ADR is the artifact that makes a decision durable across the exact gap - someone awake when it happened, someone not - that async teams are built around.
+
+***
+
+## Self-Documenting PRs
+
+A PR description that says "see ticket" forces the reviewer into a context-switch to a different tool, at a different time, possibly hours after the PR was opened - a real cost for a synchronous team and a much larger one for an async reviewer who won't get a live answer to a clarifying question for another twelve hours. A self-documenting PR states the *why* directly in the description: what problem this solves, what alternative was considered and rejected, what the reviewer should specifically look at. It's the same instinct as a good commit message, applied to the unit of work a reviewer actually engages with first.
+
+The failure mode worth naming: a PR description that's just a copy of the commit messages restates *what* changed, which the diff already shows. The value a description adds is *why*, and *why* is exactly the part that doesn't survive being deferred to "we can discuss it in review" on a team where review might happen a full day later.
+
+***
+
+## GitHub Discussions for Deliberation That Isn't Urgent
+
+Slack is built for a completely different pace than the kind of deliberation that benefits from someone thinking about it overnight and replying with a considered response instead of a reflexive one. GitHub Discussions - threaded, persistent, tied to the repo rather than scattered across DMs and channels - is a better home for "should we adopt this pattern org-wide" than a Slack thread that scrolls out of relevance within a day and is nearly unsearchable six months later. The practical rule: if a question benefits from someone in a different time zone getting to weigh in with a full night's distance from the original framing, it belongs in a Discussion, not a message that expects a same-day reply.
+
+***
+
+## Automating the Status Update a Standup Would Have Given
+
+A synchronous team's daily standup does real work - not the ceremony, but the actual information it transfers: what shipped, what's blocked, what's coming next. An async team needs that same information transferred without a meeting, and a lot of it is mechanically derivable from GitHub's own activity rather than something someone has to narrate live:
+
+```yaml
+name: Weekly Async Status Digest
+
+on:
+  schedule:
+    - cron: '0 14 * * 5'
+
+permissions:
+  contents: read
+  pull-requests: read
+  issues: read
+
+jobs:
+  digest:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Compile weekly activity
+        run: python scripts/compile_weekly_digest.py
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Post digest
+        run: |
+          curl -X POST "${{ secrets.SLACK_WEBHOOK_URL }}" \
+            -H 'Content-Type: application/json' \
+            -d "{\"text\": \"$(cat weekly-digest.md)\"}"
+```
+
+`compile_weekly_digest.py` pulls merged PRs, newly opened issues, and anything sitting in `blocked` status across the week and produces a written summary - not a replacement for the judgment a human standup update carries, but the mechanical part (what shipped, what's open) that doesn't need a live voice to convey, freeing whatever synchronous time the team does have for the parts that actually benefit from real-time back-and-forth.
+
+***
+
+## Closing
+
+None of this is about avoiding meetings out of some ideological preference for async over sync - a genuinely hard design discussion is still often faster live, and pretending otherwise doesn't make a team more async, just slower. The actual discipline is narrower and more specific: default to writing artifacts complete enough that they don't *require* a meeting to be understood, and reserve real-time coordination for the cases that actually benefit from it rather than the cases where nobody got around to writing the context down. A team that does that consistently is async-first regardless of how many time zones it spans. A team that doesn't is synchronous with extra latency, no matter how distributed its org chart looks.
+
+***
+
+Questions or corrections? Reach out. And happy holidays.
+
+[steve.kaschimer@slalom.com](mailto:steve.kaschimer@slalom.com)


### PR DESCRIPTION
## Summary

Drafts all four December posts, completing the 2026 editorial calendar:

- **#139** - GitHub Advanced Security at the Org Level: Rolling Out GHAS Across 100+ Repos. Sequenced rollout (secret scanning, then code scanning, then Dependabot alerts with auto-dismiss rules), auditing enablement across an org with the REST API/`gh` CLI, org-level default CodeQL setup, and a weekly coverage dashboard via GitHub Actions.
- **#140** - Azure AI Foundry MCP Servers: Building and Registering Custom Tools for Your Agents. Builds an MCP server exposing a GitHub search tool and a knowledge-base query tool, registers it with a Foundry agent, and covers the MCP schema, agent-to-server authentication, and deployment as an Azure Container App.
- **#141** - The DevSecOps Year in Review 2026: What Shipped, What Mattered, What's Next. A personal, opinionated retrospective structured in three parts (what shipped, what actually mattered in practice, what to watch in 2027), cross-linking the year's actual posts rather than generic industry commentary.
- **#142** - Async-First Development: Writing Code and Processes That Work Across Time Zones. Commit message discipline, ADR-driven decisions, self-documenting PRs, GitHub Discussions for non-urgent deliberation, and automating the status update a synchronous standup would otherwise provide. Lighter, holiday-week post.

Also updates `editorial-plan.md` status/file for all four posts.

None of the four posts have hero images yet - those will follow in a separate commit once generated via ChatGPT from each post's `image_prompt` field.

## Test plan

- [x] `npm run deploy` builds cleanly for all four new posts
- [x] All internal cross-links (especially the dozen+ in the year-in-review post) verified to resolve to real post files
- [x] `node scripts/a11y-check.js` - no accessibility violations (home/post/about/privacy/terms/404, light + dark)
- [ ] Hero images to follow once generated

Closes #139
Closes #140
Closes #141
Closes #142


---
_Generated by [Claude Code](https://claude.ai/code/session_01WKyNF7L5qzrfct8cec6A32)_