### PR TITLE
.NET ORMs track (6 posts): comparison + 5 setup guides

### DIFF
--- a/editorial-plan.md
+++ b/editorial-plan.md
@@ -763,49 +763,55 @@ Six posts on .NET testing frameworks, resuming the Tuesday cadence in January - 
 Six posts on .NET data access, closing out the Tuesday cadence. A comparison post anchors the track and each of the five follow-ups is a complete setup for one ORM.
 
 ### The Top 5 .NET ORMs Compared: Which One Should You Choose?
-- **Status:** `idea`
+- **Status:** `draft`
 - **Scheduled:** 2027-02-16
 - **Source:** `docs/article-ideas/top-5-dotnet-orms-compared.md`
+- **File:** `src/posts/2027-02-16-top-5-dotnet-orms-compared.md`
 - **Pitch:** Every .NET data access decision collapses into one question: how much should the ORM do for you, versus how much SQL do you want to write yourself? EF Core and Dapper are the two ends of that axis, and the other three aren't simply worse versions of either.
 - **Angle:** Compares EF Core, Dapper, NHibernate, Linq2Db, and RepoDb across category, query style, change tracking, migrations, performance, and maintainer, then gives each a strengths/weaknesses/choose-this-when breakdown. The recurring argument is that "pick one" is often the wrong framing - EF Core for the domain and migrations with Dapper on specific read paths is a widely supported pattern, not a compromise. Pushes back hard on choosing by benchmark: for most applications the bottleneck is the query, the network, or business logic, not the mapping layer's marginal overhead.
 - **Tags:** `dotnet`, `orm`, `database`, `performance`, `architecture`
 
 ### Getting Started with EF Core in .NET
-- **Status:** `idea`
+- **Status:** `draft`
 - **Scheduled:** 2027-02-23
 - **Source:** `docs/article-ideas/getting-started-with-ef-core.md`
+- **File:** `src/posts/2027-02-23-getting-started-with-ef-core.md`
 - **Pitch:** EF Core is the right default, but the gap between a tutorial's `dotnet ef migrations add` and a setup that stays maintainable is bigger than it looks. Three things trip up most first real projects: change tracking you're paying for on read-only queries, migrations that can't find your `DbContext`, and repository layers added out of habit.
 - **Angle:** Covers the provider and design-time packages - including why `Microsoft.EntityFrameworkCore.Design` belongs in the startup project, the single most common cause of broken migrations in a multi-project solution - plus `DbContext` and relationship configuration, the `--project`/`--startup-project` split, and `IDesignTimeDbContextFactory<T>` as the fallback when the tooling can't instantiate your context. Makes `AsNoTracking()` the default habit for reads, since that one habit accounts for most of the performance gap people attribute to EF Core being slow. Argues against a reflexive repository/unit-of-work layer on top of something that already implements unit of work, and treats reaching for Dapper on specific paths as normal rather than an admission the choice was wrong.
 - **Tags:** `dotnet`, `orm`, `database`, `performance`, `developer-productivity`
 
 ### Getting Started with Dapper in .NET
-- **Status:** `idea`
+- **Status:** `draft`
 - **Scheduled:** 2027-03-02
 - **Source:** `docs/article-ideas/getting-started-with-dapper.md`
+- **File:** `src/posts/2027-03-02-getting-started-with-dapper.md`
 - **Pitch:** You write the SQL, Dapper maps the results onto your objects, and almost nothing happens in between. What trips people up isn't Dapper's fault so much as the gaps it deliberately doesn't fill - connection lifecycle, migrations, and mapping conventions all become your responsibility.
 - **Angle:** Sets up a DI-registered connection factory where every call site creates and disposes its own connection and ADO.NET pooling does the actual reuse, then covers `QuerySingleOrDefaultAsync`, multi-mapping with `splitOn` for joined queries, and batched writes. Treats parameterization as the one non-negotiable rule - it's the difference between a parameterized query and a SQL injection vulnerability, not a style preference. Names the schema gap directly and pairs Dapper with DbUp or Fluent Migrator rather than pretending migrations are optional, and warns against building a generic repository that slowly reimplements a mini-ORM.
 - **Tags:** `dotnet`, `orm`, `database`, `performance`, `security`
 
 ### Getting Started with NHibernate in .NET
-- **Status:** `idea`
+- **Status:** `draft`
 - **Scheduled:** 2027-03-09
 - **Source:** `docs/article-ideas/getting-started-with-nhibernate.md`
+- **File:** `src/posts/2027-03-09-getting-started-with-nhibernate.md`
 - **Pitch:** NHibernate's maturity is real - caching, mapping flexibility, and loading control are all battle-tested after a decade in large enterprise systems - but there's genuine configuration depth to learn before any of it pays off, and skipping straight to "just make it work" produces a setup that fights you.
 - **Angle:** Uses Fluent NHibernate rather than hand-written `.hbm.xml`, covers why entity members must be `virtual` (proxy generation for lazy loading - a non-virtual property compiles fine and silently breaks), and the two lifetimes that matter: `ISessionFactory` as an expensive singleton and `ISession` scoped per unit of work. Covers session-scoped change tracking, the LINQ provider vs. HQL as entry points, `SchemaExport` for local development against a real migration tool for production, and second-level caching as a deliberate per-entity decision rather than a global default. Doesn't pretend this is a greenfield recommendation - it's a guide for extending a codebase already built on it.
 - **Tags:** `dotnet`, `orm`, `database`, `architecture`, `tooling`
 
 ### Getting Started with Linq2Db in .NET
-- **Status:** `idea`
+- **Status:** `draft`
 - **Scheduled:** 2027-03-16
 - **Source:** `docs/article-ideas/getting-started-with-linq2db.md`
+- **File:** `src/posts/2027-03-16-getting-started-with-linq2db.md`
 - **Pitch:** Linq2Db gives you EF Core's most-loved feature - strongly-typed, composable LINQ queries - without the change tracking, identity map, or unit-of-work machinery that comes bundled whether you want it or not.
 - **Angle:** Covers attribute-based entity mapping, a `DataConnection` subclass exposing `ITable<T>` properties, and DI registration where scoping is about connection lifetime rather than preserving tracked entity state. The core adjustment is updates: `Where(...).Set(...).UpdateAsync()` maps to a single `UPDATE` statement with no fetch first, and falling into an EF Core-style fetch-mutate-save habit is the most common first mistake. Same migration gap as Dapper and RepoDb, handled the same way with DbUp or Fluent Migrator, and honest that the real cost is a much smaller community, ecosystem, and hiring pool rather than any technical shortfall.
 - **Tags:** `dotnet`, `orm`, `database`, `performance`, `tooling`
 
 ### Getting Started with RepoDb in .NET
-- **Status:** `idea`
+- **Status:** `draft`
 - **Scheduled:** 2027-03-23
 - **Source:** `docs/article-ideas/getting-started-with-repodb.md`
+- **File:** `src/posts/2027-03-23-getting-started-with-repodb.md`
 - **Pitch:** RepoDb exists for one specific complaint: Dapper is fast but leaves you writing the same CRUD SQL over and over, while EF Core writes it for you at a real abstraction cost. It sits deliberately in between.
 - **Angle:** Covers the core plus provider extension packages and the `SqlServerBootstrap.Initialize()` call that's easy to skip and produces confusing runtime errors that look unrelated to the actual missing step. Uses the same connection-factory pattern as Dapper, then contrasts generated CRUD (`InsertAsync`, expression-based `QueryAsync`) against `ExecuteQueryAsync` for anything complex, plus `InsertAllAsync`/`MergeAllAsync` bulk methods that beat row-by-row loops. Names the actual failure mode: treating RepoDb exactly like Dapper and hand-writing SQL for everything, which works fine but discards the only reason to pick it over Dapper in the first place.
 - **Tags:** `dotnet`, `orm`, `database`, `performance`, `developer-productivity`

--- a/src/posts/2027-02-16-top-5-dotnet-orms-compared.md
+++ b/src/posts/2027-02-16-top-5-dotnet-orms-compared.md
@@ -1,0 +1,168 @@
+---
+author: Steve Kaschimer
+date: 2027-02-16
+image: /images/posts/2027-02-16-hero.webp
+image_alt: "Five columns of abstract data-access glyphs positioned along a horizontal axis running from full object tracking on the left to raw SQL on the right."
+image_prompt: "A dark-mode technical editorial illustration on a near-black background with electric teal, amber, and off-white accents. Composition is five vertical columns of equal width separated by thin hairline rules, each column topped by a distinct abstract glyph rendered in flat geometry: a box shape with a small tracked checkmark badge in its corner, a thin SQL-bracket glyph flowing directly into a mapped rectangle with almost no gap, a stack of three small labeled config panels beside a vault-shaped icon, a straight teal arrow passing cleanly through a narrow funnel with no obstruction, and a shape split evenly down the middle - one half a small gear-free generated-method icon, the other half a raw bracket glyph. Beneath the glyphs, a shared horizontal axis labeled in monospaced type runs from 'full tracking' on the left to 'raw SQL' on the right, with a small glowing teal dot positioned at a different point under each column. Mood is comparative, engineering-first, and non-partisan. Avoid: vendor logos, brand colors, circuit-board textures, robot faces, generic gears or database-cylinder clip art used as the dominant motif."
+layout: post.njk
+site_title: Tech Notes
+summary: "EF Core, Dapper, NHibernate, Linq2Db, and RepoDb all sit at different points on one axis: how much should the ORM do for you, versus how much SQL do you want to write yourself. A practical breakdown of what each optimizes for."
+tags: ["dotnet", "orm", "database", "performance", "architecture"]
+title: "The Top 5 .NET ORMs Compared: Which One Should You Choose?"
+---
+
+Every .NET data access decision eventually collapses into the same question: how much should the ORM do for you, versus how much SQL do you want to write yourself? That's really the axis all five of these tools sit on. EF Core sits at the "do the most for me" end. Dapper sits at the "get out of my way" end. The other three - NHibernate, Linq2Db, and RepoDb - fill in the space between with their own specific trade-offs, and none of them are simply worse versions of EF Core or Dapper.
+
+This guide compares the five ORMs .NET developers reach for most often, what each one actually optimizes for, and which project profile fits best. One thing worth knowing upfront: for a meaningful share of real production systems, the honest answer isn't "pick one" - it's EF Core for the domain and migrations, with Dapper handling the specific read paths where raw SQL control matters more than abstraction. That hybrid pattern comes up often enough in this comparison that it's worth keeping in mind while reading. This series continues with dedicated getting-started walkthroughs for each ORM in .NET.
+
+## Quick Comparison
+
+| | EF Core | Dapper | NHibernate | Linq2Db | RepoDb |
+| --- | --- | --- | --- | --- | --- |
+| **Category** | Full ORM | Micro-ORM | Full ORM | LINQ-to-SQL micro-ORM | Hybrid micro-ORM |
+| **Query style** | LINQ over entities | Raw SQL, mapped to objects | HQL, Criteria API, LINQ | Strongly-typed LINQ-to-SQL | Method-based + raw SQL |
+| **Change tracking** | Yes, built in | No | Yes, built in | No | No |
+| **Migrations** | Built-in, mature tooling | None - bring your own | Supported via tooling | None - bring your own | None - bring your own |
+| **Performance** | Good, close to raw ADO.NET when tuned | Fastest for raw/complex queries | Good, but heavier than micro-ORMs | Very fast - minimal abstraction over SQL | Comparable to or faster than Dapper in some benchmarks |
+| **Learning curve** | Moderate | Low | Higher - more configuration surface | Low-moderate | Low |
+| **Maintainer** | Microsoft | Community (Stack Overflow-originated) | Community (Hibernate .NET port) | Community | Community |
+| **Best for** | Most new ASP.NET Core projects | Read-heavy paths, reporting, raw SQL control | Existing enterprise codebases already using it | Teams wanting LINQ with minimal ORM overhead | Teams wanting Dapper's speed with less boilerplate |
+
+## EF Core
+
+Entity Framework Core is Microsoft's official ORM and the default starting point for most new ASP.NET Core projects in 2026. It's a full ORM in the traditional sense: entities, change tracking, LINQ queries translated to SQL, and a mature migrations system for evolving your schema alongside your code.
+
+**Strengths:**
+
+- Actively maintained by Microsoft with tight integration into the rest of the .NET ecosystem - `dotnet ef` tooling, dependency injection, and ASP.NET Core all assume EF Core as a baseline
+- Supports Code First, Database First, and Model First workflows, so it fits teams that want to design the schema in C# or teams that need to map an existing database
+- LINQ queries are strongly typed and refactor-safe, catching a class of bugs raw SQL strings can't
+- Migrations are genuinely good - schema evolution alongside code changes is one of EF Core's most mature capabilities relative to every other option here
+
+**Weaknesses:**
+
+- Change tracking has real overhead, and it's easy to accidentally pay for it on read-only queries if you forget `AsNoTracking()`
+- Generated SQL for complex queries can be inefficient or surprising compared to hand-written SQL, especially for reporting-style aggregations
+- The abstraction can obscure what's actually happening at the database level, which occasionally makes performance problems harder to diagnose than with a thinner layer
+
+**Choose this when:** you're starting a new ASP.NET Core project and don't have a specific reason to reach for something else - it's the right default, not just the popular one.
+
+## Dapper
+
+Dapper is a micro-ORM originally built at Stack Overflow, designed to do exactly one thing well: map the results of a SQL query you write yourself onto .NET objects, as fast as possible, with almost no overhead beyond raw ADO.NET.
+
+**Strengths:**
+
+- Consistently the fastest option for complex raw SQL and large result sets, and close to raw ADO.NET performance in general
+- Minimal footprint - a single lightweight library, no configuration ceremony, easy to learn in an afternoon
+- Full SQL control, which matters when you need to hand-tune a query for a specific execution plan or use database-specific features EF Core doesn't model well
+- Supports multi-mapping, batching, and bulk operations for scenarios where that control pays off
+
+**Weaknesses:**
+
+- No change tracking, no migrations, and no schema management - Dapper is exclusively about executing SQL and mapping results, so you need another tool or manual process for everything else
+- Every query is a raw SQL string, so refactoring a column name doesn't get caught by the compiler the way a LINQ query would
+- Scales less gracefully to large domain models with many relationships, since there's no built-in graph tracking or navigation the way a full ORM provides
+
+**Choose this when:** you have specific read paths - reporting queries, high-throughput endpoints, anything with a SQL query you'd rather write and tune directly - where the control is worth giving up the abstraction. Very commonly paired with EF Core rather than used as a full replacement.
+
+## NHibernate
+
+NHibernate is the .NET port of Java's Hibernate, and it's been used in large enterprise .NET applications for well over a decade. It's a full ORM with deep configuration options - HQL (its own query language), a Criteria API, a LINQ provider, and fine-grained control over caching and loading behavior.
+
+**Strengths:**
+
+- Extremely configurable - multi-database support, custom mapping strategies (Fluent API, XML, attribute-based), and precise control over lazy vs. eager loading
+- First-level and second-level caching are mature and well-documented, useful for high-read enterprise workloads
+- Proven at scale in large, long-running enterprise systems, with well-understood behavior after years of production use
+
+**Weaknesses:**
+
+- Steeper learning curve than any other option here - the configuration surface is large, and the XML/Fluent mapping conventions take real time to internalize
+- EF Core has closed most of the feature gap that used to differentiate NHibernate, while offering better tooling integration and a much larger active community
+- Not the recommended starting point for a new, greenfield .NET project in 2026 - its strongest use case is genuinely existing systems already built on it
+
+**Choose this when:** you're maintaining or extending an existing NHibernate codebase. For new projects, EF Core has caught up enough in capability that NHibernate's added complexity is harder to justify than it used to be.
+
+## Linq2Db
+
+Linq2Db (LINQ to DB) is a lightweight ORM that gives you strongly-typed LINQ queries with minimal abstraction between your code and the generated SQL - closer in spirit to a "thin LINQ layer over SQL" than a full ORM with change tracking and unit-of-work semantics.
+
+**Strengths:**
+
+- Very fast - because there's no change tracking or identity map overhead, query execution stays close to what you'd get writing SQL by hand
+- LINQ queries translate to SQL predictably, with less of the "what did EF Core actually generate here" uncertainty that can come with a heavier ORM
+- Supports a wide range of database providers, and is a strong fit for teams that want LINQ's ergonomics without paying for features they don't use
+
+**Weaknesses:**
+
+- No change tracking, so update workflows require more explicit handling than EF Core's automatic dirty-checking
+- Smaller community and ecosystem than EF Core or Dapper, meaning fewer tutorials, Stack Overflow answers, and third-party integrations to lean on
+- Less commonly adopted than the other four, so hiring and onboarding developers already familiar with it is less likely
+
+**Choose this when:** you want LINQ's type safety and query composability without the overhead of change tracking, and you're comfortable trading community size for a leaner, more predictable query layer.
+
+## RepoDb
+
+RepoDb positions itself deliberately between Dapper and EF Core - a hybrid micro-ORM that offers Dapper-like raw SQL execution alongside method-based CRUD operations that reduce the boilerplate a pure micro-ORM leaves you to write yourself.
+
+**Strengths:**
+
+- Genuinely fast - benchmarks frequently show it matching or exceeding Dapper's performance while offering more built-in convenience
+- Method-based CRUD (`Insert`, `Update`, `Delete`, `Query`) reduces the amount of hand-written SQL needed for routine operations, while raw SQL is still available when you need it
+- Built-in second-level caching and query tracing are useful additions a pure micro-ORM like Dapper doesn't provide out of the box
+- Async support throughout, and flexible mapping (type, field, multi-result-set) for less common data shapes
+
+**Weaknesses:**
+
+- Smaller community and ecosystem than EF Core, Dapper, or even NHibernate, which means less third-party tooling and fewer people to ask when something goes wrong
+- No migrations or schema management, the same gap Dapper has - you're on your own for evolving the database schema
+- Less battle-tested at scale in the broadest sense than the four more established options here, simply due to smaller adoption
+
+**Choose this when:** you want Dapper's performance profile but find yourself re-writing the same CRUD boilerplate repeatedly, and you're comfortable adopting a less widely used library in exchange for that convenience.
+
+## How to Decide
+
+A few heuristics that cover most real-world decisions:
+
+**Starting a new ASP.NET Core project with no strong reason to deviate?** EF Core is the right default - mature tooling, Microsoft backing, and migrations that just work.
+
+**Have specific read-heavy or reporting queries where you want full SQL control?** Reach for Dapper for those specific paths rather than replacing your whole data layer - the EF Core-plus-Dapper hybrid pattern is common and well-supported precisely because it lets each tool do what it's best at.
+
+**Maintaining an existing NHibernate codebase?** Keep using it. Its configuration depth pays off in systems already built around it, and a rewrite purely to modernize is rarely worth the risk on its own.
+
+**Want LINQ's type safety without change-tracking overhead?** Linq2Db is worth evaluating if your team values a thin, predictable query layer over a full ORM's feature set.
+
+**Like Dapper's performance but tired of writing the same CRUD SQL repeatedly?** RepoDb's hybrid approach gives you both raw SQL and generated CRUD methods without committing to full ORM overhead.
+
+None of these are exclusive choices within a single application - pairing EF Core for your domain model and migrations with Dapper (or RepoDb) for specific performance-sensitive read paths is a widely accepted pattern, not a compromise.
+
+## Frequently Asked Questions
+
+### Is Dapper actually faster than EF Core?
+
+For complex raw SQL and large result sets, yes, meaningfully. For standard, well-indexed CRUD operations, a properly tuned EF Core query using `AsNoTracking()` performs within a few percent of Dapper - the gap is often smaller than benchmarks suggest, and profiling your actual workload matters more than trusting a generic benchmark.
+
+### Can I use Dapper and EF Core in the same project?
+
+Yes, and it's a common, well-supported pattern. You can obtain the underlying `DbConnection` from your `DbContext` and pass it directly to Dapper's extension methods, letting EF Core handle your domain model and migrations while Dapper handles specific queries that benefit from raw SQL.
+
+### Is NHibernate still worth learning in 2026?
+
+For new, greenfield projects, generally no - EF Core has closed most of the feature gap while offering better tooling and a larger community. NHibernate remains a reasonable choice specifically for maintaining or extending existing systems already built on it, where the migration cost to something else would outweigh the benefit.
+
+### What's the actual difference between a micro-ORM and a full ORM?
+
+A full ORM (EF Core, NHibernate) manages an object graph with change tracking, an identity map, and typically a migrations system for schema evolution. A micro-ORM (Dapper, RepoDb, Linq2Db to varying degrees) focuses narrowly on mapping query results to objects, leaving schema management, change tracking, and unit-of-work concerns to you or another tool.
+
+### Should I choose an ORM based on raw performance benchmarks?
+
+Not primarily. Micro-ORMs will generally win raw benchmarks against full ORMs, but for most applications the bottleneck is the database query itself, network latency, or business logic - not the marginal overhead of an ORM's mapping layer. Choose based on how much abstraction and tooling (migrations, change tracking) your team actually needs, and treat performance as a secondary factor unless you have a specific, measured bottleneck.
+
+### Are RepoDb and Linq2Db mature enough for production use?
+
+Yes, both are used in production systems, but with meaningfully smaller communities than EF Core or Dapper. That's not disqualifying, but it does mean fewer Stack Overflow answers, less third-party tooling, and a smaller pool of developers already familiar with them - factor that into hiring and onboarding considerations, not just technical capability.
+
+### How do migrations work if I'm not using EF Core?
+
+Dapper, RepoDb, and Linq2Db all leave schema migrations entirely up to you - common approaches include a dedicated migration tool (like DbUp, Fluent Migrator, or Flyway) independent of the query layer. NHibernate has some tooling support for schema generation and migration, though less mature than EF Core's. This is one of the clearest differentiators when choosing between a full ORM and a micro-ORM: a full ORM typically owns migrations end-to-end, while a micro-ORM treats it as a separate concern.

--- a/src/posts/2027-02-23-getting-started-with-ef-core.md
+++ b/src/posts/2027-02-23-getting-started-with-ef-core.md
@@ -1,0 +1,205 @@
+---
+author: Steve Kaschimer
+date: 2027-02-23
+image: /images/posts/2027-02-23-hero.webp
+image_alt: "A box shape with a tracked-entity checkmark badge in its corner beside a toggle switch labeled by position rather than text, flipped to the off side."
+image_prompt: "A dark-mode technical editorial illustration on a near-black background with electric teal, amber, and off-white accents. Composition centers on a flat rectangle outline with a small amber checkmark badge in its top-right corner, representing a tracked entity. To its right, a small toggle switch icon rendered in teal, with its slider pushed fully to one side, implying an opt-out state. Below, three thin file icons stacked closely together represent migration artifacts, connected by a short teal line to a database-cylinder-free schema outline. Mood is deliberate, foundational, and precise. Avoid: vendor logos, brand colors, circuit-board textures, gears, or generic database-cylinder clip art as the dominant motif."
+layout: post.njk
+site_title: Tech Notes
+summary: "The gap between a tutorial's dotnet ef migrations add and a setup that stays maintainable is bigger than it looks. A setup guide for DbContext, migrations that don't fight multi-project solutions, and AsNoTracking() as the default habit for reads."
+tags: ["dotnet", "orm", "database", "performance", "developer-productivity"]
+title: "Getting Started with EF Core in .NET"
+---
+
+EF Core's reputation as "the default" .NET ORM is well earned, but the gap between a tutorial's `dotnet ef migrations add` and a setup that stays maintainable is bigger than it looks at first. Change tracking that silently costs you performance on read-only queries, migrations that mysteriously fail to find your `DbContext`, and repository abstractions people add out of habit rather than need are the three things that trip up most first real projects.
+
+This guide covers installing EF Core, bootstrapping a `DbContext` and migrations workflow that won't fight you later, the core query and change-tracking patterns worth knowing from day one, and the best practices that keep performance predictable as your model grows. By the end you'll have a data access layer that's fast by default, not fast only after a painful profiling session.
+
+If you're deciding between ORMs first, [a comparison of the top .NET ORMs](/posts/2027-02-16-top-5-dotnet-orms-compared/) covers where EF Core fits relative to Dapper, NHibernate, Linq2Db, and RepoDb.
+
+## What You'll Need
+
+- .NET 8 SDK or later
+- A database to target - SQL Server, PostgreSQL, and SQLite are all well-supported; this guide uses SQL Server for examples
+- The EF Core CLI tools for migrations
+
+## Installing EF Core
+
+Add the provider package for your database, plus the design-time package needed for migrations:
+
+```bash
+dotnet add package Microsoft.EntityFrameworkCore.SqlServer
+dotnet add package Microsoft.EntityFrameworkCore.Design
+```
+
+`Microsoft.EntityFrameworkCore.Design` must be installed in your **startup project** - the one with `Program.cs` - not just the project containing your `DbContext`, even if those are different projects. This is the single most common cause of migrations failing to work in a multi-project solution.
+
+Install the CLI tool globally if you haven't already:
+
+```bash
+dotnet tool install --global dotnet-ef
+```
+
+Keep the tool version aligned with your `Microsoft.EntityFrameworkCore` runtime version - a mismatch produces a warning and occasionally subtle migration issues.
+
+## Bootstrapping the Ideal Environment
+
+### Define your DbContext and entities
+
+```csharp
+public class AppDbContext(DbContextOptions<AppDbContext> options) : DbContext(options)
+{
+    public DbSet<Order> Orders => Set<Order>();
+    public DbSet<Customer> Customers => Set<Customer>();
+
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
+    {
+        modelBuilder.Entity<Order>()
+            .HasOne(o => o.Customer)
+            .WithMany(c => c.Orders)
+            .HasForeignKey(o => o.CustomerId);
+    }
+}
+
+public class Order
+{
+    public int Id { get; set; }
+    public int CustomerId { get; set; }
+    public Customer Customer { get; set; } = null!;
+    public OrderStatus Status { get; set; }
+}
+```
+
+### Register it in Program.cs
+
+```csharp
+var builder = WebApplication.CreateBuilder(args);
+
+builder.Services.AddDbContext<AppDbContext>(options =>
+    options.UseSqlServer(builder.Configuration.GetConnectionString("Default")));
+
+var app = builder.Build();
+app.Run();
+```
+
+The design-time tooling relies on being able to discover this registration by probing your app's host, which is why `app.Run()` (or a return of the built host) needs to remain reachable in `Program.cs` - restructuring top-level statements in a way that prevents the tool from finding the host is a common cause of migration commands failing.
+
+### Create and apply your first migration
+
+```bash
+dotnet ef migrations add InitialCreate
+dotnet ef database update
+```
+
+This generates three files under a `Migrations/` folder: the migration itself (`Up`/`Down` operations), a designer file EF uses internally, and a model snapshot. Commit all three to version control.
+
+### If your DbContext lives in a different project than your host
+
+Specify both explicitly:
+
+```bash
+dotnet ef migrations add AddOrderStatus --project MyApp.Infrastructure --startup-project MyApp.Web
+```
+
+And point the migrations assembly at the right project in your `DbContext` registration:
+
+```csharp
+options.UseSqlServer(connectionString, b => b.MigrationsAssembly("MyApp.Infrastructure"));
+```
+
+### If dotnet ef can't instantiate your DbContext
+
+For class libraries, test projects, or a `DbContext` with constructor parameters the tool can't resolve without a running host, implement `IDesignTimeDbContextFactory<T>`:
+
+```csharp
+public class AppDbContextFactory : IDesignTimeDbContextFactory<AppDbContext>
+{
+    public AppDbContext CreateDbContext(string[] args)
+    {
+        var options = new DbContextOptionsBuilder<AppDbContext>()
+            .UseSqlServer("Server=localhost;Database=MyAppDb;Trusted_Connection=True;")
+            .Options;
+        return new AppDbContext(options);
+    }
+}
+```
+
+## Core Workflow
+
+- **Query with `AsNoTracking()` for anything read-only.** Change tracking has real overhead; skip it whenever you're not going to modify and save the entities you're fetching.
+- **Let EF Core's change tracking handle updates for tracked entities.** Fetch, mutate the properties, call `SaveChangesAsync()` - no manual update statements needed for tracked entities.
+- **Add a migration for every schema change, immediately.** Don't let model changes and migrations drift apart; add the migration as part of the same commit as the entity change.
+- **Use `Include()` deliberately, not defensively.** Eager-loading everything "just in case" produces bloated queries - include only the navigation properties a given query actually needs.
+
+```csharp
+// Read-only: skip change tracking
+var activeOrders = await db.Orders
+    .AsNoTracking()
+    .Where(o => o.Status == OrderStatus.Processing)
+    .ToListAsync();
+
+// Write: let change tracking do the work
+var order = await db.Orders.FindAsync(orderId);
+order.Status = OrderStatus.Shipped;
+await db.SaveChangesAsync();
+```
+
+## Verifying Your Setup
+
+1. **Migrations apply cleanly** - run `dotnet ef database update` against a fresh database and confirm the schema matches your model
+2. **`AsNoTracking()` is actually reducing overhead** - profile a read-heavy endpoint with and without it if performance is a concern
+3. **Generated SQL is reasonable** - log EF Core's generated SQL (`options.LogTo(Console.WriteLine)` in development) and sanity-check a few key queries
+4. **The migrations history table matches your codebase** - confirm `__EFMigrationsHistory` in the database reflects exactly the migrations present in your `Migrations/` folder
+
+## Best Practices
+
+**Default to `AsNoTracking()` for queries, and opt into tracking only when you need to update.** This single habit accounts for a large share of the performance gap people mistakenly attribute to EF Core being "slow."
+
+**Don't add a repository/unit-of-work layer reflexively.** `DbContext` already implements the unit-of-work pattern and provides a clean, testable API on its own. Add abstraction when you have a concrete reason - isolating tests from a real database, or genuinely needing to swap data stores - not as a default habit.
+
+**Commit every migration to version control, including the designer and snapshot files.** All three matter; missing the snapshot file in particular causes confusing state mismatches for the next developer generating a migration.
+
+**Review generated SQL for anything performance-sensitive.** EF Core's LINQ-to-SQL translation is good but not infallible, especially for complex aggregations - don't assume the generated query is optimal without checking, particularly on hot paths.
+
+**Reach for Dapper for specific reporting or bulk-read queries where EF Core's abstraction gets in the way.** This is a normal, widely accepted pattern, not a sign EF Core was the wrong choice.
+
+## Comparison with Dapper
+
+| | EF Core | Dapper |
+| --- | --- | --- |
+| Query style | LINQ over tracked entities | Raw SQL, mapped to objects |
+| Change tracking | Yes, built in | No |
+| Migrations | Built-in, mature | None - bring your own |
+| Best for | Domain modeling, most CRUD, schema evolution | Read-heavy paths, reporting, hand-tuned SQL |
+
+Many production systems use both - EF Core for the domain and schema, Dapper for the specific queries where raw SQL control matters more than LINQ's abstraction. You can pull the underlying `DbConnection` straight from your `DbContext` and hand it to Dapper without maintaining two separate connection configurations.
+
+## Frequently Asked Questions
+
+### Why does dotnet ef migrations add fail with "Unable to create an object of type 'AppDbContext'"?
+
+The design-time tool couldn't instantiate your `DbContext`, usually because it can't find or run a host to discover the DI registration. Confirm `--startup-project` points at your actual host project, that `Program.cs` still builds and runs (or returns) a `WebApplication`, and that your `DbContext` constructor doesn't require a type the tool can't resolve without the app fully running. If none of that applies, implement `IDesignTimeDbContextFactory<T>` as a direct fallback.
+
+### Do I need Microsoft.EntityFrameworkCore.Design in every project, or just one?
+
+Just the startup project - the one containing `Program.cs` that the `dotnet ef` tooling actually runs. It's a common mistake to add it only to the project containing the `DbContext` in a multi-project solution, which doesn't work if that's not also your startup project.
+
+### What's the performance impact of change tracking?
+
+It's real but often overstated for typical CRUD workloads - a well-tuned EF Core query with `AsNoTracking()` performs within a few percent of Dapper for standard indexed operations. The overhead matters most on large result sets or high-throughput read paths, which is exactly where `AsNoTracking()` (or a specific Dapper query) earns its keep.
+
+### Should I use the repository pattern with EF Core?
+
+Not by default. `DbContext` already provides a clean, mockable API and implements the unit-of-work pattern itself. Add a repository abstraction when you have a specific need - isolating unit tests from a real database without an in-memory provider, or genuinely anticipating a data store swap - rather than as a blanket architectural habit, since over-abstracting EF Core tends to obscure LINQ's expressiveness rather than protect it.
+
+### How do I handle migrations across multiple environments (dev, staging, production)?
+
+Keep the same set of migration files across all environments and apply them with `dotnet ef database update` (or the equivalent runtime `context.Database.Migrate()` call) as part of your deployment process. Avoid manually editing the database schema outside of migrations in any environment - that's what causes the migrations history table to drift out of sync with reality.
+
+### Can I use EF Core with a database EF Core doesn't have a first-party provider for?
+
+Yes, via community-maintained providers - MySQL, Oracle, and others all have EF Core provider packages, though quality and update cadence vary by provider. Confirm the specific provider you need is actively maintained before committing, since the built-in SQL Server, PostgreSQL (via Npgsql), and SQLite providers have the strongest first-party support.
+
+### What's the most common mistake in a first EF Core setup?
+
+Forgetting `AsNoTracking()` on read-only queries, which quietly adds overhead across an entire application, and installing `Microsoft.EntityFrameworkCore.Design` in the wrong project in a multi-project solution, which breaks migrations in a way that's confusing to diagnose the first time you hit it.

--- a/src/posts/2027-03-02-getting-started-with-dapper.md
+++ b/src/posts/2027-03-02-getting-started-with-dapper.md
@@ -1,0 +1,186 @@
+---
+author: Steve Kaschimer
+date: 2027-03-02
+image: /images/posts/2027-03-02-hero.webp
+image_alt: "A raw SQL bracket glyph flowing directly into a mapped object rectangle with almost no gap between them, beside a small padlock icon marking a parameterized value."
+image_prompt: "A dark-mode technical editorial illustration on a near-black background with electric teal, amber, and off-white accents. Composition centers on a thin bracket-shaped glyph on the left representing a raw query, connected by a very short direct teal line to a flat mapped rectangle on the right, with almost no visual gap between them - implying minimal machinery in between. Just above the connecting line, a small amber padlock icon marks a parameter placeholder. Below, a single connection icon flows outward into several thin lines terminating in a shared pool shape, representing pooled reuse rather than a persistent single connection. Mood is direct, minimal, and fast. Avoid: vendor logos, brand colors, circuit-board textures, gears, or generic lightning-bolt speed clip art."
+layout: post.njk
+site_title: Tech Notes
+summary: "You write the SQL, Dapper maps the results onto your objects, and almost nothing happens in between. A setup guide for connection lifecycle, multi-mapping joined queries, parameterization as the one non-negotiable rule, and pairing it with a real migration tool."
+tags: ["dotnet", "orm", "database", "performance", "security"]
+title: "Getting Started with Dapper in .NET"
+---
+
+Dapper's entire pitch fits in one sentence: you write the SQL, Dapper maps the results onto your objects, and almost nothing happens in between. That simplicity is exactly why it's fast, and exactly why the things that trip people up aren't Dapper's fault so much as gaps it deliberately doesn't fill - connection management, migrations, and mapping conventions all become your responsibility rather than the library's.
+
+This guide covers installing Dapper, bootstrapping connection handling and query patterns that scale past a single "hello world" query, the core workflow for reads, writes, and multi-mapping, and the best practices that keep a Dapper-based data layer maintainable once it's more than a handful of queries. By the end you'll have a lightweight, fast data access layer with the rough edges Dapper leaves exposed already sanded down.
+
+If you're deciding between ORMs first, [a comparison of the top .NET ORMs](/posts/2027-02-16-top-5-dotnet-orms-compared/) covers where Dapper fits relative to EF Core, NHibernate, Linq2Db, and RepoDb.
+
+## What You'll Need
+
+- .NET 8 SDK or later
+- A database and its corresponding ADO.NET provider (`Microsoft.Data.SqlClient` for SQL Server, `Npgsql` for PostgreSQL, etc.) - Dapper works on top of any `IDbConnection`, so the provider choice is yours
+- Comfort writing SQL directly, since that's the entire interface
+
+## Installing Dapper
+
+```bash
+dotnet add package Dapper
+dotnet add package Microsoft.Data.SqlClient
+```
+
+That's the whole install - Dapper is a single lightweight library with no configuration files, no fluent setup, and no code generation step.
+
+## Bootstrapping the Ideal Environment
+
+Dapper doesn't manage connections for you, which is a deliberate design choice - but it means your setup needs to handle connection lifecycle explicitly instead of relying on the library to do it.
+
+### A connection factory, registered through DI
+
+```csharp
+public interface IDbConnectionFactory
+{
+    IDbConnection CreateConnection();
+}
+
+public class SqlConnectionFactory(string connectionString) : IDbConnectionFactory
+{
+    public IDbConnection CreateConnection() => new SqlConnection(connectionString);
+}
+```
+
+```csharp
+// Program.cs
+var builder = WebApplication.CreateBuilder(args);
+
+builder.Services.AddSingleton<IDbConnectionFactory>(
+    new SqlConnectionFactory(builder.Configuration.GetConnectionString("Default")!));
+```
+
+Each call site creates and disposes its own connection via `using`, letting ADO.NET's connection pooling do the actual reuse work under the hood - you don't need to manage a long-lived shared connection yourself.
+
+### A first query
+
+```csharp
+public class OrderRepository(IDbConnectionFactory connectionFactory)
+{
+    public async Task<Order?> GetByIdAsync(int orderId)
+    {
+        using var connection = connectionFactory.CreateConnection();
+        return await connection.QuerySingleOrDefaultAsync<Order>(
+            "SELECT Id, CustomerId, Status FROM Orders WHERE Id = @OrderId",
+            new { OrderId = orderId });
+    }
+}
+```
+
+Dapper maps columns to properties by name automatically - no configuration needed as long as your query's column names (or aliases) match your class's property names.
+
+### Handling schema, since Dapper won't
+
+Dapper has no migrations system. Pick a dedicated schema migration tool independent of your query layer - DbUp, Fluent Migrator, and Flyway are all common choices - and keep schema changes versioned the same way you'd version anything else, just through a different tool than your query code.
+
+## Core Workflow
+
+### Multi-mapping for joined queries
+
+```csharp
+var sql = """
+    SELECT o.Id, o.Status, c.Id, c.Name
+    FROM Orders o
+    JOIN Customers c ON c.Id = o.CustomerId
+    WHERE o.Id = @OrderId
+    """;
+
+using var connection = connectionFactory.CreateConnection();
+var order = await connection.QueryAsync<Order, Customer, Order>(
+    sql,
+    (order, customer) => { order.Customer = customer; return order; },
+    new { OrderId = orderId },
+    splitOn: "Id");
+```
+
+`splitOn` tells Dapper where one mapped object ends and the next begins in the result set - it's the piece of "configuration" multi-mapping needs, since Dapper can't infer object boundaries from column names alone.
+
+### Writes: parameterized, not string-concatenated
+
+```csharp
+using var connection = connectionFactory.CreateConnection();
+await connection.ExecuteAsync(
+    "UPDATE Orders SET Status = @Status WHERE Id = @OrderId",
+    new { Status = OrderStatus.Shipped, OrderId = orderId });
+```
+
+Always use parameters (`@OrderId`, passed as an anonymous object) rather than string-interpolating values into SQL. This isn't just a style preference - it's the difference between a parameterized query and a SQL injection vulnerability.
+
+### Batching multiple statements in one round trip
+
+```csharp
+using var connection = connectionFactory.CreateConnection();
+var orders = await connection.QueryAsync<Order>(
+    "SELECT * FROM Orders WHERE CustomerId = @CustomerId", new { CustomerId = customerId });
+```
+
+For genuinely bulk inserts or updates, Dapper's `Execute` accepts an `IEnumerable` of parameter objects and batches them efficiently rather than issuing one round trip per row.
+
+## Verifying Your Setup
+
+1. **Queries map correctly** - confirm column aliases match property names, or add explicit aliases where they don't (`SELECT customer_name AS Name`)
+2. **Connections aren't leaking** - confirm every `IDbConnection` is created inside a `using` block, since Dapper won't dispose connections for you
+3. **Parameters are used everywhere, not string interpolation** - audit for any place SQL is being built with string concatenation instead of `@Parameter` placeholders
+4. **Multi-mapped queries split correctly** - for joined queries, confirm `splitOn` is set correctly by checking that nested objects are populated, not null or duplicated
+
+## Best Practices
+
+**Always parameterize, never concatenate.** This is the single non-negotiable rule - string-interpolated SQL is a direct SQL injection risk, and Dapper's anonymous-object parameter syntax makes there no good excuse to skip it.
+
+**Wrap every connection in `using`.** Dapper doesn't manage connection lifecycle, so it's entirely your responsibility to ensure connections are disposed and returned to the pool.
+
+**Keep SQL close to the code that uses it, but out of business logic.** A dedicated repository or query class per feature (especially natural if you're also using [Vertical Slice Architecture](/posts/2026-10-20-getting-started-with-vertical-slice-architecture-dotnet/)) keeps SQL readable without scattering raw strings through unrelated logic.
+
+**Choose a schema migration tool deliberately, don't skip it.** Dapper's lack of built-in migrations doesn't mean schema changes should be undocumented or manual - a lightweight tool like DbUp keeps schema evolution versioned and repeatable.
+
+**Reach for Dapper on specific hot paths, not as a wholesale EF Core replacement, unless your project genuinely doesn't need change tracking or migrations at all.** The EF Core-plus-Dapper hybrid is a common, well-supported pattern precisely because each tool does one part of the job well.
+
+## Comparison with EF Core
+
+| | Dapper | EF Core |
+| --- | --- | --- |
+| Query style | Raw SQL, mapped to objects | LINQ over tracked entities |
+| Change tracking | None | Built in |
+| Migrations | None - bring your own | Built-in, mature |
+| Connection management | Manual, via `using` | Handled by `DbContext` |
+| Best for | Read-heavy paths, reporting, hand-tuned SQL | Domain modeling, schema evolution, most CRUD |
+
+Dapper's speed comes directly from doing less - no change tracking, no query translation layer, no migrations system. That's an advantage on specific performance-sensitive paths and a real gap everywhere else, which is exactly why so many teams use Dapper alongside EF Core rather than instead of it.
+
+## Frequently Asked Questions
+
+### Does Dapper support async?
+
+Yes, throughout - `QueryAsync`, `ExecuteAsync`, `QuerySingleOrDefaultAsync`, and their variants all support async/await, and should be your default over the synchronous equivalents in any ASP.NET Core application.
+
+### How do I prevent SQL injection with Dapper?
+
+Always pass values as parameters using Dapper's anonymous-object syntax (`new { OrderId = orderId }` matched to `@OrderId` in the SQL string), never by concatenating or interpolating user input directly into the query string. This is Dapper's built-in protection, and skipping it defeats the purpose entirely.
+
+### Can Dapper handle complex object graphs with multiple joins?
+
+Yes, via multi-mapping - passing multiple generic type parameters to `QueryAsync` along with a `splitOn` parameter telling Dapper where each object's columns start in the result set. It's more manual than EF Core's navigation properties, but it gives you precise control over exactly what SQL executes.
+
+### Does Dapper support stored procedures?
+
+Yes - pass the procedure name as the SQL text and set `commandType: CommandType.StoredProcedure` in the call. Parameters work the same way as with inline SQL.
+
+### How do I manage database schema changes without EF Core's migrations?
+
+Use a dedicated schema migration tool independent of Dapper itself - DbUp, Fluent Migrator, and Flyway are common choices in the .NET ecosystem. Keep migration scripts versioned in source control the same way you would EF Core migrations, just run through a separate tool.
+
+### Is Dapper actually faster than EF Core in practice?
+
+For complex raw SQL and large result sets, yes, meaningfully. For simple, well-indexed CRUD operations, a properly tuned EF Core query using `AsNoTracking()` often performs within a few percent of Dapper - the performance gap matters most exactly where Dapper's lack of overhead has room to show, not universally.
+
+### Should I write a generic repository wrapper around Dapper?
+
+It's optional and somewhat a matter of team preference. A thin repository per feature or entity keeps SQL organized and testable, but resist making it so generic that it starts re-implementing a mini-ORM - if you find yourself building change tracking or a query builder on top of Dapper, that's usually a sign you actually want a different tool for that specific use case.

--- a/src/posts/2027-03-09-getting-started-with-nhibernate.md
+++ b/src/posts/2027-03-09-getting-started-with-nhibernate.md
@@ -1,0 +1,196 @@
+---
+author: Steve Kaschimer
+date: 2027-03-09
+image: /images/posts/2027-03-09-hero.webp
+image_alt: "A vault-shaped icon representing an expensive singleton session factory, issuing several lightweight ticket-shaped session icons out through a narrow slot."
+image_prompt: "A dark-mode technical editorial illustration on a near-black background with electric teal, amber, and off-white accents. Composition centers on a solid amber vault-shaped outline on the left, heavier and more detailed than everything else in the frame to suggest expense and permanence. From a narrow slot in its side, several small thin teal ticket-shaped rectangles emerge in a fan pattern, each lightweight and identical, representing cheaply issued sessions. Below, a small stack of three labeled config panels sits beside a virtual-keyword glyph (a subtle italic v-shape) marking a required property modifier. Mood is enterprise, deliberate, and slightly heavier than the series' other illustrations. Avoid: vendor logos, brand colors, circuit-board textures, gears, or literal bank-vault-door imagery."
+layout: post.njk
+site_title: Tech Notes
+summary: "NHibernate's maturity is real, but there's genuine configuration depth to learn before it pays off. A setup guide for Fluent mappings, why entities need virtual members, the SessionFactory-as-singleton/Session-per-unit-of-work split, and second-level caching."
+tags: ["dotnet", "orm", "database", "architecture", "tooling"]
+title: "Getting Started with NHibernate in .NET"
+---
+
+NHibernate predates most of the .NET ORM landscape it now gets compared against, and it shows in a good way and a demanding one. The good way: caching, mapping flexibility, and loading control are all mature and battle-tested after over a decade of production use in large enterprise systems. The demanding way: there's real configuration depth to learn before any of that maturity pays off, and skipping straight to "just make it work" produces a setup that fights you the moment your model gets non-trivial.
+
+This guide covers installing NHibernate, bootstrapping session management and mapping the way most production NHibernate codebases actually do it (Fluent NHibernate, not raw XML), the core session and transaction workflow, and the best practices that keep NHibernate's flexibility from turning into accidental complexity. By the end you'll have a setup suited to extending an existing NHibernate codebase or making a deliberate, informed choice to start a new one.
+
+If you're deciding between ORMs first, [a comparison of the top .NET ORMs](/posts/2027-02-16-top-5-dotnet-orms-compared/) covers where NHibernate fits relative to EF Core, Dapper, Linq2Db, and RepoDb - including why it's rarely the recommended default for new, greenfield projects in 2026.
+
+## What You'll Need
+
+- .NET 8 SDK or later
+- A database and its ADO.NET driver
+- Some familiarity with the Unit of Work and Session patterns, since NHibernate's `ISession` is the center of nearly everything you'll do with it
+
+## Installing NHibernate
+
+```bash
+dotnet add package NHibernate
+dotnet add package FluentNHibernate
+```
+
+`FluentNHibernate` gives you a strongly-typed C# mapping API instead of hand-written XML `.hbm.xml` files - it's the standard approach in modern NHibernate codebases and worth using from the start rather than learning XML mapping first.
+
+## Bootstrapping the Ideal Environment
+
+### Define your entities and Fluent mappings
+
+```csharp
+public class Order
+{
+    public virtual int Id { get; protected set; }
+    public virtual Customer Customer { get; set; } = null!;
+    public virtual OrderStatus Status { get; set; }
+}
+```
+
+NHibernate requires entity members to be `virtual` - this is how it generates lazy-loading proxies at runtime. Forgetting this is one of the most common first-time mistakes; the entity will compile and run, but lazy loading and change tracking silently won't work as expected.
+
+```csharp
+public class OrderMap : ClassMap<Order>
+{
+    public OrderMap()
+    {
+        Id(x => x.Id);
+        References(x => x.Customer).Column("CustomerId");
+        Map(x => x.Status).CustomType<OrderStatus>();
+    }
+}
+```
+
+### Build the SessionFactory once, at startup
+
+The `ISessionFactory` is expensive to build and meant to be a singleton - built once at application startup, not per request:
+
+```csharp
+// Program.cs
+var builder = WebApplication.CreateBuilder(args);
+
+var sessionFactory = Fluently.Configure()
+    .Database(MsSqlConfiguration.MsSql2012.ConnectionString(
+        builder.Configuration.GetConnectionString("Default")))
+    .Mappings(m => m.FluentMappings.AddFromAssemblyOf<OrderMap>())
+    .BuildSessionFactory();
+
+builder.Services.AddSingleton(sessionFactory);
+builder.Services.AddScoped(sp => sp.GetRequiredService<ISessionFactory>().OpenSession());
+```
+
+Note the two different lifetimes: `ISessionFactory` is a singleton, but each `ISession` it opens is scoped per request (or per unit of work) - sessions are lightweight and cheap to open, unlike the factory that creates them.
+
+### Schema generation for local development
+
+NHibernate can generate a schema from your mappings, useful for local development and testing:
+
+```csharp
+new SchemaExport(configuration).Create(false, true);
+```
+
+For production, this isn't a substitute for a proper migration strategy - most NHibernate codebases pair it with a dedicated migration tool (Fluent Migrator is common) rather than relying on automatic schema generation against a real database.
+
+## Core Workflow
+
+### Reading and writing within a session
+
+```csharp
+public class OrderRepository(ISession session)
+{
+    public async Task<Order?> GetByIdAsync(int id) =>
+        await session.GetAsync<Order>(id);
+
+    public async Task<Order> ProcessOrderAsync(int orderId)
+    {
+        using var transaction = session.BeginTransaction();
+
+        var order = await session.GetAsync<Order>(orderId)
+            ?? throw new OrderNotFoundException(orderId);
+
+        order.Status = OrderStatus.Processing;
+
+        await transaction.CommitAsync();
+        return order;
+    }
+}
+```
+
+NHibernate tracks changes to loaded entities within a session the same way EF Core does - modifying a loaded entity's properties and committing the transaction is enough; there's no explicit "update" call needed for tracked entities.
+
+### Querying with LINQ or HQL
+
+```csharp
+// LINQ provider
+var activeOrders = await session.Query<Order>()
+    .Where(o => o.Status == OrderStatus.Processing)
+    .ToListAsync();
+
+// HQL, NHibernate's own query language
+var results = await session.CreateQuery(
+    "from Order o where o.Status = :status")
+    .SetParameter("status", OrderStatus.Processing)
+    .ListAsync<Order>();
+```
+
+The LINQ provider is the more approachable entry point for teams coming from EF Core; HQL and the Criteria API offer more control for complex queries once you're comfortable with the basics.
+
+## Verifying Your Setup
+
+1. **Entities have `virtual` members where needed** - confirm lazy-loaded navigation properties and any property NHibernate needs to proxy are marked `virtual`
+2. **SessionFactory is built once** - confirm it's registered as a singleton, not accidentally rebuilt per request, which is expensive and defeats its purpose
+3. **Sessions are properly scoped and disposed** - confirm each request gets its own session and that sessions are disposed at the end of their scope
+4. **Mappings match your schema** - run `SchemaExport` in validation mode against a real database and confirm no mismatches are reported
+
+## Best Practices
+
+**Mark entity members `virtual` deliberately, not by habit alone.** Understand why NHibernate needs it (proxy generation for lazy loading) rather than just following the convention - it clarifies a lot of otherwise-confusing lazy-loading behavior later.
+
+**Keep the SessionFactory a singleton and sessions scoped per unit of work.** Conflating the two lifetimes is a common source of subtle bugs and unnecessary overhead.
+
+**Use Fluent NHibernate mappings over raw XML for new code.** XML `.hbm.xml` files still work and you'll encounter them in older NHibernate codebases, but Fluent mappings are more maintainable and give you compiler-checked property references.
+
+**Configure second-level caching deliberately, not by default.** NHibernate's caching is genuinely powerful for high-read scenarios, but it introduces cache invalidation complexity - turn it on for specific entities where the read pattern justifies it, not globally out of the gate.
+
+**If you're extending an existing NHibernate codebase, follow its existing mapping conventions before introducing new ones.** Consistency across an established codebase's mapping style matters more than which specific convention (Fluent vs. XML, HQL vs. LINQ) is technically "better."
+
+## Comparison with EF Core
+
+| | NHibernate | EF Core |
+| --- | --- | --- |
+| Query style | HQL, Criteria API, LINQ | LINQ over tracked entities |
+| Change tracking | Yes, session-scoped | Yes, context-scoped |
+| Mapping | Fluent NHibernate or XML | Fluent API or data annotations |
+| Caching | Mature first- and second-level caching | Less built-in caching sophistication |
+| Tooling & community | Smaller, more enterprise-focused | Larger, Microsoft-backed, broader resources |
+| Best fit | Existing enterprise codebases | New projects, broader ecosystem support |
+
+The conceptual overlap is real - both are full ORMs with change tracking, both support LINQ, both need something like a session/context per unit of work. The practical difference in 2026 is less about capability gaps (EF Core has closed most of them) and more about which one has the tooling, community, and momentum behind it for a new project.
+
+## Frequently Asked Questions
+
+### Why do my NHibernate entity properties need to be virtual?
+
+NHibernate generates dynamic proxy classes for lazy loading and change tracking, and that proxy generation requires overriding your entity's members - which is only possible if they're `virtual`. A non-virtual property will still compile, but NHibernate can't proxy it, silently breaking lazy loading for that property.
+
+### Is NHibernate still a good choice for a new project in 2026?
+
+Generally not recommended as the default. EF Core has closed most of the feature gap that used to differentiate NHibernate, while offering better tooling integration, Microsoft backing, and a substantially larger community. NHibernate remains a solid choice specifically for extending an existing codebase already built on it.
+
+### What's the difference between HQL and NHibernate's LINQ provider?
+
+HQL (Hibernate Query Language) is NHibernate's own SQL-like query language, offering fine-grained control similar to what the Criteria API provides. The LINQ provider translates standard C# LINQ expressions to SQL, similar in spirit to EF Core's approach, and is generally the more approachable starting point for teams already comfortable with LINQ.
+
+### How does NHibernate's second-level cache work?
+
+The first-level cache is session-scoped and automatic - entities loaded within a session are cached for the duration of that session. The second-level cache is process- or distributed-scoped and configured explicitly per entity, useful for frequently-read, infrequently-changed data. It requires deliberate setup and a cache provider (in-memory, Redis, etc.), and isn't enabled by default.
+
+### Should I use Fluent NHibernate or XML mapping files?
+
+Fluent NHibernate for new code - it gives you compiler-checked, strongly-typed mappings instead of hand-written XML strings that only fail at runtime if wrong. You'll likely encounter XML `.hbm.xml` mappings in older NHibernate codebases, and NHibernate itself continues to support both, so understanding XML mapping is still useful for maintenance work even if you don't choose it for anything new.
+
+### Can I use NHibernate and Dapper together, the way people pair EF Core and Dapper?
+
+Yes, the same hybrid pattern applies - NHibernate for your domain model and change-tracked writes, Dapper for specific reporting or high-throughput read queries where raw SQL control matters more than the ORM's abstraction. You can obtain the underlying `IDbConnection` from an NHibernate session similarly to how you would from an EF Core `DbContext`.
+
+### What's the most common mistake in a first NHibernate setup?
+
+Rebuilding the `ISessionFactory` per request instead of treating it as an expensive, one-time singleton, and forgetting to mark entity members `virtual`, which silently breaks lazy loading in a way that's confusing to diagnose without understanding NHibernate's proxy-based mechanism.

--- a/src/posts/2027-03-16-getting-started-with-linq2db.md
+++ b/src/posts/2027-03-16-getting-started-with-linq2db.md
@@ -1,0 +1,178 @@
+---
+author: Steve Kaschimer
+date: 2027-03-16
+image: /images/posts/2027-03-16-hero.webp
+image_alt: "A teal LINQ query bracket passing cleanly through a narrow funnel with no obstruction into a single SQL statement, with no intermediate tracking layer shown."
+image_prompt: "A dark-mode technical editorial illustration on a near-black background with electric teal, amber, and off-white accents. Composition centers on a thin bracket-shaped LINQ glyph on the left, connected by a clean, unobstructed straight teal line passing directly through a narrow funnel shape in the middle, emerging on the right as a single flat SQL-statement rectangle. No intermediate layer or badge sits along the line, emphasizing the lack of a tracking mechanism. Below, a small 'SET' label rendered as a compact rectangle with an arrow connects directly to a database-row icon, implying a set-based update with no fetch step. Mood is lean, predictable, and direct. Avoid: vendor logos, brand colors, circuit-board textures, gears, or generic database-cylinder clip art."
+layout: post.njk
+site_title: Tech Notes
+summary: "Linq2Db gives you EF Core's most-loved feature - strongly-typed LINQ - without the change tracking, identity map, or unit-of-work machinery. A setup guide for attribute-based mapping, set-based updates, and the adjustment away from EF Core's fetch-mutate-save habit."
+tags: ["dotnet", "orm", "database", "performance", "tooling"]
+title: "Getting Started with Linq2Db in .NET"
+---
+
+Linq2Db occupies an unusual spot in the .NET ORM landscape: it gives you EF Core's most-loved feature - strongly-typed, composable LINQ queries - without the change tracking, identity map, or unit-of-work machinery that comes bundled with a full ORM whether you want it or not. For teams that want LINQ's ergonomics and nothing else, that's the entire pitch, and it's a narrower, more deliberate tool than either EF Core or Dapper.
+
+This guide covers installing Linq2Db, bootstrapping a data connection and mapped entities, the core query and update workflow without change tracking to lean on, and the best practices that keep a Linq2Db data layer predictable as it grows. By the end you'll have a lightweight, fast, strongly-typed query layer that stays honest about exactly what SQL it's generating.
+
+If you're deciding between ORMs first, [a comparison of the top .NET ORMs](/posts/2027-02-16-top-5-dotnet-orms-compared/) covers where Linq2Db fits relative to EF Core, Dapper, NHibernate, and RepoDb.
+
+## What You'll Need
+
+- .NET 8 SDK or later
+- A database and its corresponding Linq2Db provider package
+- Comfort with LINQ, since it's the entire query interface - there's no raw-SQL-first mode the way Dapper has
+
+## Installing Linq2Db
+
+```bash
+dotnet add package linq2db
+dotnet add package linq2db.SqlServer
+```
+
+Linq2Db supports a wide range of database providers - PostgreSQL, MySQL, SQLite, Oracle, and others each have their own provider package following the same `linq2db.<Provider>` naming convention.
+
+## Bootstrapping the Ideal Environment
+
+### Define mapped entities
+
+```csharp
+[Table("Orders")]
+public class Order
+{
+    [PrimaryKey, Identity]
+    public int Id { get; set; }
+
+    [Column]
+    public int CustomerId { get; set; }
+
+    [Column]
+    public OrderStatus Status { get; set; }
+}
+```
+
+Mapping is attribute-based by default, similar in spirit to EF Core's data annotations, though Linq2Db also supports a fluent mapping API if you'd rather keep entities free of Linq2Db-specific attributes.
+
+### Define your data connection
+
+```csharp
+public class AppDataConnection(DataOptions options) : DataConnection(options)
+{
+    public ITable<Order> Orders => this.GetTable<Order>();
+    public ITable<Customer> Customers => this.GetTable<Customer>();
+}
+```
+
+```csharp
+// Program.cs
+var builder = WebApplication.CreateBuilder(args);
+
+var dataOptions = new DataOptions()
+    .UseSqlServer(builder.Configuration.GetConnectionString("Default")!);
+
+builder.Services.AddScoped(_ => new AppDataConnection(dataOptions));
+```
+
+Unlike EF Core's `DbContext`, `DataConnection` is intentionally thin - there's no change tracking or identity map underneath it, so registering it as scoped is mostly about connection lifetime, not about preserving any tracked entity state across calls.
+
+### Schema, the same way as Dapper and RepoDb
+
+Linq2Db has no built-in migrations system. Pair it with a dedicated schema migration tool (DbUp, Fluent Migrator) the same way you would with Dapper or RepoDb, and keep schema changes versioned independently of your query code.
+
+## Core Workflow
+
+### Querying with LINQ, mapped directly to SQL
+
+```csharp
+using var db = new AppDataConnection(dataOptions);
+
+var activeOrders = await db.Orders
+    .Where(o => o.Status == OrderStatus.Processing)
+    .ToListAsync();
+```
+
+Because there's no change tracking layer to translate through, the LINQ-to-SQL mapping in Linq2Db tends to be more predictable and closer to what you'd write by hand than EF Core's, at the cost of not having the automatic dirty-checking EF Core provides.
+
+### Updates: explicit, not automatic
+
+Since there's no change tracking, updates are explicit operations rather than "mutate a tracked entity and call SaveChanges":
+
+```csharp
+using var db = new AppDataConnection(dataOptions);
+
+await db.Orders
+    .Where(o => o.Id == orderId)
+    .Set(o => o.Status, OrderStatus.Shipped)
+    .UpdateAsync();
+```
+
+This set-based update syntax maps directly to a single `UPDATE` statement - no need to fetch the entity first, unlike EF Core's fetch-mutate-save pattern. For scenarios where you do need to fetch first, `InsertOrUpdateAsync` and direct `UpdateAsync(entity)` calls are also available.
+
+### Joins stay in LINQ, translated directly to SQL joins
+
+```csharp
+var results = await db.Orders
+    .Join(db.Customers, o => o.CustomerId, c => c.Id, (o, c) => new { o.Id, o.Status, c.Name })
+    .Where(x => x.Status == OrderStatus.Processing)
+    .ToListAsync();
+```
+
+## Verifying Your Setup
+
+1. **Mappings match your schema** - confirm entity attributes reflect actual column names and types, since there's no runtime schema validation the way `SchemaExport` provides in NHibernate
+2. **Generated SQL is what you expect** - Linq2Db supports logging generated SQL; check it for a few representative queries to confirm the LINQ-to-SQL translation is behaving as intended
+3. **Set-based updates are used where appropriate** - for bulk updates, confirm you're using `Set().UpdateAsync()` rather than fetching and updating each entity individually, which defeats the performance advantage
+4. **Connections are properly scoped** - confirm `DataConnection` instances aren't being held longer than a single unit of work
+
+## Best Practices
+
+**Use set-based updates for bulk or simple property changes.** `db.Orders.Where(...).Set(...).UpdateAsync()` translates to a single efficient `UPDATE` statement - don't fall into an EF Core-style fetch-then-save habit that Linq2Db doesn't need.
+
+**Log generated SQL during development.** Because Linq2Db has less abstraction between LINQ and SQL than EF Core, checking the actual generated queries is quick and catches mapping issues early.
+
+**Don't expect automatic change tracking, and don't try to bolt it on.** If your project genuinely needs change tracking and a full unit-of-work pattern, that's a signal to reconsider whether EF Core is a better fit rather than working around Linq2Db's intentional lack of it.
+
+**Pick a schema migration tool early, the same as you would with Dapper.** Linq2Db doesn't manage schema, and treating that as an afterthought leads to undocumented, ad hoc schema changes.
+
+**Keep entity mapping attributes clean and minimal.** Linq2Db's attribute-based mapping is meant to stay close to the database schema - resist adding business logic or computed properties directly onto mapped entities; keep that in a separate layer.
+
+## Comparison with RepoDb
+
+| | Linq2Db | RepoDb |
+| --- | --- | --- |
+| Query style | Strongly-typed LINQ | Method-based CRUD + raw SQL |
+| Change tracking | None | None |
+| Type safety | Strong - compiler-checked LINQ expressions | Moderate - string-based SQL for anything beyond basic CRUD |
+| Best for | Teams wanting LINQ without ORM overhead | Teams wanting Dapper's speed with less CRUD boilerplate |
+
+Both are micro-ORMs without change tracking, but they optimize for different things: Linq2Db leans into LINQ's compile-time safety and composability, while RepoDb leans into reducing boilerplate for common CRUD operations while still allowing raw SQL when needed. Neither manages schema migrations - that's a deliberate gap in both, not an oversight.
+
+## Frequently Asked Questions
+
+### Does Linq2Db have change tracking like EF Core?
+
+No, deliberately. Linq2Db is closer to a thin LINQ layer over SQL than a full ORM - updates are explicit (set-based updates or direct entity updates), not automatic dirty-checking. This keeps overhead low but means you can't rely on "fetch, mutate, save" the way you would with EF Core.
+
+### How does Linq2Db compare to EF Core in terms of raw performance?
+
+Linq2Db is generally faster than EF Core for equivalent queries, since there's no change tracking or identity map overhead to pay for. The gap is most noticeable on large result sets or high-throughput paths - for small, simple queries the difference is often negligible in absolute terms.
+
+### Can I write raw SQL with Linq2Db when LINQ doesn't fit?
+
+Yes - Linq2Db supports raw SQL execution alongside its LINQ query API for cases where a hand-written query is clearer or more efficient than the LINQ equivalent, similar in spirit to how Dapper works, just available as an escape hatch rather than the primary interface.
+
+### Does Linq2Db support migrations?
+
+No, the same gap Dapper and RepoDb have. Pair it with a dedicated schema migration tool like DbUp or Fluent Migrator, and keep schema evolution versioned independently of your Linq2Db query code.
+
+### Is Linq2Db actively maintained?
+
+Yes, it has an active open-source community and ongoing releases, though its user base and ecosystem are meaningfully smaller than EF Core's or Dapper's. That translates to fewer tutorials and community resources, which is worth factoring into a team's decision alongside its technical merits.
+
+### Why would I choose Linq2Db over Dapper if both lack change tracking?
+
+The main difference is query style - Linq2Db gives you strongly-typed, compiler-checked LINQ expressions that get translated to SQL, while Dapper has you write SQL directly as strings. If you value LINQ's refactor-safety and composability but don't want EF Core's change-tracking overhead, Linq2Db fills that specific niche; if you'd rather write and fully control the SQL yourself, Dapper is the more direct fit.
+
+### What's the most common mistake in a first Linq2Db setup?
+
+Falling into an EF Core-style habit of fetching an entity, mutating it, and looking for a `SaveChanges()` equivalent that doesn't exist. Linq2Db's update model is set-based and explicit by design - learning that pattern early avoids writing code that looks idiomatic but doesn't take advantage of what makes Linq2Db efficient in the first place.

--- a/src/posts/2027-03-23-getting-started-with-repodb.md
+++ b/src/posts/2027-03-23-getting-started-with-repodb.md
@@ -1,0 +1,192 @@
+---
+author: Steve Kaschimer
+date: 2027-03-23
+image: /images/posts/2027-03-23-hero.webp
+image_alt: "A shape split evenly down the middle, one half a compact generated-method icon, the other half a raw SQL bracket glyph, meeting at a shared connector in the center."
+image_prompt: "A dark-mode technical editorial illustration on a near-black background with electric teal, amber, and off-white accents. Composition centers on a single rounded rectangle split cleanly down the vertical middle by a thin hairline: the left half in teal contains four small compact icons representing generated CRUD methods (insert, update, delete, query arrows), the right half in amber contains a raw SQL bracket glyph. Both halves connect to a shared small circular node at the bottom center, implying one underlying connection powering both paths. Mood is balanced, pragmatic, and dual-purpose. Avoid: vendor logos, brand colors, circuit-board textures, gears, or generic database-cylinder clip art."
+layout: post.njk
+site_title: Tech Notes
+summary: "Dapper is fast but leaves you writing the same CRUD SQL repeatedly; EF Core writes it for you at a real cost. A setup guide for RepoDb's generated CRUD methods, the raw-SQL escape hatch, bulk operations, and the bootstrap call that's easy to skip."
+tags: ["dotnet", "orm", "database", "performance", "developer-productivity"]
+title: "Getting Started with RepoDb in .NET"
+---
+
+RepoDb's whole reason for existing is a specific complaint: Dapper is fast but leaves you writing the same CRUD SQL over and over, while EF Core does CRUD for you but at a real performance and abstraction cost. RepoDb sits deliberately between them - generated CRUD methods when you want convenience, raw SQL when you want control, and consistently strong benchmark performance either way.
+
+This guide covers installing RepoDb, bootstrapping connection handling and its code-generation-free mapping approach, the core CRUD and raw-query workflow, and the best practices that make the most of its hybrid design instead of accidentally using it like a slower Dapper. By the end you'll have a fast, low-boilerplate data layer that still gives you an escape hatch to raw SQL whenever you need it.
+
+If you're deciding between ORMs first, [a comparison of the top .NET ORMs](/posts/2027-02-16-top-5-dotnet-orms-compared/) covers where RepoDb fits relative to EF Core, Dapper, NHibernate, and Linq2Db.
+
+## What You'll Need
+
+- .NET 8 SDK or later
+- A database and the corresponding RepoDb extension package
+- The same ADO.NET provider you'd use with Dapper, since RepoDb also works on top of `IDbConnection`
+
+## Installing RepoDb
+
+```bash
+dotnet add package RepoDb
+dotnet add package RepoDb.SqlServer
+```
+
+RepoDb ships a core package plus database-specific extension packages (`RepoDb.SqlServer`, `RepoDb.PostgreSql`, `RepoDb.MySql`, `RepoDb.Sqlite`, and others) that register provider-specific behavior. Call the provider's bootstrap method once at startup:
+
+```csharp
+// Program.cs
+var builder = WebApplication.CreateBuilder(args);
+
+SqlServerBootstrap.Initialize();
+
+builder.Services.AddSingleton<IDbConnectionFactory>(
+    new SqlConnectionFactory(builder.Configuration.GetConnectionString("Default")!));
+```
+
+## Bootstrapping the Ideal Environment
+
+### Define plain entity classes
+
+RepoDb doesn't require attributes, base classes, or a fluent mapping API for basic use - convention-based mapping (matching property names to column names) works out of the box:
+
+```csharp
+public class Order
+{
+    public int Id { get; set; }
+    public int CustomerId { get; set; }
+    public OrderStatus Status { get; set; }
+}
+```
+
+For cases where naming doesn't match, map explicitly:
+
+```csharp
+[Map("tbl_orders")]
+public class Order
+{
+    [Map("order_id")]
+    public int Id { get; set; }
+}
+```
+
+### Connection handling, the same pattern as Dapper
+
+```csharp
+public interface IDbConnectionFactory
+{
+    IDbConnection CreateConnection();
+}
+
+public class SqlConnectionFactory(string connectionString) : IDbConnectionFactory
+{
+    public IDbConnection CreateConnection() => new SqlConnection(connectionString);
+}
+```
+
+RepoDb extends `IDbConnection` the same way Dapper does, so if you're migrating from or pairing with Dapper, the connection lifecycle management is identical - create per unit of work, wrap in `using`.
+
+## Core Workflow
+
+### Generated CRUD methods for the common case
+
+```csharp
+using var connection = connectionFactory.CreateConnection();
+
+var order = await connection.QueryAsync<Order>(o => o.Id == orderId);
+
+var newId = await connection.InsertAsync(new Order { CustomerId = 1, Status = OrderStatus.Pending });
+
+await connection.UpdateAsync(new Order { Id = orderId, Status = OrderStatus.Shipped },
+    o => o.Id == orderId);
+
+await connection.DeleteAsync<Order>(orderId);
+```
+
+This is RepoDb's core value proposition over plain Dapper: the same kind of CRUD you'd otherwise hand-write as SQL strings is available as strongly-typed method calls, without the change-tracking overhead a full ORM would add.
+
+### Raw SQL when you need it
+
+```csharp
+using var connection = connectionFactory.CreateConnection();
+
+var results = await connection.ExecuteQueryAsync<OrderSummary>(
+    """
+    SELECT o.Id, o.Status, c.Name AS CustomerName
+    FROM Orders o
+    JOIN Customers c ON c.Id = o.CustomerId
+    WHERE o.Status = @Status
+    """,
+    new { Status = OrderStatus.Processing });
+```
+
+This is the same Dapper-style raw SQL execution - RepoDb doesn't force you to express everything through its method-based API, which is the point of the hybrid design.
+
+### Bulk operations
+
+```csharp
+using var connection = connectionFactory.CreateConnection();
+
+await connection.InsertAllAsync(newOrders);
+```
+
+`InsertAllAsync`, `UpdateAllAsync`, and `MergeAllAsync` are optimized for bulk operations, generally outperforming issuing individual insert/update calls in a loop.
+
+## Verifying Your Setup
+
+1. **Provider bootstrap ran** - confirm `SqlServerBootstrap.Initialize()` (or the equivalent for your provider) executes once at startup; skipping it causes provider-specific features to silently not work
+2. **Convention-based mapping matches your schema** - for entities without explicit `[Map]` attributes, confirm property names align with actual column names
+3. **Generated CRUD produces expected SQL** - RepoDb supports tracing/logging; check a few queries to confirm the generated SQL matches expectations
+4. **Bulk operations are actually being used for bulk scenarios** - confirm you're not looping individual `InsertAsync` calls where `InsertAllAsync` would be both simpler and faster
+
+## Best Practices
+
+**Use generated CRUD methods for standard operations, raw SQL for anything complex.** That split is the entire point of choosing RepoDb over plain Dapper - lean into both sides rather than defaulting to raw SQL everywhere out of Dapper habit.
+
+**Use the bulk operation methods for anything inserting or updating more than a handful of rows.** `InsertAllAsync` and `UpdateAllAsync` are specifically optimized for this and meaningfully outperform row-by-row loops.
+
+**Enable RepoDb's built-in caching deliberately for read-heavy, infrequently-changing data.** Its `MemoryCache` integration is a real feature worth using where it fits, not something to bolt on reflexively everywhere.
+
+**Keep entity classes plain where possible, and use `[Map]` attributes only where naming conventions don't align.** This keeps the convention-based mapping doing most of the work without unnecessary annotation clutter.
+
+**Pick a schema migration tool, the same as with Dapper or Linq2Db.** RepoDb doesn't manage schema evolution - that's consistently true across every micro-ORM in this series, and needs a separate, deliberate decision.
+
+## Comparison with Dapper
+
+| | RepoDb | Dapper |
+| --- | --- | --- |
+| Query style | Method-based CRUD + raw SQL | Raw SQL only |
+| Boilerplate for common CRUD | Low - generated methods | Higher - every query hand-written |
+| Performance | Comparable to or exceeding Dapper in benchmarks | Consistently fast baseline |
+| Built-in caching | Yes, via MemoryCache integration | No |
+| Community size | Smaller | Larger, more established |
+
+RepoDb is best understood as "what if Dapper generated the boring CRUD for you" - it keeps Dapper's raw SQL escape hatch and connection model while removing the need to hand-write basic insert/update/delete/select statements for straightforward entities.
+
+## Frequently Asked Questions
+
+### How is RepoDb different from Dapper if both lack change tracking?
+
+RepoDb adds generated, strongly-typed CRUD methods (`InsertAsync`, `UpdateAsync`, `DeleteAsync`, `QueryAsync` with expression-based filters) on top of the same raw-SQL-when-you-want-it model Dapper uses. Dapper requires you to hand-write SQL for every operation, including simple ones; RepoDb only requires it for queries complex enough to need it.
+
+### Do I need to call a bootstrap method before using RepoDb?
+
+Yes, for most providers - something like `SqlServerBootstrap.Initialize()` needs to run once at application startup to register provider-specific behavior. Skipping it is a common cause of confusing runtime errors that look unrelated to the actual missing step.
+
+### Does RepoDb support migrations?
+
+No - like Dapper and Linq2Db, schema management is left entirely to you. Pair it with a dedicated migration tool such as DbUp or Fluent Migrator, and keep schema changes versioned independently of your RepoDb query and CRUD code.
+
+### Is RepoDb actually faster than Dapper?
+
+Benchmarks frequently show RepoDb matching or slightly exceeding Dapper's performance, particularly for its generated CRUD operations and bulk methods. The practical difference for most applications is smaller than raw benchmark numbers suggest - the bigger win is usually reduced boilerplate, not a dramatic performance gap.
+
+### Can I mix RepoDb's generated methods with raw SQL in the same project?
+
+Yes, and that's the intended usage pattern - use generated CRUD methods (`InsertAsync`, `UpdateAsync`, expression-based `QueryAsync`) for straightforward operations, and drop into `ExecuteQueryAsync` with raw SQL for anything complex enough that the generated API doesn't fit cleanly.
+
+### Is RepoDb mature enough for production use?
+
+Yes, it's used in production systems, though with a meaningfully smaller community than EF Core or Dapper. That means fewer tutorials, less third-party tooling, and a smaller pool of developers already familiar with it - a reasonable trade-off for many teams, but worth weighing against the two more established options.
+
+### What's the most common mistake in a first RepoDb setup?
+
+Forgetting to call the provider's bootstrap method at startup, and treating RepoDb exactly like Dapper by hand-writing raw SQL for everything - which works, but skips the reduced-boilerplate CRUD methods that are RepoDb's main advantage over plain Dapper in the first place.


### PR DESCRIPTION
## Summary

Drafts the complete six-post .NET ORMs Tuesday track, closing out the .NET Tuesday-track sequence (Architecture Patterns -> Logging Frameworks -> Testing Frameworks -> ORMs):

- **The Top 5 .NET ORMs Compared: Which One Should You Choose?** (2027-02-16) - the anchor comparison post: EF Core, Dapper, NHibernate, Linq2Db, and RepoDb across category, query style, change tracking, migrations, performance, and maintainer. The recurring argument: "pick one" is often the wrong framing - EF Core for the domain and migrations, Dapper on specific read paths, is a widely supported hybrid pattern, not a compromise.
- **Getting Started with EF Core in .NET** (2027-02-23) - the provider/design-time package split, migrations across multi-project solutions, `IDesignTimeDbContextFactory<T>` as a fallback, and `AsNoTracking()` as the default habit for reads.
- **Getting Started with Dapper in .NET** (2027-03-02) - a DI-registered connection factory, multi-mapping joined queries with `splitOn`, parameterization as the one non-negotiable rule, and pairing Dapper with a real migration tool.
- **Getting Started with NHibernate in .NET** (2027-03-09) - Fluent NHibernate mappings, why entity members must be `virtual`, the `ISessionFactory`-as-singleton/`ISession`-per-unit-of-work split, and second-level caching as a deliberate per-entity decision.
- **Getting Started with Linq2Db in .NET** (2027-03-16) - attribute-based mapping, set-based updates (`Where().Set().UpdateAsync()`) instead of EF Core's fetch-mutate-save habit, and the honest trade-off of a smaller community.
- **Getting Started with RepoDb in .NET** (2027-03-23) - the provider bootstrap call that's easy to skip, generated CRUD methods vs. `ExecuteQueryAsync` for anything complex, and bulk operations that beat row-by-row loops.

All six were adapted from the already-complete drafts in `docs/article-ideas/`, following the same "Top 5 X Compared" / "Getting Started with X" structure established by the AI Coding Agents, .NET Architecture Patterns, .NET Logging Frameworks, and .NET Testing Frameworks tracks - comparison tables, strengths/weaknesses/choose-this-when, FAQ sections, cross-links back to the anchor post. The Dapper post also links forward to the existing Vertical Slice Architecture post where it mentions pairing SQL-per-feature with that pattern.

Also updates `editorial-plan.md` status/file for all six entries.

None of the six posts have hero images yet - those will follow in a separate commit once generated via ChatGPT from each post's `image_prompt` field.

## Test plan

- [x] `npm run deploy` builds cleanly for all six new posts
- [x] Cross-links from each setup guide back to the anchor comparison post (and the one forward-link to Vertical Slice Architecture) verified to resolve
- [x] `node scripts/a11y-check.js` - no accessibility violations (home/post/about/privacy/terms/404, light + dark)
- [ ] Hero images to follow once generated


---
_Generated by [Claude Code](https://claude.ai/code/session_01WKyNF7L5qzrfct8cec6A32)_