### PR TITLE
.NET Architecture Patterns track (6 posts): comparison + 5 setup guides

### DIFF
--- a/editorial-plan.md
+++ b/editorial-plan.md
@@ -583,9 +583,10 @@ Six posts on AI coding agents, running Tuesdays alongside the Friday DevOps trac
 Six posts on how to organize a .NET codebase, picking up the Tuesday cadence directly from the AI coding agents track. A comparison post anchors the track and each of the five follow-ups sets one pattern up end to end.
 
 ### The Top 5 .NET Architecture Patterns Compared: Which One Should You Choose?
-- **Status:** `idea`
+- **Status:** `draft`
 - **Scheduled:** 2026-09-29
 - **Source:** `docs/article-ideas/top-5-dotnet-architecture-patterns-compared.md`
+- **File:** `src/posts/2026-09-29-top-5-dotnet-architecture-patterns-compared.md`
 - **Pitch:** Layered, Clean, Vertical Slice, Modular Monolith, and Microservices aren't five points on a scale from bad to good - they're different trades between structure, speed, and organizational scale. This is the orientation piece for a team that has to pick one and defend the choice.
 - **Angle:** Opens with a comparison table across organizing principle, deployment unit, learning curve, change isolation, and operational overhead, then gives each pattern a strengths/weaknesses/choose-this-when breakdown. The load-bearing argument is that several of these compose rather than compete - Vertical Slice or Clean Architecture inside a module of a Modular Monolith is a common and underrated landing spot. Closes on the point that a Modular Monolith is usually the honest predecessor to Microservices rather than its opposite, and that module boundaries only hold when enforcement is structural rather than cultural.
 - **Tags:** `dotnet`, `architecture`, `microservices`, `platform-engineering`, `developer-productivity`

--- a/editorial-plan.md
+++ b/editorial-plan.md
@@ -592,41 +592,46 @@ Six posts on how to organize a .NET codebase, picking up the Tuesday cadence dir
 - **Tags:** `dotnet`, `architecture`, `microservices`, `platform-engineering`, `developer-productivity`
 
 ### Getting Started with Clean Architecture in .NET
-- **Status:** `idea`
+- **Status:** `draft`
 - **Scheduled:** 2026-10-06
 - **Source:** `docs/article-ideas/getting-started-with-clean-architecture-dotnet.md`
+- **File:** `src/posts/2026-10-06-getting-started-with-clean-architecture-dotnet.md`
 - **Pitch:** The dependency rule is easy to state and easy to leave aspirational. Getting the project structure right so the compiler enforces it - rather than code review hoping to catch violations - is where most first attempts go sideways.
 - **Angle:** Scaffolds the solution both from the Ardalis Clean Architecture template and by hand, showing the Core/UseCases/Infrastructure/Web reference graph that turns the dependency rule into a compile error. Covers where entities, handlers, and repository implementations actually belong, the single point in `Program.cs` where the concrete and the abstract meet, and NetArchTest/ArchUnitNET architecture tests that fail the build when `Core` picks up an infrastructure dependency a project reference alone wouldn't catch. Ends on the honest limitation: the ceremony earns its keep only where there's real business logic to protect, and a rules-free CRUD endpoint doesn't need four layers and a MediatR handler.
 - **Tags:** `dotnet`, `architecture`, `testing`, `developer-productivity`
 
 ### Getting Started with Layered (N-Tier) Architecture in .NET
-- **Status:** `idea`
+- **Status:** `draft`
 - **Scheduled:** 2026-10-13
 - **Source:** `docs/article-ideas/getting-started-with-layered-architecture-dotnet.md`
+- **File:** `src/posts/2026-10-13-getting-started-with-layered-architecture-dotnet.md`
 - **Pitch:** Layered architecture still runs a huge share of production .NET, and for genuinely CRUD-shaped applications that's the right call rather than a compromise. The mistake isn't using it - it's using it past the point where it stops fitting the problem.
 - **Angle:** Sets up Web/Business/DataAccess as three separate projects so violating the dependency direction is a compile error rather than a convention people forget, wires EF Core into the data layer, and keeps the business layer free of ASP.NET Core types. Covers DTOs vs. entities at the API boundary, repository interfaces purely for testability, and why the business layer becomes a dumping ground without deliberate internal splitting. Closes with the signal to move on: when most feature changes touch all three layers, that friction is pointing at Vertical Slice or a Modular Monolith, not at adding more structure inside the same three layers.
 - **Tags:** `dotnet`, `architecture`, `testing`, `developer-productivity`
 
 ### Getting Started with Vertical Slice Architecture in .NET
-- **Status:** `idea`
+- **Status:** `draft`
 - **Scheduled:** 2026-10-20
 - **Source:** `docs/article-ideas/getting-started-with-vertical-slice-architecture-dotnet.md`
+- **File:** `src/posts/2026-10-20-getting-started-with-vertical-slice-architecture-dotnet.md`
 - **Pitch:** Vertical Slice Architecture asks what a single request actually needs and puts all of it in one folder, so adding a feature means adding a slice rather than touching four existing layers. Its failure mode is teams reading "organize by feature" as "duplicate everything."
 - **Angle:** Builds a complete slice - command, handler, endpoint, validator - under `Features/<Area>/<Feature>/` with MediatR and FastEndpoints, where assembly scanning means new slices register nothing manually. Makes the case that a MediatR pipeline behavior is where validation, logging, and transaction handling belong, since re-implementing cross-cutting concerns slightly differently per slice is what stops many independent slices from feeling like one coherent application. Argues against extracting shared abstractions early and against reflexively hiding `DbContext` behind a repository in every slice, then positions the pattern relative to a Modular Monolith as a different altitude rather than a competing choice.
 - **Tags:** `dotnet`, `architecture`, `developer-productivity`, `tooling`
 
 ### Getting Started with Modular Monolith Architecture in .NET
-- **Status:** `idea`
+- **Status:** `draft`
 - **Scheduled:** 2026-10-27
 - **Source:** `docs/article-ideas/getting-started-with-modular-monolith-dotnet.md`
+- **File:** `src/posts/2026-10-27-getting-started-with-modular-monolith-dotnet.md`
 - **Pitch:** A Modular Monolith is deceptively easy to describe and genuinely hard to keep honest - nothing forces modules to respect each other's boundaries except deliberate enforcement, and the moment enforcement lapses it's a monolith with extra folders.
 - **Angle:** Structures each module as an implementation project plus a `Contracts` project, where modules reference only each other's contracts and implementations are marked `internal` so a cross-module reach is a compile error rather than a code review note. Gives each module its own `DbContext` and self-registering DI extension so the host stays thin, and backs the whole arrangement with architecture tests that fail CI on a boundary violation. Covers the two decisions that actually determine whether the pattern holds - separate schemas vs. separate databases, and in-process events vs. direct contract calls - and argues a Modular Monolith is a complete architecture rather than an unfinished Microservices migration.
 - **Tags:** `dotnet`, `architecture`, `microservices`, `platform-engineering`, `ci-cd`
 
 ### Getting Started with Microservices Architecture in .NET
-- **Status:** `idea`
+- **Status:** `draft`
 - **Scheduled:** 2026-11-03
 - **Source:** `docs/article-ideas/getting-started-with-microservices-dotnet.md`
+- **File:** `src/posts/2026-11-03-getting-started-with-microservices-dotnet.md`
 - **Pitch:** Microservices solve an organizational problem most projects don't have yet: independent teams needing to deploy and scale without blocking each other. .NET Aspire has made the local development side dramatically less painful, but it hasn't changed that trade-off.
 - **Angle:** Scaffolds a multi-service solution with Aspire and describes the whole topology in AppHost - a Postgres container per service, `WithReference` for service discovery instead of hardcoded URLs, and one `dotnet run` that brings everything up with a dashboard showing logs and traces across services. Covers ServiceDefaults as the place shared OpenTelemetry, health checks, and resilience configuration live without coupling services to each other's business logic. Is explicit that AppHost is a development tool that never gets deployed, and that Aspire removes friction from building and running services locally without removing contract versioning, partial failure handling, or distributed data consistency - which are the actual cost of the pattern.
 - **Tags:** `dotnet`, `architecture`, `microservices`, `observability`, `devops`

--- a/src/posts/2026-09-29-top-5-dotnet-architecture-patterns-compared.md
+++ b/src/posts/2026-09-29-top-5-dotnet-architecture-patterns-compared.md
@@ -1,0 +1,163 @@
+---
+author: Steve Kaschimer
+date: 2026-09-29
+image: /images/posts/2026-09-29-hero.webp
+image_alt: "Five columns of abstract organization glyphs positioned along a horizontal axis running from single-layer structure on the left to fully distributed on the right."
+image_prompt: "A dark-mode technical editorial illustration on a near-black background with electric teal, amber, and off-white accents. Composition is five vertical columns of equal width separated by thin hairline rules, each column topped by a distinct abstract glyph rendered in flat geometry: three stacked horizontal bars, a set of concentric rings with a small dot at the center, a single bordered card, a grid of bordered boxes each with its own small internal dot, and a loose cluster of separate connected nodes. Beneath the glyphs, a shared horizontal axis labeled in monospaced type runs from 'single deployable' on the left to 'distributed' on the right, with a small glowing teal dot positioned at a different point under each column. A faint amber bracket spans two adjacent columns to suggest patterns composing rather than competing. Mood is comparative, engineering-first, and non-partisan. Avoid: vendor logos, brand colors, circuit-board textures, robot faces, generic gears or lightbulb clip art."
+layout: post.njk
+site_title: Tech Notes
+summary: "Layered, Clean, Vertical Slice, Modular Monolith, and Microservices all answer the same question differently. A practical breakdown of what each actually optimizes for, and which project profile fits."
+tags: ["dotnet", "architecture", "microservices", "platform-engineering", "developer-productivity"]
+title: "The Top 5 .NET Architecture Patterns Compared: Which One Should You Choose?"
+---
+
+Every .NET project eventually asks the same question: how should this codebase actually be organized? The honest answer is "it depends" - but that's not a satisfying place to leave a decision that gets harder to reverse the longer a project runs. Layered architecture, Clean Architecture, Vertical Slice Architecture, Modular Monolith, and Microservices all answer the organization question differently, and they're not five points on a single spectrum from "bad" to "good" - they're different trade-offs between structure, speed, and how much a system needs to scale organizationally, not just technically.
+
+This guide breaks down what each pattern actually optimizes for, where it starts to strain, and which project profile it fits. A useful thing to know upfront: several of these aren't mutually exclusive. Vertical Slice Architecture and Clean Architecture can coexist inside a single module of a Modular Monolith, and a Modular Monolith is often the honest predecessor to Microservices rather than its opposite. This series continues with dedicated getting-started walkthroughs for each pattern in .NET.
+
+## Quick Comparison
+
+| Dimension | Layered (N-Tier) | Clean Architecture | Vertical Slice | Modular Monolith | Microservices |
+| --- | --- | --- | --- | --- | --- |
+| **Organizes code by** | Technical layer (UI, business, data) | Dependency direction, centered on domain | Feature/use case | Business capability module | Independently deployable service |
+| **Deployment unit** | Single app | Single app | Single app | Single app | Many services |
+| **Learning curve** | Lowest - most familiar | Moderate - more abstraction and ceremony | Low - maps directly to requests | Moderate - requires enforced boundaries | Highest - distributed systems complexity |
+| **Change isolation** | Weak - a change often touches every layer | Good within the dependency rule | Excellent - one feature, one slice | Excellent between modules | Excellent between services |
+| **Operational overhead** | Minimal | Minimal | Minimal | Minimal (still one deployable) | Significant (networking, observability, deployment) |
+| **Best for** | Small apps, CRUD-heavy tools, learning projects | Domain-heavy apps needing long-term testability | Feature-heavy apps with independent use cases | Growing systems that need internal boundaries without distributed complexity | Large orgs needing independent scaling and deployment per team |
+
+## Layered (N-Tier) Architecture
+
+Layered architecture is the default most developers learn first: a Presentation layer, a Business Logic layer, and a Data Access layer, each depending on the one below it. It's not fashionable to discuss anymore, but it's still how a large share of production .NET code is actually organized, and for good reason in the right context.
+
+**Strengths:**
+
+- Immediately familiar - almost every developer already knows this shape, which lowers onboarding cost
+- Minimal ceremony: no interfaces-for-the-sake-of-interfaces, no dependency inversion to reason about
+- Fast to start, and perfectly adequate for genuinely simple, CRUD-heavy applications
+
+**Weaknesses:**
+
+- Layers tend to depend directly on concrete implementations (especially the data layer), making business logic harder to unit test in isolation
+- A single feature change often touches every layer, which is the opposite of change isolation
+- As an app grows, the business logic layer tends to become a dumping ground with no natural internal boundaries
+
+**Choose this when:** the application is small, genuinely CRUD-shaped, short-lived, or a learning project where the goal is understanding fundamentals rather than optimizing for long-term change.
+
+## Clean Architecture
+
+Clean Architecture (and its close relatives, Onion and Hexagonal architecture) organizes code around a dependency rule instead of a technical stack: dependencies point inward, toward the domain, and the domain knows nothing about infrastructure, UI, or frameworks. Business rules sit at the center, insulated from the details around them.
+
+**Strengths:**
+
+- The domain layer is genuinely framework-independent and highly testable, since it has no dependency on EF Core, ASP.NET Core, or any other infrastructure concern
+- Swapping infrastructure - a different database, a different message broker - is a matter of implementing an interface, not rewriting business logic
+- Well-documented and widely templated in the .NET ecosystem, so teams adopting it aren't inventing conventions from scratch
+
+**Weaknesses:**
+
+- More abstraction and ceremony than most features actually need - a simple CRUD endpoint can end up passing through several layers and interfaces before touching a database
+- The learning curve is real for teams unfamiliar with dependency inversion; project structure isn't self-explanatory the way layered architecture is
+- Because it organizes by dependency direction rather than by feature, related code for one use case can end up spread across several projects
+
+**Choose this when:** the domain has genuine business complexity worth protecting - non-trivial rules, invariants, and logic you want insulated from infrastructure churn - and the team is willing to invest in the structure that protects it.
+
+## Vertical Slice Architecture
+
+Vertical Slice Architecture organizes code by feature instead of by layer: everything a single request needs - the endpoint, request/response models, validation, business logic, and data access - lives together in one place. Adding a feature means adding a slice, not touching four existing layers.
+
+**Strengths:**
+
+- Excellent change isolation - a feature can be modified or removed without touching code that exists purely for technical separation
+- Maps directly to how requests actually work, which makes the codebase easier to navigate for a specific use case
+- Pairs naturally with CQRS and libraries like MediatR, since each slice is essentially a self-contained command or query handler
+
+**Weaknesses:**
+
+- Without discipline, shared logic can get duplicated across slices rather than properly extracted, since there's no default "shared layer" the way layered architecture provides one
+- Doesn't inherently protect the domain from infrastructure concerns the way Clean Architecture's dependency rule does - that discipline has to be added deliberately if it matters for your domain
+- Less familiar to teams used to layered thinking, which can cause friction in code review before the pattern clicks
+
+**Choose this when:** the application has many largely independent features or use cases, and the primary pain you're solving is coordinating changes across layers just to ship one feature.
+
+## Modular Monolith
+
+A Modular Monolith is a single deployable application internally organized into modules with enforced boundaries - each module owns its own domain model, and often its own data, communicating with other modules through explicit, narrow interfaces rather than reaching directly into each other's internals. It's a macro-architecture decision, distinct from what you choose to do inside each module.
+
+**Strengths:**
+
+- Delivers most of the boundary and ownership benefits people associate with Microservices, without the operational overhead of a distributed system
+- Each module can internally use whatever fits it best - Clean Architecture in one, Vertical Slice in another - since the modular boundary is what protects the rest of the system, not the internal structure
+- A credible, lower-risk stepping stone toward Microservices later, since module boundaries that are already enforced in-process translate naturally into service boundaries later if that becomes necessary
+
+**Weaknesses:**
+
+- Boundaries are a discipline, not a guarantee - without enforcement (project references, architecture tests, code review vigilance), a modular monolith drifts back into a tangled "big ball of mud"
+- Still a single deployment unit, so it inherits some monolith constraints: one release cadence, shared fault domain, scaling the whole app together rather than one module independently
+- Requires a genuine upfront decision about module boundaries, which is harder to get right early than either layered or vertical slice organization
+
+**Choose this when:** the system is growing complex enough that unconstrained coupling is becoming a real problem, but the team doesn't want - or isn't ready for - the operational cost of distributed services.
+
+## Microservices
+
+Microservices decompose a system into independently deployable services, each owning its own data and communicating over the network rather than through in-process calls. It's less a code organization pattern than a deployment and organizational one - the code inside a given service can be organized with Clean Architecture, Vertical Slice, or anything else.
+
+**Strengths:**
+
+- Services can be deployed, scaled, and released independently, which matters enormously once multiple teams need to ship on different cadences without blocking each other
+- Failure isolation: a problem in one service doesn't necessarily take down the whole system the way an in-process monolith failure can
+- Different services can use different tech stacks, data stores, and scaling profiles suited to their specific workload
+
+**Weaknesses:**
+
+- Real distributed systems complexity: network calls where there used to be method calls, eventual consistency where there used to be a single transaction, and observability, retries, and failure handling that all need deliberate design
+- Significant operational overhead - service discovery, deployment pipelines per service, distributed tracing, and infrastructure that a monolith simply doesn't need
+- Genuinely counterproductive for small teams or systems without the organizational scale that justifies the overhead - premature adoption is one of the most common architecture mistakes in the industry
+
+**Choose this when:** multiple teams need to own, deploy, and scale parts of the system independently, and the organizational and operational cost is justified by that need - not because Microservices are perceived as more modern or prestigious.
+
+## How to Decide
+
+A few heuristics that cover most real-world decisions:
+
+**Building something small, short-lived, or genuinely CRUD-shaped?** Layered architecture is not a compromise here - it's the right amount of structure for the problem.
+
+**Domain has real business complexity you want protected from infrastructure churn?** Clean Architecture's dependency rule earns its ceremony when there's actually business logic worth insulating.
+
+**Application is mostly a collection of largely independent features?** Vertical Slice Architecture keeps each feature's blast radius contained and makes the codebase easy to navigate feature-by-feature.
+
+**System is growing past what a single mental model can hold, but you're not ready for distributed systems overhead?** A Modular Monolith gets you real internal boundaries while staying one deployable, and it's a credible path toward Microservices later if you need it.
+
+**Multiple teams need independent deployment and scaling, and you can justify the operational investment?** Microservices solve an organizational problem as much as a technical one - make sure that's the problem you actually have.
+
+None of these are permanent, either - a common and often underrated path is Vertical Slice or Clean Architecture inside a Modular Monolith, evolving specific modules into standalone services only once a concrete scaling or team-ownership need actually shows up, rather than architecting for that need speculatively from day one.
+
+## Frequently Asked Questions
+
+### Are Clean Architecture and Vertical Slice Architecture mutually exclusive?
+
+No. They answer different questions - Vertical Slice Architecture organizes what code lives together (by feature), while Clean Architecture governs how dependencies point (inward, toward the domain). A vertical slice can still keep its business logic free of direct infrastructure dependencies; the two patterns compose more often than they compete.
+
+### Is a Modular Monolith just a Microservices system that hasn't been split up yet?
+
+Not quite, but the framing is useful. A Modular Monolith is a legitimate, complete architecture in its own right - not merely an unfinished Microservices migration. Many systems stay modular monoliths indefinitely because the operational cost of splitting into services never gets justified by an actual organizational need. That said, well-enforced module boundaries do make a later split meaningfully easier if that need eventually arises.
+
+### Should I start a new project with Microservices?
+
+Usually not. Microservices solve problems around independent team ownership, deployment, and scaling that most new projects don't have yet. Starting with a Modular Monolith or Vertical Slice Architecture and evolving toward services once a concrete need appears is generally lower-risk than architecting for distributed systems complexity speculatively.
+
+### Which pattern is easiest to migrate away from later?
+
+Vertical Slice Architecture and a well-bounded Modular Monolith both tend to migrate cleanly, because they already organize code around cohesive units (features or modules) rather than cross-cutting technical layers. Layered architecture is typically the hardest to migrate away from, since business logic and data access tend to be entangled across the whole codebase rather than isolated by feature or module.
+
+### Can I use more than one of these patterns in the same codebase?
+
+Yes, and it's common in practice. A Modular Monolith might use Clean Architecture inside one complex module and Vertical Slice Architecture inside a simpler one. What matters is that the choice is deliberate per module rather than applying maximum ceremony everywhere or minimum structure everywhere regardless of actual complexity.
+
+### Does choosing Clean Architecture or Vertical Slice Architecture affect my choice of ORM or database?
+
+Not fundamentally, though the patterns influence how that dependency is structured. Clean Architecture pushes data access behind an interface defined in the domain or application layer, so the domain doesn't reference EF Core directly. Vertical Slice Architecture is more relaxed about this by default, often allowing a slice to talk to the database directly for simplicity, with abstraction added deliberately only where a specific slice needs it.
+
+### How do I know when a Modular Monolith's boundaries are actually being enforced, versus just aspirational?
+
+Enforcement needs to be structural, not just cultural - project references that make it a compile error for one module to reach into another's internals, and increasingly, automated architecture tests that fail a build when a boundary is violated. If the only thing stopping cross-module coupling is code review vigilance, the boundaries will erode as the team and codebase grow.

--- a/src/posts/2026-10-06-getting-started-with-clean-architecture-dotnet.md
+++ b/src/posts/2026-10-06-getting-started-with-clean-architecture-dotnet.md
@@ -1,0 +1,230 @@
+---
+author: Steve Kaschimer
+date: 2026-10-06
+image: /images/posts/2026-10-06-hero.webp
+image_alt: "A set of concentric rings around a small central dot, with arrows along the outer ring pointing inward and a padlock icon marking the boundary of the innermost ring."
+image_prompt: "A dark-mode technical editorial illustration on a near-black background with electric teal, amber, and off-white accents. Composition centers on four concentric rings around a small glowing off-white dot, rendered as thin circular outlines of increasing radius. Along the outermost ring, three short arrows point inward toward the center, each in teal. Where the second-from-center ring meets the innermost ring, a small amber padlock icon sits directly on the boundary line, implying an enforced crossing point. Faint monospaced labels sit just outside each ring at reduced opacity, too small to read as real text, suggesting layered naming without literal words. Mood is precise, structural, and calm. Avoid: vendor logos, brand colors, circuit-board textures, gears, or generic onion/vegetable imagery despite the ring shape."
+layout: post.njk
+site_title: Tech Notes
+summary: "The dependency rule is easy to state and easy to leave aspirational. A setup guide for making it a compile-time guarantee - project structure, architecture tests, and the one place the concrete and the abstract meet."
+tags: ["dotnet", "architecture", "testing", "developer-productivity"]
+title: "Getting Started with Clean Architecture in .NET"
+---
+
+Clean Architecture's core idea is simple to state and easy to get wrong in practice: dependencies point inward, toward the domain, and the domain knows nothing about the database, the web framework, or any other infrastructure detail. Getting the idea is the easy part. Getting the project structure right - so that rule is actually enforced rather than just aspired to - is where most first attempts go sideways.
+
+This guide covers scaffolding a Clean Architecture solution in .NET, bootstrapping it so the dependency rule is a compile-time guarantee rather than a convention, the core workflow of adding a feature, and the best practices that keep the pattern's ceremony proportional to the complexity it's protecting. By the end you'll have a solution structure you can extend without the discipline eroding as it grows.
+
+If you're deciding between architecture styles first, [a comparison of the top .NET architecture patterns](/posts/2026-09-29-top-5-dotnet-architecture-patterns-compared/) covers where Clean Architecture fits relative to layered architecture, Vertical Slice, Modular Monolith, and Microservices.
+
+## What You'll Need
+
+- .NET 8 SDK or later
+- A relational database (SQL Server, PostgreSQL, or SQLite for local development)
+- Familiarity with dependency inversion - it's the concept the entire pattern is built around
+
+## Installing and Scaffolding
+
+Rather than assembling the project structure by hand, start from a proven template. Steve "Ardalis" Smith's Clean Architecture Solution Template is the most widely used starting point in the .NET community:
+
+```bash
+dotnet new install Ardalis.CleanArchitecture.Template
+dotnet new clean-arch -o MyApp
+cd MyApp
+```
+
+This scaffolds a solution with `Core`, `UseCases`, `Infrastructure`, and `Web` projects, wired with MediatR for CQRS-style use case handling and FastEndpoints for minimal API endpoints. If you'd rather build the structure by hand to understand each piece, create the projects directly:
+
+```bash
+dotnet new sln -n MyApp
+
+dotnet new classlib -n MyApp.Core
+dotnet new classlib -n MyApp.UseCases
+dotnet new classlib -n MyApp.Infrastructure
+dotnet new webapi -n MyApp.Web
+
+dotnet sln add MyApp.Core MyApp.UseCases MyApp.Infrastructure MyApp.Web
+
+dotnet add MyApp.UseCases reference MyApp.Core
+dotnet add MyApp.Infrastructure reference MyApp.Core MyApp.UseCases
+dotnet add MyApp.Web reference MyApp.Core MyApp.UseCases MyApp.Infrastructure
+```
+
+## Bootstrapping the Ideal Environment
+
+The dependency rule is the entire point of Clean Architecture, and it only works if it's structurally enforced. This is where the project reference graph matters more than in any other pattern in this series.
+
+### The four layers, and what belongs where
+
+```
+MyApp.Core/             -> Entities, value objects, domain interfaces, business rules
+MyApp.UseCases/         -> Application logic: commands, queries, handlers (often via MediatR)
+MyApp.Infrastructure/   -> EF Core DbContext, repository implementations, external services
+MyApp.Web/              -> API endpoints, DI wiring, Program.cs
+```
+
+The critical rule: `Core` references nothing else in the solution. It doesn't know EF Core exists, doesn't know ASP.NET Core exists, and defines interfaces (like `IOrderRepository`) that `Infrastructure` implements - not the other way around.
+
+```csharp
+// MyApp.Core/Interfaces/IOrderRepository.cs
+public interface IOrderRepository
+{
+    Task<Order?> GetByIdAsync(int id);
+    Task AddAsync(Order order);
+}
+
+// MyApp.Core/Entities/Order.cs
+public class Order
+{
+    public int Id { get; private set; }
+    public OrderStatus Status { get; private set; }
+
+    public void MarkAsProcessing()
+    {
+        if (Status != OrderStatus.Pending)
+            throw new InvalidOperationException("Only pending orders can be processed.");
+        Status = OrderStatus.Processing;
+    }
+}
+```
+
+```csharp
+// MyApp.Infrastructure/Data/OrderRepository.cs
+public class OrderRepository : IOrderRepository
+{
+    private readonly AppDbContext _context;
+    public OrderRepository(AppDbContext context) => _context = context;
+
+    public Task<Order?> GetByIdAsync(int id) =>
+        _context.Orders.FirstOrDefaultAsync(o => o.Id == id);
+
+    public async Task AddAsync(Order order) => await _context.Orders.AddAsync(order);
+}
+```
+
+```csharp
+// MyApp.UseCases/Orders/ProcessOrderHandler.cs
+public class ProcessOrderHandler(IOrderRepository repository)
+    : IRequestHandler<ProcessOrderCommand, Order>
+{
+    public async Task<Order> Handle(ProcessOrderCommand request, CancellationToken ct)
+    {
+        var order = await repository.GetByIdAsync(request.OrderId)
+            ?? throw new OrderNotFoundException(request.OrderId);
+
+        order.MarkAsProcessing();
+        return order;
+    }
+}
+```
+
+### Wiring dependency injection in Program.cs
+
+This is where `Infrastructure`'s implementations get bound to `Core`'s interfaces - the one place in the solution where the concrete and the abstract meet:
+
+```csharp
+var builder = WebApplication.CreateBuilder(args);
+
+builder.Services.AddDbContext<AppDbContext>(options =>
+    options.UseSqlServer(builder.Configuration.GetConnectionString("Default")));
+
+builder.Services.AddScoped<IOrderRepository, OrderRepository>();
+builder.Services.AddMediatR(cfg => cfg.RegisterServicesFromAssembly(typeof(ProcessOrderHandler).Assembly));
+
+builder.Services.AddFastEndpoints();
+
+var app = builder.Build();
+app.UseFastEndpoints();
+app.Run();
+```
+
+### Enforce the rule with architecture tests, not just discipline
+
+Project references stop the most obvious violations, but a determined developer can still add a NuGet package reference to EF Core directly in `Core`. Add an architecture test to catch that automatically:
+
+```csharp
+[Fact]
+public void Core_Should_Not_Reference_Infrastructure()
+{
+    var result = Types.InAssembly(typeof(Order).Assembly)
+        .Should()
+        .NotHaveDependencyOn("MyApp.Infrastructure")
+        .GetResult();
+
+    Assert.True(result.IsSuccessful);
+}
+```
+
+Using a library like `NetArchTest` or `ArchUnitNET` turns the dependency rule from an aspiration into something your build fails on if violated.
+
+## Core Workflow
+
+Adding a feature typically means:
+
+1. **Core** - add or update entities and domain interfaces if the feature introduces new business rules
+2. **UseCases** - add a command or query and its handler, containing the application-specific orchestration logic
+3. **Infrastructure** - implement any new repository or external service interfaces the use case depends on
+4. **Web** - add the endpoint that maps an HTTP request to the command/query and returns the result
+
+More ceremony than layered architecture for a simple feature, but the payoff is that `Core` and `UseCases` stay testable and infrastructure-agnostic no matter how the surrounding technology changes.
+
+## Verifying Your Setup
+
+1. **`Core` has zero external dependencies** - check its `.csproj`; it should reference nothing beyond the .NET base class libraries
+2. **Architecture tests pass** - confirm a `NetArchTest`/`ArchUnitNET` suite actively fails if `Core` gains a dependency on `Infrastructure`
+3. **Domain logic is testable without a database** - unit test `Order.MarkAsProcessing()` with no `DbContext`, no mocks, nothing but the entity itself
+4. **Swapping infrastructure doesn't touch Core or UseCases** - as a sanity check, imagine replacing EF Core with Dapper; confirm that change is contained entirely to `Infrastructure`
+
+## Best Practices
+
+**Keep `Core` genuinely dependency-free.** The instant it references EF Core "just for this one convenience," the isolation that makes the domain testable and infrastructure-agnostic starts eroding.
+
+**Back the dependency rule with automated architecture tests.** Code review catches most violations, but a failing build catches all of them, consistently, without relying on a reviewer noticing.
+
+**Don't over-apply the pattern to trivial CRUD.** A simple, rules-free create/read/update/delete endpoint doesn't need four layers and a MediatR handler - Clean Architecture earns its ceremony specifically where there's real business logic to protect.
+
+**Use the Specification pattern for complex queries instead of leaking IQueryable into UseCases.** Keeping query logic behind named, testable specifications avoids `Core`/`UseCases` depending on EF Core's query surface directly.
+
+**Start from a proven template rather than inventing conventions from scratch.** The Ardalis Clean Architecture template encodes a lot of hard-won structure decisions - deviate deliberately once you understand why the defaults exist, not before.
+
+## Comparison with Vertical Slice Architecture
+
+| Dimension | Clean Architecture | Vertical Slice Architecture |
+| --- | --- | --- |
+| Organizing principle | Dependency direction, domain-centered | Feature/use case |
+| Where related code for one feature lives | Spread across Core, UseCases, Infrastructure, Web | Co-located in one slice |
+| Ceremony for a simple feature | Higher - touches multiple projects even for CRUD | Lower - one slice, start to finish |
+| Domain protection from infrastructure | Enforced by the dependency rule | Not enforced by default; added deliberately if needed |
+| Best fit | Domain-heavy apps with real business rules worth insulating | Feature-heavy apps with largely independent use cases |
+
+The two aren't opposites - a single project can use Vertical Slice Architecture for organizing features while still applying Clean Architecture's dependency rule inside slices that touch genuinely complex domain logic. Many teams land on a pragmatic middle ground rather than picking one pattern dogmatically for the whole codebase.
+
+## Frequently Asked Questions
+
+### What's the difference between Clean, Onion, and Hexagonal architecture?
+
+They're variations on the same core idea - dependencies point inward toward the domain, and infrastructure is a detail plugged in at the edges via interfaces. The naming differences largely reflect different authors' framing (Onion emphasizes concentric layers, Hexagonal/Ports-and-Adapters emphasizes swappable adapters) rather than fundamentally different rules. In .NET, "Clean Architecture" is the most common label, largely due to Robert Martin's writing and Steve Smith's widely used template.
+
+### Do I need MediatR to do Clean Architecture in .NET?
+
+No, MediatR is a common convenience for structuring the UseCases layer as discrete command/query handlers, but it's not required by the pattern itself. You can implement use cases as plain service classes with interfaces - MediatR just standardizes the shape and adds convenient cross-cutting behavior (logging, validation) via its pipeline.
+
+### Why does my Core project need interfaces if Infrastructure implements them?
+
+This is the dependency inversion at the heart of the pattern: `Core` defines what it needs (`IOrderRepository`) without knowing how it's fulfilled, and `Infrastructure` provides the implementation. This means `Core` can be compiled, tested, and reasoned about without `Infrastructure` existing at all - the dependency points from `Infrastructure` toward `Core`'s interface, not the other way around.
+
+### Is Clean Architecture overkill for a small project?
+
+Often, yes. The ceremony pays for itself when there's real business complexity worth protecting from infrastructure churn. A small CRUD app with minimal business rules will likely feel over-engineered under Clean Architecture - layered architecture or Vertical Slice Architecture will get you there with less overhead.
+
+### How do I actually enforce the dependency rule, not just hope for it?
+
+Project references catch the obvious violations (a class library can't reference a project that doesn't reference it back), but architecture tests using `NetArchTest` or `ArchUnitNET` catch the subtler ones, like a stray NuGet package reference. Make the architecture test part of your CI build so a violation fails the pipeline, not just a code review.
+
+### Can Clean Architecture work with Vertical Slice Architecture in the same solution?
+
+Yes - this is a common and pragmatic combination. Organize the UseCases layer around features (vertical slices) while still respecting the Core/Infrastructure dependency rule underneath. You get feature-oriented navigation and enforced domain isolation at the same time, at the cost of needing to actively decide how each new piece of code should be organized rather than following one rigid convention everywhere.
+
+### What goes in Core versus UseCases?
+
+`Core` holds domain entities, value objects, domain interfaces, and business rules intrinsic to the entities themselves (like an `Order` refusing an invalid state transition). `UseCases` holds application-specific orchestration - the steps a particular command or query needs to take, which repositories to call, and in what order - without containing infrastructure details itself.

--- a/src/posts/2026-10-13-getting-started-with-layered-architecture-dotnet.md
+++ b/src/posts/2026-10-13-getting-started-with-layered-architecture-dotnet.md
@@ -1,0 +1,195 @@
+---
+author: Steve Kaschimer
+date: 2026-10-13
+image: /images/posts/2026-10-13-hero.webp
+image_alt: "Three stacked horizontal bars labeled Web, Business, and Data Access, with one-way downward arrows between them and a small blocked icon on an arrow pointing back upward."
+image_prompt: "A dark-mode technical editorial illustration on a near-black background with electric teal, amber, and off-white accents. Composition is three horizontal bars of equal width stacked vertically with small gaps between them, rendered as thin off-white outlined rectangles. A teal downward arrow connects the top bar to the middle bar, and another connects the middle bar to the bottom bar. Below the bottom bar, a faint amber arrow attempts to curve back upward toward the top bar but is intercepted by a small 'no entry' style circle-and-line icon. Faint monospaced micro-labels sit inside each bar at reduced opacity, too small to read as real text. Mood is orderly, conventional, and a little retro-technical. Avoid: vendor logos, brand colors, circuit-board textures, gears, or generic office building imagery."
+layout: post.njk
+site_title: Tech Notes
+summary: "Layered architecture still runs a huge share of production .NET, and for genuinely CRUD-shaped apps that's the right call. A setup guide for keeping the dependency direction honest as the codebase grows."
+tags: ["dotnet", "architecture", "testing", "developer-productivity"]
+title: "Getting Started with Layered (N-Tier) Architecture in .NET"
+---
+
+Layered architecture doesn't get much attention in architecture talks anymore, but it's still how a huge share of production .NET applications are actually built - and for genuinely simple, CRUD-shaped applications, that's the right call, not a compromise. The mistake isn't using layered architecture; it's using it past the point where it stops fitting the problem.
+
+This guide covers setting up a layered .NET solution from scratch, bootstrapping the project structure so layers stay honest about their boundaries, the core workflow of adding a feature, and the best practices that keep a layered codebase from decaying into a tangled mess as it grows. By the end you'll have a clean, conventional starting point - and a clear sense of when to reach for something else instead.
+
+If you're deciding between architecture styles first, [a comparison of the top .NET architecture patterns](/posts/2026-09-29-top-5-dotnet-architecture-patterns-compared/) covers where layered architecture fits relative to Clean Architecture, Vertical Slice, Modular Monolith, and Microservices.
+
+## What You'll Need
+
+- .NET 8 SDK or later
+- A relational database (SQL Server, PostgreSQL, or SQLite for local development)
+- No third-party architecture packages required - this pattern uses only the .NET SDK and EF Core
+
+## Installing and Scaffolding
+
+Layered architecture needs no special tooling - it's a project structure convention, not a library. Create a solution with one project per layer:
+
+```bash
+mkdir MyApp && cd MyApp
+dotnet new sln
+
+dotnet new webapi -n MyApp.Web
+dotnet new classlib -n MyApp.Business
+dotnet new classlib -n MyApp.DataAccess
+
+dotnet sln add MyApp.Web MyApp.Business MyApp.DataAccess
+
+dotnet add MyApp.Web reference MyApp.Business
+dotnet add MyApp.Business reference MyApp.DataAccess
+```
+
+Add EF Core to the data access layer:
+
+```bash
+dotnet add MyApp.DataAccess package Microsoft.EntityFrameworkCore.SqlServer
+dotnet add MyApp.DataAccess package Microsoft.EntityFrameworkCore.Design
+```
+
+## Bootstrapping the Ideal Environment
+
+The whole value of layered architecture depends on the dependency direction actually being enforced - Web depends on Business, Business depends on DataAccess, and nothing points backward. Project references are what make that a compile error rather than a convention people can accidentally violate.
+
+### Structuring each layer
+
+```
+MyApp.Web/         -> Controllers, DTOs, Program.cs
+MyApp.Business/    -> Services, business rules, validation
+MyApp.DataAccess/  -> DbContext, entities, repositories
+```
+
+A typical data access layer:
+
+```csharp
+// MyApp.DataAccess/AppDbContext.cs
+public class AppDbContext : DbContext
+{
+    public AppDbContext(DbContextOptions<AppDbContext> options) : base(options) { }
+    public DbSet<Order> Orders => Set<Order>();
+}
+
+// MyApp.DataAccess/OrderRepository.cs
+public class OrderRepository
+{
+    private readonly AppDbContext _context;
+    public OrderRepository(AppDbContext context) => _context = context;
+
+    public Task<Order?> GetByIdAsync(int id) =>
+        _context.Orders.FirstOrDefaultAsync(o => o.Id == id);
+}
+```
+
+A business layer that depends only on the data access layer, never on ASP.NET Core types:
+
+```csharp
+// MyApp.Business/OrderService.cs
+public class OrderService
+{
+    private readonly OrderRepository _repository;
+    public OrderService(OrderRepository repository) => _repository = repository;
+
+    public async Task<Order> ProcessOrderAsync(int orderId)
+    {
+        var order = await _repository.GetByIdAsync(orderId)
+            ?? throw new OrderNotFoundException(orderId);
+
+        order.Status = OrderStatus.Processing;
+        return order;
+    }
+}
+```
+
+### Wiring it together in Program.cs
+
+```csharp
+var builder = WebApplication.CreateBuilder(args);
+
+builder.Services.AddDbContext<AppDbContext>(options =>
+    options.UseSqlServer(builder.Configuration.GetConnectionString("Default")));
+
+builder.Services.AddScoped<OrderRepository>();
+builder.Services.AddScoped<OrderService>();
+
+builder.Services.AddControllers();
+
+var app = builder.Build();
+app.MapControllers();
+app.Run();
+```
+
+### Keep the dependency direction honest
+
+The single most important discipline in layered architecture: never let the data access layer reference the business layer, and never let the business layer reference ASP.NET Core packages. If `MyApp.Business` needs an `IHttpContextAccessor` or an ASP.NET-specific type, that's a sign logic that belongs in the Web layer has crept into Business.
+
+## Core Workflow
+
+Adding a feature in layered architecture typically touches every layer, in order:
+
+1. **Data access** - add or update the entity and repository method needed
+2. **Business** - add the service method implementing the business rule, calling the repository
+3. **Web** - add the controller action or endpoint, mapping requests to the business layer and responses back
+
+This is layered architecture's defining trade-off: consistent, predictable structure for every feature, at the cost of touching multiple projects even for a small change.
+
+## Verifying Your Setup
+
+1. **Dependency direction holds** - confirm `MyApp.DataAccess` has no project reference to `MyApp.Business` or `MyApp.Web`
+2. **Business logic is testable in isolation** - write a unit test for `OrderService` using an in-memory or mocked repository, without spinning up ASP.NET Core
+3. **The business layer has no framework dependencies** - check that `MyApp.Business.csproj` doesn't reference `Microsoft.AspNetCore.App`
+4. **Migrations apply cleanly** - run `dotnet ef database update` from the Web project and confirm the schema matches your entities
+
+## Best Practices
+
+**Enforce the dependency direction with project references, not convention.** If a layer can physically reference another layer it shouldn't, eventually it will.
+
+**Keep DTOs separate from entities.** Returning EF Core entities directly from controllers couples your API contract to your database schema - map to dedicated request/response models in the Web layer instead.
+
+**Don't let the business layer become a dumping ground.** As an app grows, resist the urge to keep adding unrelated logic to one large service class - split by responsibility even within the business layer, well before you're forced to.
+
+**Use interfaces for repositories if you expect to unit test business logic.** `IOrderRepository` behind `OrderRepository` costs little and makes mocking data access in tests straightforward.
+
+**Recognize when you've outgrown this pattern.** If most changes still require touching three layers for a single feature, and the codebase has passed a certain size, that friction is a real signal to consider Vertical Slice Architecture or a Modular Monolith rather than adding more structure inside the same three layers.
+
+## Comparison with Clean Architecture
+
+| Dimension | Layered (N-Tier) | Clean Architecture |
+| --- | --- | --- |
+| Organizing principle | Technical layer | Dependency direction, domain-centered |
+| Ceremony | Minimal | Moderate - more interfaces and abstraction |
+| Testability of business logic | Good, if discipline is maintained | Strong by design - the domain has zero infrastructure dependencies |
+| Familiarity | Highest - most developers already know this shape | Requires understanding dependency inversion |
+| Best fit | Small, CRUD-shaped applications | Domain-heavy applications worth protecting from infrastructure churn |
+
+Layered architecture is Clean Architecture's simpler cousin - both separate concerns, but Clean Architecture adds an explicit rule about dependency direction (everything points inward toward the domain) that layered architecture doesn't enforce as strictly, trading some ceremony for stronger guarantees about testability and infrastructure independence.
+
+## Frequently Asked Questions
+
+### Is layered architecture outdated?
+
+No - it's simply the right amount of structure for a certain class of problem: small applications, CRUD-heavy tools, and projects where the team's familiarity with the pattern outweighs the benefits of something more elaborate. It becomes a poor fit specifically when an application's complexity outgrows what three technical layers can cleanly express.
+
+### Why does my business layer need its own project instead of just a folder?
+
+A separate project makes the dependency direction a compile-time guarantee rather than a convention. A folder inside the Web project can still accidentally reference ASP.NET Core types; a separate class library physically cannot unless you add that reference deliberately.
+
+### Should repositories return entities or DTOs?
+
+Repositories typically return entities - that's the data access layer's natural vocabulary. The mapping to DTOs happens in the Web layer (or business layer, if the business logic needs a different shape), so your API contract doesn't leak database schema details directly to clients.
+
+### How do I unit test the business layer without a real database?
+
+Depend on repository interfaces rather than concrete `DbContext`-backed classes, and mock or stub them in tests. This is the main reason to introduce an `IOrderRepository` abstraction even in a straightforward layered setup - it keeps business logic testable without spinning up a database.
+
+### When should I move from layered architecture to something else?
+
+When most feature changes require touching every layer just to ship one piece of functionality, and that friction is measurably slowing the team down, it's worth evaluating Vertical Slice Architecture (which organizes by feature instead) or a Modular Monolith (which introduces boundaries layered architecture doesn't have). Neither is strictly better - they solve the specific pain layered architecture starts to cause once an app grows past a certain size.
+
+### Can I mix layered architecture with CQRS?
+
+Yes, though it's less natural than pairing CQRS with Vertical Slice Architecture. You can still split read and write paths within the business layer, but you'll likely find the layered structure fighting the feature-oriented nature of CQRS handlers - if you're reaching for CQRS deliberately, it's worth evaluating whether Vertical Slice Architecture would fit better from the start.
+
+### Does layered architecture prevent the "big ball of mud" problem?
+
+Not automatically. Layered architecture separates *technical* concerns but does nothing to prevent unrelated business logic from accumulating in a single business layer over time. Preventing that requires the same kind of deliberate internal organization (splitting services by responsibility) that any architecture needs as it grows.

--- a/src/posts/2026-10-20-getting-started-with-vertical-slice-architecture-dotnet.md
+++ b/src/posts/2026-10-20-getting-started-with-vertical-slice-architecture-dotnet.md
@@ -1,0 +1,215 @@
+---
+author: Steve Kaschimer
+date: 2026-10-20
+image: /images/posts/2026-10-20-hero.webp
+image_alt: "A single bordered vertical card containing four small stacked icons for an endpoint, a command, a handler, and a validator, set apart from a row of unrelated separate cards."
+image_prompt: "A dark-mode technical editorial illustration on a near-black background with electric teal, amber, and off-white accents. Composition centers on a single tall, narrow card with a thin off-white border, containing four small stacked glyphs in a vertical column: an arrow-into-box icon (endpoint), a small envelope icon (command), a gear-in-brackets icon (handler), and a checkmark-shield icon (validator), each in teal. To the right, three shorter, unrelated flat cards sit at reduced opacity, each with just one icon, implying separate, disconnected features. A faint amber outline briefly traces the entire tall card as if to say 'self-contained.' Mood is focused, contained, and modular. Avoid: vendor logos, brand colors, circuit-board textures, gears used as a dominant motif, or literal folder-icon clip art."
+layout: post.njk
+site_title: Tech Notes
+summary: "Vertical Slice Architecture puts everything a single request needs in one place. A setup guide for structuring slices, wiring cross-cutting concerns through a pipeline, and keeping the pattern from turning into duplicated chaos."
+tags: ["dotnet", "architecture", "developer-productivity", "tooling"]
+title: "Getting Started with Vertical Slice Architecture in .NET"
+---
+
+Vertical Slice Architecture starts from a different question than most patterns in this series. Instead of asking "how should we separate technical concerns," it asks "what does this specific request actually need" - and then puts the endpoint, validation, business logic, and data access for that one feature in the same place, rather than spreading it across layers that exist purely for technical tidiness.
+
+This guide covers setting up a Vertical Slice solution in .NET, bootstrapping the folder structure and libraries that make slices genuinely self-contained, the core workflow of adding a feature, and the best practices that keep slices from drifting into duplicated chaos as the codebase grows. By the end you'll have a structure where adding a feature means adding a slice, not touching four existing files.
+
+If you're deciding between architecture styles first, [a comparison of the top .NET architecture patterns](/posts/2026-09-29-top-5-dotnet-architecture-patterns-compared/) covers where Vertical Slice Architecture fits relative to layered architecture, Clean Architecture, Modular Monolith, and Microservices.
+
+## What You'll Need
+
+- .NET 8 SDK or later
+- A relational database (SQL Server, PostgreSQL, or SQLite for local development)
+- Comfort with CQRS-style thinking - commands and queries as discrete, self-contained units are the natural shape of a slice
+
+## Installing and Scaffolding
+
+Vertical Slice Architecture is a folder and code organization convention more than a specific library, but two packages make it dramatically easier to implement cleanly in .NET: MediatR for wiring requests to handlers, and FastEndpoints (or minimal APIs) for lightweight endpoint definitions.
+
+```bash
+dotnet new webapi -n MyApp
+cd MyApp
+
+dotnet add package MediatR
+dotnet add package FastEndpoints
+dotnet add package Microsoft.EntityFrameworkCore.SqlServer
+dotnet add package FluentValidation
+```
+
+Unlike Clean Architecture, Vertical Slice Architecture typically lives in a single project rather than being split across multiple class libraries - the organization happens at the folder level, by feature, not at the project level, by technical concern.
+
+## Bootstrapping the Ideal Environment
+
+The whole pattern lives or dies on folder structure. Instead of `Controllers/`, `Services/`, and `Repositories/` folders, organize by feature:
+
+```
+Features/
+  Orders/
+    CreateOrder/
+      CreateOrderEndpoint.cs
+      CreateOrderCommand.cs
+      CreateOrderHandler.cs
+      CreateOrderValidator.cs
+    ProcessOrder/
+      ProcessOrderEndpoint.cs
+      ProcessOrderCommand.cs
+      ProcessOrderHandler.cs
+    GetOrderById/
+      GetOrderByIdEndpoint.cs
+      GetOrderByIdQuery.cs
+      GetOrderByIdHandler.cs
+```
+
+### A complete slice, start to finish
+
+```csharp
+// Features/Orders/ProcessOrder/ProcessOrderCommand.cs
+public record ProcessOrderCommand(int OrderId) : IRequest<ProcessOrderResult>;
+
+public record ProcessOrderResult(int OrderId, string Status);
+```
+
+```csharp
+// Features/Orders/ProcessOrder/ProcessOrderHandler.cs
+public class ProcessOrderHandler(AppDbContext db) : IRequestHandler<ProcessOrderCommand, ProcessOrderResult>
+{
+    public async Task<ProcessOrderResult> Handle(ProcessOrderCommand request, CancellationToken ct)
+    {
+        var order = await db.Orders.FindAsync([request.OrderId], ct)
+            ?? throw new OrderNotFoundException(request.OrderId);
+
+        order.Status = OrderStatus.Processing;
+        await db.SaveChangesAsync(ct);
+
+        return new ProcessOrderResult(order.Id, order.Status.ToString());
+    }
+}
+```
+
+```csharp
+// Features/Orders/ProcessOrder/ProcessOrderEndpoint.cs
+public class ProcessOrderEndpoint(IMediator mediator) : Endpoint<ProcessOrderCommand, ProcessOrderResult>
+{
+    public override void Configure()
+    {
+        Post("/orders/{OrderId}/process");
+    }
+
+    public override async Task HandleAsync(ProcessOrderCommand req, CancellationToken ct)
+    {
+        var result = await mediator.Send(req, ct);
+        await SendAsync(result, cancellation: ct);
+    }
+}
+```
+
+Everything this feature needs - request shape, validation (if added via a `ProcessOrderValidator : AbstractValidator<ProcessOrderCommand>`), business logic, and data access - lives in one folder. Removing the feature means deleting one folder, not hunting across a controller, a service, and a repository.
+
+### Wiring it up in Program.cs
+
+```csharp
+var builder = WebApplication.CreateBuilder(args);
+
+builder.Services.AddDbContext<AppDbContext>(options =>
+    options.UseSqlServer(builder.Configuration.GetConnectionString("Default")));
+
+builder.Services.AddMediatR(cfg => cfg.RegisterServicesFromAssembly(typeof(Program).Assembly));
+builder.Services.AddValidatorsFromAssembly(typeof(Program).Assembly);
+builder.Services.AddFastEndpoints();
+
+var app = builder.Build();
+app.UseFastEndpoints();
+app.Run();
+```
+
+### Handle cross-cutting concerns with a MediatR pipeline, not copy-paste
+
+Validation, logging, and transaction handling shouldn't be re-implemented in every handler. A MediatR pipeline behavior applies them once, across every slice:
+
+```csharp
+public class ValidationBehavior<TRequest, TResponse>(IValidator<TRequest>? validator)
+    : IPipelineBehavior<TRequest, TResponse> where TRequest : IRequest<TResponse>
+{
+    public async Task<TResponse> Handle(
+        TRequest request, RequestHandlerDelegate<TResponse> next, CancellationToken ct)
+    {
+        if (validator is not null)
+        {
+            var result = await validator.ValidateAsync(request, ct);
+            if (!result.IsValid) throw new ValidationException(result.Errors);
+        }
+        return await next();
+    }
+}
+```
+
+## Core Workflow
+
+Adding a feature is deliberately simple:
+
+1. Create a new folder under `Features/<Area>/<FeatureName>/`
+2. Add the command or query, its handler, the endpoint, and a validator if needed
+3. Register nothing extra - MediatR and FastEndpoints discover handlers and endpoints via assembly scanning
+
+Removing or changing a feature is just as contained: touch one folder, and confirm nothing else referenced its internals (nothing should, if the slice was kept properly self-contained).
+
+## Verifying Your Setup
+
+1. **A feature lives in one folder** - pick any slice and confirm you don't need to open files outside its folder to understand it end-to-end
+2. **Cross-cutting concerns apply automatically** - confirm validation errors from `FluentValidation` are caught by the pipeline behavior without each handler calling the validator manually
+3. **Deleting a slice is clean** - as a test, delete a feature folder and confirm nothing elsewhere in the codebase breaks
+4. **Shared logic is deliberately extracted, not duplicated** - if two slices need the same calculation, confirm it lives in a shared, named location rather than being copy-pasted
+
+## Best Practices
+
+**Resist extracting shared abstractions too early.** A little duplication between two slices is often cheaper than a shared abstraction that has to flex to fit both - extract only once a real, stable pattern emerges across three or more slices.
+
+**Use a MediatR pipeline for cross-cutting concerns, not per-handler boilerplate.** Validation, logging, and transaction wrapping belong in pipeline behaviors, applied uniformly, not copy-pasted into every handler.
+
+**Don't feel obligated to abstract data access behind a repository inside every slice.** Talking to `DbContext` directly from a handler is often fine in Vertical Slice Architecture - add an abstraction only where a specific slice actually needs one (for testing, for swapping implementations), not as a blanket rule.
+
+**Keep slices focused on one use case.** A "slice" that handles create, update, and delete for an entity in one file has drifted back toward CRUD-service thinking - one command or query per slice keeps the isolation real.
+
+**Extract genuinely shared domain logic into a clearly named shared location.** When logic is truly common across many features (a domain entity's own business rules, for instance), a small shared folder is appropriate - the goal is avoiding unnecessary structure, not avoiding all structure.
+
+## Comparison with Modular Monolith
+
+| Dimension | Vertical Slice Architecture | Modular Monolith |
+| --- | --- | --- |
+| Unit of organization | Feature / use case | Business capability module |
+| Typical scope | Within a single project | Across multiple modules, each potentially its own project |
+| Boundary enforcement | Convention - folders, not compiler-enforced | Often compiler-enforced via project references |
+| Best fit | Feature-heavy apps with largely independent use cases | Growing systems needing macro-level boundaries between domains |
+
+These aren't competing choices so much as different altitudes - a Modular Monolith answers "how do we split the system into modules," while Vertical Slice Architecture answers "how do we organize code within one of those modules." Many well-structured modular monoliths use Vertical Slice Architecture inside each module.
+
+## Frequently Asked Questions
+
+### Does Vertical Slice Architecture mean no shared code at all?
+
+No - it means shared code should be a deliberate, named extraction rather than a default layer everything routes through. Domain entities, truly common validation rules, and genuinely reusable infrastructure code still belong in shared locations; the difference is that sharing is opt-in per case, not the default structure.
+
+### Do I need MediatR to do Vertical Slice Architecture?
+
+No, but it's a strong fit. MediatR gives each slice a consistent shape (a request, a handler) and a pipeline for cross-cutting concerns, which is most of what makes slices easy to keep consistent across a codebase. You can implement the same organizing principle with plain classes and manual DI registration if you'd rather avoid the dependency.
+
+### How is this different from just putting everything in one big controller?
+
+The key difference is isolation, not co-location for its own sake. A slice groups the request, validation, business logic, and data access for one specific use case - it doesn't mean cramming unrelated features into a single class. Each slice remains narrowly scoped to one command or query.
+
+### Won't I end up duplicating a lot of logic across slices?
+
+Some duplication is expected and often fine - it's cheaper than a shared abstraction that has to compromise to fit multiple use cases. Duplication becomes a real problem only when the same non-trivial logic starts drifting out of sync across slices; that's the signal to extract it deliberately, not a reason to avoid the pattern.
+
+### Can Vertical Slice Architecture scale to a large codebase?
+
+Yes, particularly when paired with a Modular Monolith's module boundaries at the macro level - Vertical Slice Architecture organizes within a module, while the module boundary handles isolation between larger business capabilities. Without that outer structure, a very large number of slices in one flat `Features/` folder can become its own kind of unwieldy, so consider grouping slices by area as the feature count grows.
+
+### Does Vertical Slice Architecture protect the domain from infrastructure the way Clean Architecture does?
+
+Not by default. A slice is free to call `DbContext` directly, which is convenient but doesn't give you the same infrastructure-independence guarantee Clean Architecture's dependency rule provides. If a specific slice has domain logic worth protecting, you can apply that discipline deliberately within the slice - the two patterns compose rather than conflict.
+
+### What's the biggest mistake teams make adopting Vertical Slice Architecture?
+
+Treating "organize by feature" as "duplicate everything with no shared structure," which produces its own kind of mess - inconsistent validation, inconsistent error handling, and cross-cutting concerns re-implemented slightly differently in every slice. A shared pipeline for validation, logging, and error handling is what keeps many independent slices feeling like one coherent application.

--- a/src/posts/2026-10-27-getting-started-with-modular-monolith-dotnet.md
+++ b/src/posts/2026-10-27-getting-started-with-modular-monolith-dotnet.md
@@ -1,0 +1,207 @@
+---
+author: Steve Kaschimer
+date: 2026-10-27
+image: /images/posts/2026-10-27-hero.webp
+image_alt: "A grid of bordered boxes representing modules, each with a small padlock on its interior and a single narrow doorway line labeled Contracts connecting adjacent boxes."
+image_prompt: "A dark-mode technical editorial illustration on a near-black background with electric teal, amber, and off-white accents. Composition is a 2x2 grid of bordered rectangular boxes (modules), each with a small amber padlock icon near its center representing internal, protected content. Between adjacent boxes, a single thin teal line with a small doorway/gate glyph connects them at one narrow point only, labeled implicitly as a crossing point rather than an open wall. One box in the grid has a faint red crack running partway across its border, suggesting a boundary under strain. Mood is orderly but watchful - structure that requires upkeep. Avoid: vendor logos, brand colors, circuit-board textures, gears, or literal brick-wall imagery."
+layout: post.njk
+site_title: Tech Notes
+summary: "A Modular Monolith is deceptively easy to describe and genuinely hard to keep honest. A setup guide for making module boundaries a compiler-enforced guarantee instead of an aspiration that erodes under deadline pressure."
+tags: ["dotnet", "architecture", "microservices", "platform-engineering", "ci-cd"]
+title: "Getting Started with Modular Monolith Architecture in .NET"
+---
+
+A Modular Monolith is deceptively easy to describe and genuinely hard to keep honest: one deployable application, internally split into modules that behave almost like separate services - owning their own data, exposing narrow public interfaces, and never reaching directly into each other's internals. The description sounds like good hygiene any codebase should have. The hard part is that nothing forces it to stay true except deliberate enforcement, and the moment that enforcement lapses, it's just a monolith again.
+
+This guide covers structuring a Modular Monolith solution in .NET, bootstrapping module boundaries so they're compiler-enforced rather than aspirational, the core workflow of adding a feature within the right module, and the best practices that keep boundaries intact as the system and team grow. By the end you'll have a structure that gets most of the benefit people associate with Microservices, without the operational cost.
+
+If you're deciding between architecture styles first, [a comparison of the top .NET architecture patterns](/posts/2026-09-29-top-5-dotnet-architecture-patterns-compared/) covers where Modular Monolith fits relative to layered architecture, Clean Architecture, Vertical Slice, and Microservices.
+
+## What You'll Need
+
+- .NET 8 SDK or later
+- A relational database - modules can share a database with separate schemas, or use fully separate databases, depending on how strict you want isolation to be
+- A library like `NetArchTest` or `ArchUnitNET` for enforcing boundaries automatically in CI
+
+## Installing and Scaffolding
+
+There's no special package that makes a solution a Modular Monolith - the pattern lives entirely in how you structure projects and enforce references between them. Start with one project per module, plus a thin host:
+
+```bash
+dotnet new sln -n MyApp
+
+dotnet new webapi -n MyApp.Host
+
+dotnet new classlib -n MyApp.Modules.Orders
+dotnet new classlib -n MyApp.Modules.Orders.Contracts
+
+dotnet new classlib -n MyApp.Modules.Inventory
+dotnet new classlib -n MyApp.Modules.Inventory.Contracts
+
+dotnet sln add MyApp.Host MyApp.Modules.Orders MyApp.Modules.Orders.Contracts MyApp.Modules.Inventory MyApp.Modules.Inventory.Contracts
+
+dotnet add MyApp.Host reference MyApp.Modules.Orders MyApp.Modules.Inventory
+
+# Modules depend on each other's Contracts projects only -- never on each other's implementation
+dotnet add MyApp.Modules.Orders reference MyApp.Modules.Inventory.Contracts
+```
+
+Note what's missing: `MyApp.Modules.Orders` never gets a reference to `MyApp.Modules.Inventory` directly - only to its `Contracts` project. That asymmetry is the whole mechanism that keeps modules from reaching into each other's internals.
+
+## Bootstrapping the Ideal Environment
+
+Two decisions determine whether a Modular Monolith stays a Modular Monolith: how modules communicate, and how modules store data. Get both wrong and it quietly becomes a regular monolith with extra folders.
+
+### Contracts projects: the only thing modules can see of each other
+
+Each module exposes a `Contracts` project containing the interfaces, DTOs, and events other modules are allowed to depend on - nothing else:
+
+```csharp
+// MyApp.Modules.Inventory.Contracts/IInventoryService.cs
+public interface IInventoryService
+{
+    Task<bool> IsInStockAsync(string sku, int quantity);
+    Task ReserveAsync(string sku, int quantity);
+}
+```
+
+```csharp
+// MyApp.Modules.Inventory/InventoryService.cs
+internal class InventoryService(InventoryDbContext db) : IInventoryService
+{
+    // internal -- cannot be referenced directly from outside this module,
+    // only through the IInventoryService interface in Contracts
+    public async Task<bool> IsInStockAsync(string sku, int quantity) { /* ... */ return true; }
+    public Task ReserveAsync(string sku, int quantity) => Task.CompletedTask;
+}
+```
+
+Marking the implementation `internal` is what makes the boundary a compile-time guarantee - `MyApp.Modules.Orders` physically cannot instantiate `InventoryService` directly, only consume it through `IInventoryService`.
+
+### Each module owns its own data
+
+Give each module its own `DbContext`, scoped to only the tables it owns:
+
+```csharp
+// MyApp.Modules.Inventory/InventoryDbContext.cs
+internal class InventoryDbContext(DbContextOptions<InventoryDbContext> options) : DbContext(options)
+{
+    public DbSet<StockItem> StockItems => Set<StockItem>();
+}
+```
+
+Whether modules share one physical database with separate schemas, or use fully separate databases, is a deployment decision independent of the code-level boundary - both are legitimate, and many teams start with shared-database-separate-schema and split databases later only if a real need arises.
+
+### Registering each module's services from the host
+
+```csharp
+// MyApp.Modules.Orders/OrdersModule.cs
+public static class OrdersModule
+{
+    public static IServiceCollection AddOrdersModule(this IServiceCollection services, IConfiguration config)
+    {
+        services.AddDbContext<OrdersDbContext>(opts => opts.UseSqlServer(config.GetConnectionString("Orders")));
+        services.AddScoped<IOrderService, OrderService>();
+        return services;
+    }
+}
+```
+
+```csharp
+// MyApp.Host/Program.cs
+var builder = WebApplication.CreateBuilder(args);
+
+builder.Services.AddOrdersModule(builder.Configuration);
+builder.Services.AddInventoryModule(builder.Configuration);
+
+var app = builder.Build();
+app.Run();
+```
+
+Each module registers itself; the host stays thin, just composing modules rather than knowing their internals.
+
+### Enforce boundaries with architecture tests
+
+Project references stop the most obvious cross-module reach, but add an explicit test so a violation fails CI rather than waiting for code review to catch it:
+
+```csharp
+[Fact]
+public void Orders_Should_Only_Depend_On_Inventory_Contracts()
+{
+    var result = Types.InAssembly(typeof(OrdersModule).Assembly)
+        .That().ResideInNamespace("MyApp.Modules.Orders")
+        .ShouldNot().HaveDependencyOn("MyApp.Modules.Inventory")
+        .GetResult();
+
+    Assert.True(result.IsSuccessful);
+}
+```
+
+## Core Workflow
+
+Adding a feature starts with a question layered architecture and Vertical Slice Architecture don't ask: **which module owns this?** Once that's settled:
+
+1. Implement the feature entirely within that module - internally, it can use Clean Architecture, Vertical Slice Architecture, or whatever fits that module best
+2. If the feature needs data or behavior from another module, go through that module's `Contracts` interface - never its internals
+3. If two modules need to react to the same event (an order being placed, inventory needing to be reserved), consider an in-process event/message mechanism rather than a direct synchronous call, so modules stay loosely coupled
+
+## Verifying Your Setup
+
+1. **Cross-module references only touch Contracts projects** - audit each module's `.csproj` and confirm it never references another module's implementation project
+2. **Implementation types are `internal`, not `public`** - confirm a module's service classes can't be instantiated directly from outside the module
+3. **Architecture tests fail on a deliberate violation** - as a test, temporarily add a direct cross-module reference and confirm your CI build catches it
+4. **Each module's data is genuinely isolated** - confirm one module's `DbContext` has no `DbSet` for tables another module owns
+
+## Best Practices
+
+**Decide module boundaries around business capabilities, not technical layers.** "Orders" and "Inventory" are good module boundaries; "Controllers" and "Services" are not - that's just layered architecture with extra ceremony.
+
+**Make internals `internal`, not just conventionally private.** The compiler enforcing the boundary is worth far more than a naming convention or a comment saying "don't reach into this."
+
+**Automate boundary enforcement from day one.** A Modular Monolith with only code-review-enforced boundaries degrades within a few sprints under any real deadline pressure. Architecture tests in CI are what make the boundary durable.
+
+**Let each module choose its own internal architecture.** A complex module can use Clean Architecture internally; a simple one can use Vertical Slice Architecture or even plain layered code. The modular boundary is what protects the rest of the system - it doesn't need to dictate what happens inside.
+
+**Communicate between modules through contracts and events, not shared database queries.** A module querying another module's tables directly defeats the entire point of the boundary, even if it happens to work today.
+
+## Comparison with Microservices
+
+| Dimension | Modular Monolith | Microservices |
+| --- | --- | --- |
+| Deployment unit | One application | Many independently deployable services |
+| Module communication | In-process, through Contracts interfaces | Over the network (HTTP, messaging) |
+| Data isolation | Enforced by convention/DbContext scoping, physically co-located | Enforced by physical separation - each service owns its own database |
+| Operational overhead | Minimal - one thing to deploy, monitor, and scale | Significant - service discovery, distributed tracing, per-service pipelines |
+| Best fit | Systems needing internal boundaries without distributed complexity | Organizations needing independent team deployment and scaling |
+
+A Modular Monolith is often the more honest starting point for systems that might eventually need Microservices - module boundaries enforced in-process translate far more cleanly into service boundaries later than trying to retrofit boundaries into a tangled monolith after the fact.
+
+## Frequently Asked Questions
+
+### Should each module have its own database?
+
+It depends on how much isolation you need now versus how much migration flexibility you want later. Separate schemas in a shared database is a common starting point - simpler operationally, while still keeping each module's tables logically scoped to that module. Fully separate databases give stronger isolation and a more direct path to Microservices later, at the cost of more operational setup upfront.
+
+### How do modules communicate without breaking the boundary?
+
+Through each module's `Contracts` project - interfaces and DTOs specifically designed to be consumed externally. For scenarios where synchronous, direct calls create too much coupling (module A needs to know about an event in module B without calling it directly), an in-process event or messaging mechanism keeps modules reacting to each other without depending on each other's implementation details.
+
+### What stops a Modular Monolith from becoming a regular monolith over time?
+
+Automated enforcement - architecture tests that fail the build on a boundary violation, and implementation types marked `internal` so illegal cross-module references are compile errors, not just discouraged. Without both, boundaries erode under deadline pressure regardless of how clearly they were originally documented.
+
+### Can different modules use different architectures internally?
+
+Yes, and this is one of the pattern's real strengths. A module with complex domain logic can use Clean Architecture internally; a simpler module can use Vertical Slice Architecture or plain layered code. The modular boundary protects the rest of the system regardless of what's happening inside any one module.
+
+### Is a Modular Monolith just a stepping stone to Microservices?
+
+Not necessarily - it's a complete, legitimate architecture that many systems stay on indefinitely, because the organizational need that would justify Microservices' operational cost never actually materializes. That said, well-enforced module boundaries do make a later split into services meaningfully easier if that need does eventually show up.
+
+### How many modules is too many for a Modular Monolith?
+
+There's no fixed number - the practical limit is usually about whether your team can still reason about module boundaries and ownership clearly. If modules start needing to know a lot about each other's internals just to function, that's usually a sign the boundaries were drawn in the wrong place, not that the pattern has been outgrown.
+
+### Do I need message queues or an event bus for a Modular Monolith?
+
+Not necessarily. Because modules run in the same process, in-process event dispatching (a simple mediator or domain event pattern) is often enough to keep modules decoupled without introducing external messaging infrastructure. A real message broker becomes more relevant if you're anticipating splitting specific modules into separate services later.

--- a/src/posts/2026-11-03-getting-started-with-microservices-dotnet.md
+++ b/src/posts/2026-11-03-getting-started-with-microservices-dotnet.md
@@ -1,0 +1,191 @@
+---
+author: Steve Kaschimer
+date: 2026-11-03
+image: /images/posts/2026-11-03-hero.webp
+image_alt: "A loose cluster of separate connected nodes linked by thin network lines, with a small dashboard panel below showing traces spanning two of the nodes."
+image_prompt: "A dark-mode technical editorial illustration on a near-black background with electric teal, amber, and off-white accents. Composition is five small rounded-rectangle nodes scattered in a loose cluster, each an independent flat card outline, connected to two or three neighbors by thin teal lines representing network calls rather than in-process references. One connector line has a small amber warning triangle at its midpoint, implying a possible network failure point. Below the cluster, a small dashboard panel shows a horizontal trace bar spanning two nodes with tick marks, plus a tiny health-check dot beside each node. Mood is distributed, observant, and slightly more complex than the rest of the series' illustrations. Avoid: vendor logos, brand colors, circuit-board textures, gears, or literal cloud-shape icons."
+layout: post.njk
+site_title: Tech Notes
+summary: "Microservices solve an organizational problem most projects don't have yet. A setup guide using .NET Aspire for local orchestration, service discovery, and observability - and an honest look at what Aspire doesn't remove."
+tags: ["dotnet", "architecture", "microservices", "observability", "devops"]
+title: "Getting Started with Microservices Architecture in .NET"
+---
+
+Microservices solve a problem most projects don't have yet: independent teams needing to deploy, scale, and release parts of a system without blocking each other. When that problem is real, the pattern pays for itself. When it isn't, the same distributed-systems overhead - network calls where there used to be method calls, eventual consistency where there used to be a transaction - becomes pure cost with no corresponding benefit. .NET Aspire has made the local development side of this dramatically less painful than it used to be, but it doesn't change the fundamental trade-off.
+
+This guide covers scaffolding a microservices solution in .NET using Aspire, bootstrapping service-to-service communication and observability, the core workflow of adding or changing a service, and the best practices that keep a distributed system debuggable instead of chaotic. By the end you'll have a local development setup that mirrors production topology without requiring a full Kubernetes cluster on your laptop.
+
+If you're deciding between architecture styles first, [a comparison of the top .NET architecture patterns](/posts/2026-09-29-top-5-dotnet-architecture-patterns-compared/) covers where Microservices fit relative to layered architecture, Clean Architecture, Vertical Slice, and Modular Monolith - including why a Modular Monolith is often the more honest starting point.
+
+## What You'll Need
+
+- .NET 8 SDK or later (.NET Aspire requires .NET 8.0 or later)
+- Docker or Podman, since Aspire orchestrates containerized dependencies (databases, message brokers) locally
+- Visual Studio 2022+, VS Code with the C# Dev Kit, or the .NET CLI
+
+## Installing and Scaffolding
+
+.NET Aspire is the current standard tooling for building and running a multi-service .NET solution locally. Install the workload and scaffold a starter solution:
+
+```bash
+dotnet workload update
+dotnet new install Aspire.ProjectTemplates
+
+dotnet new aspire-starter -n MyApp
+cd MyApp
+```
+
+This generates an `AppHost` project (the orchestrator), a `ServiceDefaults` project (shared configuration), and starter service projects. To add services by hand instead:
+
+```bash
+dotnet new webapi -n MyApp.OrdersService
+dotnet new webapi -n MyApp.InventoryService
+dotnet new aspire-apphost -n MyApp.AppHost
+dotnet new aspire-servicedefaults -n MyApp.ServiceDefaults
+
+dotnet add MyApp.AppHost reference MyApp.OrdersService MyApp.InventoryService
+dotnet add MyApp.OrdersService reference MyApp.ServiceDefaults
+dotnet add MyApp.InventoryService reference MyApp.ServiceDefaults
+```
+
+## Bootstrapping the Ideal Environment
+
+The AppHost project is where the whole distributed system gets described in code - what services exist, what infrastructure they depend on, and how they discover each other.
+
+### Defining services and their dependencies in AppHost
+
+```csharp
+// MyApp.AppHost/Program.cs
+var builder = DistributedApplication.CreateBuilder(args);
+
+var ordersDb = builder.AddPostgres("orders-db").AddDatabase("orders");
+var inventoryDb = builder.AddPostgres("inventory-db").AddDatabase("inventory");
+
+var inventory = builder.AddProject<Projects.MyApp_InventoryService>("inventory")
+    .WithReference(inventoryDb);
+
+var orders = builder.AddProject<Projects.MyApp_OrdersService>("orders")
+    .WithReference(ordersDb)
+    .WithReference(inventory);   // service discovery -- no hardcoded URLs
+
+builder.Build().Run();
+```
+
+Running this single project brings up Postgres containers for each service, starts both APIs, wires service discovery between them, and opens a dashboard showing logs, traces, and health across the whole system - replacing what used to be a docker-compose file, manually managed connection strings, and separate terminal windows per service.
+
+```bash
+dotnet run --project MyApp.AppHost
+```
+
+### ServiceDefaults: shared configuration without shared code coupling
+
+Every service references `ServiceDefaults` for consistent health checks, OpenTelemetry, and resilience configuration, without services depending on each other's business logic:
+
+```csharp
+// MyApp.ServiceDefaults/Extensions.cs
+public static IHostApplicationBuilder AddServiceDefaults(this IHostApplicationBuilder builder)
+{
+    builder.ConfigureOpenTelemetry();
+    builder.AddDefaultHealthChecks();
+    builder.Services.AddServiceDiscovery();
+    builder.Services.ConfigureHttpClientDefaults(http => http.AddStandardResilienceHandler());
+    return builder;
+}
+```
+
+```csharp
+// MyApp.OrdersService/Program.cs
+var builder = WebApplication.CreateBuilder(args);
+builder.AddServiceDefaults();
+builder.AddNpgsqlDbContext<OrdersDbContext>("orders");
+
+var app = builder.Build();
+app.MapDefaultEndpoints(); // health checks, etc.
+app.Run();
+```
+
+### Calling another service through service discovery, not a hardcoded URL
+
+```csharp
+// MyApp.OrdersService -- calling the inventory service
+builder.Services.AddHttpClient<IInventoryClient, InventoryClient>(client =>
+{
+    client.BaseAddress = new("http://inventory"); // resolved via Aspire service discovery
+});
+```
+
+The `WithReference(inventory)` call in AppHost is what makes `http://inventory` resolvable - Aspire injects the actual address as configuration at run time, so nothing is hardcoded per environment.
+
+### AppHost is a development tool, not a production deployment target
+
+This is worth being explicit about: AppHost orchestrates local development and CI, but it never gets deployed itself. In production, each service runs as a standard container on whatever platform you use - Kubernetes, Azure Container Apps, AWS ECS - with Aspire's role limited to generating manifests or informing that deployment, not running the show at runtime.
+
+## Core Workflow
+
+Adding or changing a service looks different depending on scope:
+
+- **Changing one service's internal logic** - work entirely within that service's project; if it doesn't change its public API or events, no other service needs to know
+- **Adding a new service** - create the project, add it to AppHost with its dependencies declared via `WithReference`, and decide upfront whether it needs its own database
+- **Changing how two services communicate** - this is the highest-risk category; a change to a request/response contract or event schema needs coordination (often versioning) since the calling service can't be redeployed atomically with the one it calls
+
+## Verifying Your Setup
+
+1. **The AppHost dashboard shows every service healthy** - run the AppHost and confirm all services and their infrastructure dependencies report healthy status
+2. **Service discovery resolves correctly** - confirm a service can reach another by its Aspire-assigned name (`http://inventory`) without a hardcoded port or host
+3. **Traces span service boundaries** - make a request that touches two services and confirm the dashboard shows a single distributed trace across both, not two disconnected logs
+4. **Each service's data is genuinely isolated** - confirm one service's database credentials and connection string aren't accessible to another service
+
+## Best Practices
+
+**Don't adopt Microservices until you have the organizational problem they solve.** Independent team ownership and deployment cadence is the actual justification - if one team owns the whole system, a Modular Monolith usually serves better with far less overhead.
+
+**Version your service contracts deliberately.** Because services deploy independently, a breaking change to a request or event shape can't assume the consumer has already updated - plan for backward-compatible changes or explicit versioning.
+
+**Invest in observability from the start, not after the first production incident.** Aspire's dashboard is excellent locally, but production needs the same OpenTelemetry data flowing into a real observability platform - distributed tracing is not optional once you have more than one service.
+
+**Give each service its own database.** Sharing a database across services reintroduces the tight coupling Microservices are supposed to eliminate, even if the services themselves are deployed separately.
+
+**Design for failure explicitly.** A downstream service being slow or unavailable needs to be handled deliberately - retries, circuit breakers, timeouts - rather than assumed away. `ServiceDefaults`' standard resilience handler is a starting point, not a complete answer for every failure mode your system will actually encounter.
+
+## Comparison with Modular Monolith
+
+| Dimension | Microservices | Modular Monolith |
+| --- | --- | --- |
+| Deployment unit | Many independent services | One application |
+| Communication | Network calls (HTTP, messaging) | In-process, through Contracts interfaces |
+| Data isolation | Enforced by physical separation | Enforced by convention/DbContext scoping |
+| Failure modes | Network failures, partial outages, eventual consistency | Simpler - largely in-process failure modes |
+| Operational tooling | Aspire (dev), Kubernetes/Container Apps/ECS (prod), distributed tracing | Standard single-app deployment and monitoring |
+| Best fit | Multiple teams needing independent deployment and scaling | Systems needing internal boundaries without distributed complexity |
+
+Aspire genuinely closes the local-development gap between these two patterns - but it's worth being honest that Aspire only removes friction from *building and running* microservices locally; it doesn't remove the production-grade concerns (contract versioning, partial failure handling, distributed data consistency) that are the actual cost of the pattern.
+
+## Frequently Asked Questions
+
+### Do I need Kubernetes to build microservices in .NET?
+
+Not for local development - Aspire handles local orchestration without requiring Kubernetes on your machine. For production, you'll need some container orchestration platform (Kubernetes, Azure Container Apps, AWS ECS, or similar), but that's a production deployment decision separate from your local development setup.
+
+### Is .NET Aspire a production runtime?
+
+No. Aspire's AppHost orchestrates local development and CI - starting containers, wiring service discovery, providing a dashboard - but it is never deployed to production itself. In production, each service runs as a standard container on whatever platform your team uses.
+
+### How do services talk to each other without hardcoding URLs?
+
+Through Aspire's service discovery in local development - declaring `WithReference(otherService)` in AppHost makes that service resolvable by name, with the actual address injected as configuration. In production, the equivalent is typically handled by your container platform's own service discovery or a service mesh.
+
+### Should every microservice have its own database?
+
+Yes, as a strong default. Sharing a database across services undermines the independence Microservices are meant to provide - a schema change for one service can silently break another if they share tables. Independent databases per service, with communication happening through APIs or events rather than shared queries, keep the boundary real.
+
+### How do I handle a service being temporarily unavailable?
+
+Explicitly, not by assumption. Retries with backoff, circuit breakers, and sensible timeouts are the baseline - `ServiceDefaults`' standard resilience handler provides a starting point, but real production systems need to think through what a caller should do when a dependency is degraded, not just when it's fully down.
+
+### When is a Microservices architecture the wrong choice?
+
+When the organizational problem it solves - independent team deployment and scaling - doesn't actually exist yet. A single team building a system doesn't need the operational overhead of distributed services; a Modular Monolith delivers most of the internal-boundary benefit without the network calls, eventual consistency, and per-service infrastructure that Microservices require.
+
+### Can I start with a Modular Monolith and migrate specific modules to Microservices later?
+
+Yes, and this is often the lower-risk path. A Modular Monolith with well-enforced module boundaries - narrow public contracts, isolated data per module - translates naturally into service boundaries later. Migrating one module into its own service once a concrete scaling or ownership need appears is generally safer than architecting for distributed systems complexity from day one.


### PR DESCRIPTION
## Summary

Drafts the complete six-post .NET Architecture Patterns Tuesday track:

- **Top 5 .NET Architecture Patterns Compared: Which One Should You Choose?** (2026-09-29) - the anchor comparison post: a decision framework across Layered, Clean Architecture, Vertical Slice, Modular Monolith, and Microservices, with a comparison table, strengths/weaknesses/choose-this-when per pattern, decision heuristics, and an FAQ.
- **Getting Started with Clean Architecture in .NET** (2026-10-06) - scaffolding the Core/UseCases/Infrastructure/Web dependency graph so the dependency rule is a compile-time guarantee, backed by NetArchTest/ArchUnitNET architecture tests.
- **Getting Started with Layered (N-Tier) Architecture in .NET** (2026-10-13) - Web/Business/DataAccess as separate projects, keeping the dependency direction honest, and the signal for when to move on.
- **Getting Started with Vertical Slice Architecture in .NET** (2026-10-20) - building a complete slice (endpoint, command, handler, validator) per feature, with a MediatR pipeline for cross-cutting concerns.
- **Getting Started with Modular Monolith Architecture in .NET** (2026-10-27) - Contracts projects and `internal` implementations as a compiler-enforced module boundary, backed by architecture tests.
- **Getting Started with Microservices Architecture in .NET** (2026-11-03) - scaffolding a multi-service solution with .NET Aspire, service discovery, ServiceDefaults, and an honest look at what Aspire does and doesn't remove.

All six were adapted from the already-complete drafts in `docs/article-ideas/`, following the same "Top 5 X Compared" / "Getting Started with X" structure established by the AI Coding Agents track (comparison tables, strengths/weaknesses, FAQ sections, cross-links back to the anchor post - no `***` dividers or closing signature, matching that track's convention rather than the DevOps-track post format).

Also updates `editorial-plan.md` status/file for all six entries.

None of the six posts have hero images yet - those will follow in a separate commit once generated via ChatGPT from each post's `image_prompt` field.

## Test plan

- [x] `npm run deploy` builds cleanly for all six new posts
- [x] Cross-links from each setup guide back to the anchor comparison post verified to resolve
- [x] `node scripts/a11y-check.js` - no accessibility violations (home/post/about/privacy/terms/404, light + dark)
- [ ] Hero images to follow once generated


---
_Generated by [Claude Code](https://claude.ai/code/session_01WKyNF7L5qzrfct8cec6A32)_