### PR TITLE
Add .NET API Styles Tuesday track (6 posts)

### DIFF
--- a/editorial-plan.md
+++ b/editorial-plan.md
@@ -818,17 +818,69 @@ Six posts on .NET data access, closing out the Tuesday cadence. A comparison pos
 
 ---
 
+## 📅 Tuesday Track - .NET API Styles (March-May 2027)
+
+Six posts on how a .NET service talks to the outside world, picking up the Tuesday cadence directly from the ORMs track. A comparison post anchors the track and each of the five follow-ups is a complete setup for one API style.
+
+### The Top 5 .NET API Styles Compared: Which One Should You Choose?
+- **Status:** `draft`
+- **Scheduled:** 2027-03-30
+- **Source:** `docs/article-ideas/top-5-dotnet-api-styles-compared.md`
+- **File:** `src/posts/2027-03-30-top-5-dotnet-api-styles-compared.md`
+- **Pitch:** "REST API" has quietly stopped being the only answer to how a service talks to the outside world. Minimal APIs and Controllers are two flavors of the same idea, while gRPC, GraphQL, and SignalR each exist because REST is the wrong shape for a specific problem.
+- **Angle:** Argues this isn't a ranking, it's a match between protocol and problem - fixed response shapes over HTTP, binary RPC between services you control, client-specified queries, or server-initiated push. Makes Minimal APIs the default for new projects (Microsoft's own recommendation) while keeping Controllers as a real answer for large APIs with a mature filter and binding ecosystem. Closes on the point that most production systems combine several of these rather than picking one, so the useful question is per-endpoint, not per-system.
+- **Tags:** `dotnet`, `api-design`, `architecture`, `performance`, `developer-productivity`
+
+### Getting Started with Minimal APIs in .NET
+- **Status:** `draft`
+- **Scheduled:** 2027-04-06
+- **Source:** `docs/article-ideas/getting-started-with-minimal-apis.md`
+- **File:** `src/posts/2027-04-06-getting-started-with-minimal-apis.md`
+- **Pitch:** Minimal APIs make the first ten minutes genuinely trivial. The part that doesn't show up in a quickstart is what happens once forty of those route calls are sitting in Program.cs without a deliberate organizational strategy.
+- **Angle:** Covers route groups and per-feature extension methods as the antidote to a sprawling Program.cs, OpenAPI documentation set up from day one rather than retrofitted, and validation wired through an endpoint filter instead of ad hoc per-handler checks. Argues against re-implementing Controllers' full ceremony on top of Minimal APIs - if that's what a project needs, Controllers is probably the better fit outright.
+- **Tags:** `dotnet`, `api-design`, `developer-productivity`, `tooling`
+
+### Getting Started with Controllers (MVC) in .NET
+- **Status:** `draft`
+- **Scheduled:** 2027-04-13
+- **Source:** `docs/article-ideas/getting-started-with-controllers-mvc.md`
+- **File:** `src/posts/2027-04-13-getting-started-with-controllers-mvc.md`
+- **Pitch:** More than a decade of accumulated Controllers conventions are exactly why large APIs still reach for the pattern even with Minimal APIs now the recommended default. The tricky part is knowing which conventions still earn their keep.
+- **Angle:** Covers the `--use-controllers` flag current templates now require, what `[ApiController]` actually does (automatic model validation, binding source inference, problem-details error responses - not just a marker attribute), FluentValidation auto-validation as an alternative to DataAnnotations, and filters as Controllers' clearest structural advantage over Minimal API endpoint filters. Draws a clean line between middleware and filters, since conflating the two is a common source of confusion.
+- **Tags:** `dotnet`, `api-design`, `developer-productivity`, `tooling`
+
+### Getting Started with GraphQL (Hot Chocolate) in .NET
+- **Status:** `draft`
+- **Scheduled:** 2027-04-20
+- **Source:** `docs/article-ideas/getting-started-with-graphql-hotchocolate.md`
+- **File:** `src/posts/2027-04-20-getting-started-with-graphql-hotchocolate.md`
+- **Pitch:** GraphQL's promise - clients ask for exactly the fields they need, nested across related entities - is also exactly what makes a naive first implementation slow. The N+1 query problem is the trap, and DataLoaders are the fix.
+- **Angle:** Covers Hot Chocolate's code-first schema with `[UseProjection]`/`[UseFiltering]`/`[UseSorting]` translating client queries directly into efficient EF Core queries, then builds a DataLoader step by step to show exactly what problem it solves - one batched query instead of one per related entity. Treats query depth and complexity limits as a day-one requirement, not a hardening pass, since GraphQL's flexibility is also an unbounded cost model until it's constrained.
+- **Tags:** `dotnet`, `api-design`, `graphql`, `performance`, `architecture`
+
+### Getting Started with SignalR in .NET
+- **Status:** `draft`
+- **Scheduled:** 2027-04-27
+- **Source:** `docs/article-ideas/getting-started-with-signalr.md`
+- **File:** `src/posts/2027-04-27-getting-started-with-signalr.md`
+- **Pitch:** SignalR's basic setup is genuinely simple. The part that catches people off guard is everything that happens the moment a second server instance joins the deployment and a backplane isn't there yet.
+- **Angle:** Builds a Hub with group management, then makes the more common real-world case - pushing updates from application services via `IHubContext<T>` rather than waiting on client-initiated Hub methods - the default pattern rather than an aside. Covers the Redis backplane as a one-line fix for a bug that otherwise has no error message, just clients silently missing updates depending on which instance they're connected to. Explicit throughout that SignalR complements a REST/GraphQL/gRPC API rather than replacing one.
+- **Tags:** `dotnet`, `api-design`, `real-time`, `architecture`, `devops`
+
+### Getting Started with gRPC in .NET
+- **Status:** `draft`
+- **Scheduled:** 2027-05-04
+- **Source:** `docs/article-ideas/getting-started-with-grpc-dotnet.md`
+- **File:** `src/posts/2027-05-04-getting-started-with-grpc-dotnet.md`
+- **Pitch:** gRPC asks you to design the contract in a .proto file before writing any C# at all. That inversion is where its compile-time safety across services comes from, and it's also where most of the initial friction sits coming from REST's "just write a handler" habit.
+- **Angle:** Covers the proto-first workflow, why Kestrel needs HTTP/2 (and TLS, even locally, since there's no clear-text protocol negotiation for a dual-protocol endpoint), unary calls versus server/client/bidirectional streaming, and sharing a single .proto file via a common project reference so contract drift becomes a build error instead of a runtime surprise. Scopes gRPC explicitly to internal service-to-service communication, not public or browser-facing APIs, since that's the one decision most first attempts get wrong.
+- **Tags:** `dotnet`, `api-design`, `grpc`, `performance`, `microservices`
+
+---
+
 ## 📅 Backlog - Unscheduled Series
 
-Twelve six-post series remain unscheduled, drawn from the drafts in `docs/article-ideas/`. They continue the Tuesday cadence once the ORM series ends on 2027-03-23, and they're listed here in priority order. They're deliberately undated - that horizon is too far out to put honest dates against - so each series gets one entry rather than six speculative ones, and entries are expanded into individual dated posts when a series moves onto the calendar.
-
-### .NET API Styles (6 posts)
-- **Status:** `idea`
-- **Source:** `docs/article-ideas/top-5-dotnet-api-styles-compared.md` + 5 getting-started drafts
-- **Series:** Top 5 comparison, then Minimal APIs, Controllers (MVC), GraphQL (Hot Chocolate), SignalR, gRPC
-- **Pitch:** "REST API" has quietly stopped being the only answer to how a service talks to the outside world. Minimal APIs and Controllers are two flavors of the same idea, while gRPC, GraphQL, and SignalR each exist because REST is the wrong shape for a specific problem.
-- **Angle:** The comparison argues this isn't a ranking, it's a match between protocol and problem - fixed response shapes over HTTP, binary RPC between services you control, client-specified queries, or server-initiated push. It makes Minimal APIs the default for new projects (Microsoft's own recommendation) while keeping Controllers as a real answer for large APIs with a mature filter and binding ecosystem. The closing argument is that most production systems combine several of these rather than picking one, so the useful question is per-endpoint, not per-system.
-- **Tags:** `dotnet`, `api-design`, `architecture`, `performance`, `developer-productivity`
+Eleven six-post series remain unscheduled, drawn from the drafts in `docs/article-ideas/`. They continue the Tuesday cadence once the .NET API Styles series ends on 2027-05-04, and they're listed here in priority order. They're deliberately undated - that horizon is too far out to put honest dates against - so each series gets one entry rather than six speculative ones, and entries are expanded into individual dated posts when a series moves onto the calendar.
 
 ### .NET Validation Approaches (6 posts)
 - **Status:** `idea`

--- a/src/posts/2027-03-30-top-5-dotnet-api-styles-compared.md
+++ b/src/posts/2027-03-30-top-5-dotnet-api-styles-compared.md
@@ -1,0 +1,164 @@
+---
+author: Steve Kaschimer
+date: 2027-03-30
+image: /images/posts/2027-03-30-hero.webp
+image_alt: "Five columns of abstract API-style glyphs positioned along a horizontal axis running from request-response simplicity on the left to real-time push on the right."
+image_prompt: "A dark-mode technical editorial illustration on a near-black background with electric teal, amber, and off-white accents. Composition is five vertical columns of equal width separated by thin hairline rules, each column topped by a distinct abstract glyph rendered in flat geometry: a minimal single-arrow request-response glyph, a layered rectangle stack representing structured routing, a solid amber lightning-bolt glyph inside a narrow channel implying binary speed, a flexible bracket shape with several thin branches fanning out to represent selectable fields, and a pulsing broadcast-wave glyph radiating from a small central dot. Beneath the glyphs, a shared horizontal axis labeled in monospaced type runs from 'request-response' on the left to 'real-time push' on the right, with a small glowing teal dot positioned at a different point under each column. Mood is comparative, engineering-first, and non-partisan. Avoid: vendor logos, brand colors, circuit-board textures, robot faces, or generic gear clip art used as the dominant motif."
+layout: post.njk
+site_title: Tech Notes
+summary: "Minimal APIs, Controllers, gRPC, GraphQL, and SignalR all answer a different question about how a client should talk to your backend. A practical breakdown of what each optimizes for and when the default isn't the right call."
+tags: ["dotnet", "api-design", "architecture", "performance", "developer-productivity"]
+title: "The Top 5 .NET API Styles Compared: Which One Should You Choose?"
+---
+
+Every .NET API decision eventually collapses into the same question: what does the client actually need from this endpoint - a simple request-response, structured conventions at scale, raw speed between services, exactly the fields it asks for, or a live push the moment something changes? That's the axis these five styles sit on. Minimal APIs and Controllers both answer "request-response," just with different amounts of built-in structure. gRPC trades flexibility for speed between services that don't need a browser. GraphQL lets the client shape the response instead of the server dictating it. SignalR isn't really a REST alternative at all - it's for real-time push, a different problem entirely.
+
+This guide compares the five API styles .NET developers reach for most often, what each one actually optimizes for, and which project profile fits best. None of these are mutually exclusive within a single application - a typical production system might expose Minimal API or Controller endpoints for its public REST surface, gRPC between internal services, and SignalR for one specific real-time feature, all in the same solution. This series continues with dedicated getting-started walkthroughs for each style.
+
+## Quick Comparison
+
+| | Minimal APIs | Controllers (MVC) | gRPC | GraphQL (Hot Chocolate) | SignalR |
+| --- | --- | --- | --- | --- | --- |
+| **Category** | Lightweight REST | Conventions-based REST | RPC over HTTP/2 | Query language over HTTP | Real-time push |
+| **Transport** | HTTP/1.1 or HTTP/2, JSON | HTTP/1.1 or HTTP/2, JSON | HTTP/2, Protobuf | HTTP/1.1 or HTTP/2, JSON | WebSockets (with fallbacks) |
+| **Client flexibility** | Server dictates response shape | Server dictates response shape | Server dictates message shape | Client selects exactly the fields it wants | N/A - push-based, not request-driven |
+| **Performance** | Good, low ceremony | Good, more middleware overhead than Minimal APIs | Fastest - binary serialization, HTTP/2 multiplexing | Good, but resolver-per-field cost adds up without care | Efficient for its purpose; needs a backplane past one instance |
+| **Browser support** | Full | Full | None without gRPC-Web + a proxy | Full | Full |
+| **Best for** | New REST APIs, especially smaller or greenfield services | Large REST APIs benefiting from established conventions | Internal service-to-service calls, latency-sensitive paths | Client-driven data needs, avoiding over/under-fetching | Live updates, notifications, chat, dashboards |
+
+## Minimal APIs
+
+Minimal APIs are Microsoft's current recommended default for new ASP.NET Core REST APIs - a lightweight, low-ceremony way to define HTTP endpoints without the conventions and infrastructure a full MVC controller pipeline brings along.
+
+**Strengths:**
+
+- Low ceremony - a working endpoint is a few lines, with no controller class, action method, or attribute routing boilerplate required
+- Route groups and per-feature extension methods (`MapOrderEndpoints`) keep a growing API organized without falling back to MVC's conventions
+- First-class OpenAPI support via `Microsoft.AspNetCore.OpenApi`, and validation wires in cleanly through custom endpoint filters
+- Fast to start with, and the template Microsoft ships by default for new Web API projects
+
+**Weaknesses:**
+
+- Less built-in structure than Controllers - model binding, validation, and filtering conventions are things you assemble yourself rather than inherit for free
+- Fewer years of established community patterns to lean on compared to MVC's long history, though this gap is closing fast
+- A very large API with many endpoints can end up needing the same kind of organizational discipline Controllers give you by default, just self-imposed instead of framework-enforced
+
+**Choose this when:** you're starting a new REST API and don't have a large existing MVC codebase or team convention pulling you toward Controllers - it's the more modern default in 2026, not just the newer option.
+
+## Controllers (MVC)
+
+Controllers are the original ASP.NET Core web API pattern, and remain the right choice for large APIs that benefit from `[ApiController]`'s built-in conventions - automatic model validation, binding source inference, and consistent problem-details error responses - without having to reconstruct them by hand.
+
+**Strengths:**
+
+- `[ApiController]` gives you automatic model validation, binding source inference, and standardized error responses out of the box
+- Filters (`IActionFilter` and friends) provide a mature, well-understood cross-cutting concerns mechanism distinct from middleware
+- Deep, long-established community knowledge and tooling, since this has been the default ASP.NET Core API pattern since the framework's earliest versions
+- Conventions scale well to large teams and large APIs, where consistent structure across many endpoints matters more than minimizing per-endpoint ceremony
+
+**Weaknesses:**
+
+- More ceremony per endpoint than Minimal APIs - a controller class and action method for what might be a five-line Minimal API handler
+- New ASP.NET Core project templates default to Minimal APIs now, so scaffolding Controllers requires an explicit flag (`dotnet new webapi --use-controllers`) rather than being the default path
+- The conventions that pay off at scale can feel like unnecessary structure on a small service with a handful of endpoints
+
+**Choose this when:** you have a large REST API, an existing MVC codebase, or a team that values `[ApiController]`'s established conventions over Minimal APIs' lighter footprint.
+
+## gRPC
+
+gRPC is a binary RPC framework built on HTTP/2 and Protocol Buffers, designed for fast, strongly-typed communication between services - not for talking to a browser directly.
+
+**Strengths:**
+
+- Fastest option here by a clear margin - binary Protobuf serialization plus HTTP/2 multiplexing beats JSON-over-HTTP/1.1 for both payload size and connection efficiency
+- Strongly-typed contracts via `.proto` files, shared across client and server through a common project reference, which keeps them from drifting apart
+- Native support for streaming RPCs (client, server, and bidirectional), a capability none of the request-response styles here have built in
+- `RpcException`/`StatusCode` gives you a structured, consistent error-handling model across every RPC
+
+**Weaknesses:**
+
+- No browser support without gRPC-Web plus a compatible proxy - genuinely not an option for a public API a frontend calls directly
+- Requires HTTP/2 and TLS even for local development, since Kestrel needs both to negotiate the protocol on a dual-purpose endpoint
+- Protobuf's binary format isn't human-readable on the wire, which makes ad hoc debugging less convenient than inspecting a JSON payload
+
+**Choose this when:** you're building internal service-to-service communication where every service is under your control and browsers aren't in the picture - it's the wrong tool for a public-facing API a frontend calls directly.
+
+## GraphQL (Hot Chocolate)
+
+GraphQL, via the Hot Chocolate library, lets the client specify exactly which fields it wants in a single request, instead of the server dictating a fixed response shape the way REST and gRPC both do.
+
+**Strengths:**
+
+- Clients request exactly the fields they need, eliminating both over-fetching (getting fields you don't use) and under-fetching (needing a second request for related data)
+- A single `/graphql` endpoint replaces a proliferation of REST endpoints tailored to specific client views
+- `[UseProjection]`/`[UseFiltering]`/`[UseSorting]` push those concerns down to the database query itself rather than requiring hand-written variants per use case
+- Banana Cake Pop, Hot Chocolate's built-in IDE, gives you interactive schema exploration without needing a separate API client
+
+**Weaknesses:**
+
+- The N+1 query problem is a real, common pitfall - resolving a list of parent entities and then a related field per item can silently issue one query per item unless you use a `DataLoader` to batch them
+- Needs deliberate cost and depth limiting (`AddMaxExecutionDepthRule`, paging options) or a client can construct a query that's expensive to resolve
+- A steeper conceptual learning curve than REST for teams unfamiliar with resolvers, the N+1 problem, and schema-first thinking
+
+**Choose this when:** your clients have genuinely varied data needs - different views need different shapes of the same underlying data - and you're willing to take on resolver design and query-cost limiting as an ongoing concern, not a one-time setup step.
+
+## SignalR
+
+SignalR is ASP.NET Core's real-time communication library, built on WebSockets (with automatic fallback transports) for pushing updates to connected clients the moment something happens - not a REST, GraphQL, or gRPC replacement, but a different category of problem.
+
+**Strengths:**
+
+- Purpose-built for real-time push - live dashboards, notifications, chat, collaborative features - where polling would be wasteful or too slow
+- `IHubContext<T>` lets any part of your application push updates to connected clients, not just code running inside a Hub method itself
+- Client libraries (JavaScript, .NET, and others) include automatic reconnection handling out of the box
+- Falls back gracefully to other transports when WebSockets aren't available, without changing your application code
+
+**Weaknesses:**
+
+- Requires a Redis backplane (`Microsoft.AspNetCore.SignalR.StackExchangeRedis`) the moment you run more than one server instance - and forgetting it fails silently, with some clients simply missing updates rather than throwing an error
+- Solves a fundamentally different problem than REST/GraphQL/gRPC, so it's additive to an API surface, not a replacement for it
+- Persistent connections carry real infrastructure cost at scale - connection count and server affinity become operational concerns REST endpoints don't have
+
+**Choose this when:** you have a genuine real-time push requirement - clients need to know about a change the moment it happens, not on their next poll - and you're prepared to add a backplane before scaling past one instance.
+
+## How to Decide
+
+A few heuristics that cover most real-world decisions:
+
+**Starting a new REST API with no strong reason to deviate?** Minimal APIs are the modern default - lower ceremony, first-class OpenAPI support, and what the project templates scaffold now.
+
+**Have a large existing MVC codebase, or a team that values `[ApiController]`'s conventions?** Stick with Controllers - the structure pays for itself at scale, and there's no compelling reason to migrate a working large API just to reduce per-endpoint ceremony.
+
+**Building service-to-service communication with no browser in the picture?** gRPC's performance and strongly-typed contracts are worth the setup cost, provided every caller is a service you control, not a public frontend.
+
+**Clients need meaningfully different shapes of the same data?** GraphQL earns its complexity when over- and under-fetching are real, recurring problems - not just theoretically possible ones.
+
+**Need to push updates to clients the moment something changes?** SignalR is the tool, but budget for a Redis backplane before your first horizontal scale-out, not after clients start silently missing messages.
+
+None of these are exclusive choices within a single application - REST (Minimal APIs or Controllers) for your public surface, gRPC between internal services, and SignalR for one specific real-time feature can all coexist in the same solution without conflict.
+
+## Frequently Asked Questions
+
+### Should new ASP.NET Core projects use Minimal APIs or Controllers?
+
+Minimal APIs are Microsoft's current recommended default for new REST APIs, and what the project templates scaffold unless you pass `--use-controllers`. Controllers remain the right call for large APIs or teams that specifically want `[ApiController]`'s built-in conventions - it's not that Controllers are deprecated, just that Minimal APIs are the newer, lighter-weight starting point.
+
+### Can gRPC be called directly from a browser?
+
+Not without gRPC-Web plus a compatible proxy to translate between what browsers can actually send and gRPC's native HTTP/2 framing. For a public API a frontend calls directly, REST or GraphQL are the practical choices; reserve gRPC for service-to-service calls where every caller is under your control.
+
+### What's the N+1 problem in GraphQL, and how do I fix it?
+
+It happens when resolving a list of parent entities, then a related field on each one, issues one database query per item instead of a single batched query. Hot Chocolate's `DataLoader` fixes this by batching those per-item lookups into a single query within the same request, and it's a pattern you'll need on essentially any non-trivial GraphQL schema, not an edge case.
+
+### Why did my SignalR app silently stop delivering messages to some clients?
+
+Almost always a missing Redis backplane after scaling to more than one server instance. Without it, a message sent from one instance only reaches clients connected to that same instance - there's no error, just some clients quietly missing updates. Adding `AddStackExchangeRedis(...)` is the fix, and it's worth doing before your first scale-out, not after you notice the symptom.
+
+### Do I need HTTPS for gRPC even during local development?
+
+Yes - Kestrel requires HTTP/2 and TLS to negotiate a gRPC connection on a dual-purpose endpoint, since there's no clear-text protocol negotiation path available. This trips people up in local development more than production, where TLS is already a given.
+
+### Is SignalR a replacement for GraphQL subscriptions?
+
+Not a general-purpose replacement, but they overlap for real-time use cases. SignalR is a dedicated real-time library with broader adoption and a simpler mental model for pure push scenarios; GraphQL subscriptions integrate real-time updates into an existing GraphQL schema, which is more natural if you're already using GraphQL for the rest of your API and want events to flow through the same client.

--- a/src/posts/2027-04-06-getting-started-with-minimal-apis.md
+++ b/src/posts/2027-04-06-getting-started-with-minimal-apis.md
@@ -1,0 +1,200 @@
+---
+author: Steve Kaschimer
+date: 2027-04-06
+image: /images/posts/2027-04-06-hero.webp
+image_alt: "A layered rectangle stack representing per-feature route groups, each labeled section connecting to a single narrow endpoint channel with no controller class icon in sight."
+image_prompt: "A dark-mode technical editorial illustration on a near-black background with electric teal, amber, and off-white accents. Composition centers on a small stack of three thin labeled rectangles representing per-feature route groups, each connected by a short teal line converging into a single narrow endpoint channel on the right. Below, a small filter-funnel icon sits beside a compact validation checkmark badge, representing an endpoint filter. Mood is lean, modern, and low-ceremony. Avoid: vendor logos, brand colors, circuit-board textures, gears, or a class-diagram box as the dominant motif."
+layout: post.njk
+site_title: Tech Notes
+summary: "Minimal APIs are Microsoft's recommended default for new ASP.NET Core REST APIs in 2026. A setup guide for route groups that keep a growing API organized, OpenAPI wiring, and validation through a reusable endpoint filter."
+tags: ["dotnet", "api-design", "developer-productivity", "tooling"]
+title: "Getting Started with Minimal APIs in .NET"
+---
+
+Minimal APIs are the leaner of the two REST styles ASP.NET Core offers, and Microsoft's recommended default for new projects - `dotnet new webapi` scaffolds them unless you explicitly opt into Controllers. The pitch is straightforward: fewer classes, less ceremony, an endpoint that's a few lines of code. The part that trips people up isn't the basics, it's what happens once you have more than a handful of endpoints and `Program.cs` starts sprawling.
+
+This guide covers installing and scaffolding a Minimal API project, organizing endpoints with route groups and per-feature extension methods before `Program.cs` becomes unmanageable, wiring up OpenAPI documentation, and adding validation through a reusable endpoint filter. By the end you'll have a setup that stays organized as it grows, not just a working "hello world" endpoint.
+
+If you're deciding between API styles first, [a comparison of the top .NET API styles](/posts/2027-03-30-top-5-dotnet-api-styles-compared/) covers where Minimal APIs fit relative to Controllers, gRPC, GraphQL, and SignalR.
+
+## What You'll Need
+
+- .NET 8 SDK or later
+- Basic familiarity with ASP.NET Core's dependency injection and hosting model
+- No prior Minimal API experience required - the whole point is that there's less to learn upfront than Controllers
+
+## Scaffolding a Minimal API Project
+
+```bash
+dotnet new web
+```
+
+`dotnet new web` gives you the bare Minimal API template. If you've used `dotnet new webapi` before and got Controllers instead, that's because the webapi template now defaults to Minimal APIs too - `--use-controllers` is what opts back into MVC.
+
+## Bootstrapping the Ideal Environment
+
+### Start simple, then reach for route groups
+
+A handful of endpoints directly in `Program.cs` is fine at first:
+
+```csharp
+var builder = WebApplication.CreateBuilder(args);
+var app = builder.Build();
+
+app.MapGet("/orders/{id}", (int id) => Results.Ok(new { id, status = "Processing" }));
+app.MapPost("/orders", (CreateOrderRequest request) => Results.Created($"/orders/{1}", request));
+
+app.Run();
+```
+
+This is exactly where Minimal APIs earn their reputation for low ceremony - and exactly where a growing API starts to sprawl if every endpoint lives directly in `Program.cs`. The fix is route groups combined with per-feature extension methods, not abandoning Minimal APIs for Controllers.
+
+### Organize with route groups and extension methods
+
+```csharp
+public static class OrderEndpoints
+{
+    public static RouteGroupBuilder MapOrderEndpoints(this RouteGroupBuilder group)
+    {
+        group.MapGet("/{id}", GetOrder);
+        group.MapPost("/", CreateOrder);
+        return group;
+    }
+
+    private static async Task<IResult> GetOrder(int id, AppDbContext db) =>
+        await db.Orders.FindAsync(id) is { } order
+            ? Results.Ok(order)
+            : Results.NotFound();
+
+    private static async Task<IResult> CreateOrder(CreateOrderRequest request, AppDbContext db)
+    {
+        var order = new Order { CustomerId = request.CustomerId };
+        db.Orders.Add(order);
+        await db.SaveChangesAsync();
+        return Results.Created($"/orders/{order.Id}", order);
+    }
+}
+```
+
+```csharp
+// Program.cs
+app.MapGroup("/orders").MapOrderEndpoints();
+```
+
+Each feature gets its own extension method and, typically, its own file - `OrderEndpoints.cs`, `CustomerEndpoints.cs` - which keeps `Program.cs` as a short list of `MapGroup(...).MapXEndpoints()` calls no matter how large the API grows.
+
+### Wire up OpenAPI documentation
+
+```bash
+dotnet add package Microsoft.AspNetCore.OpenApi
+```
+
+```csharp
+// Program.cs
+builder.Services.AddOpenApi();
+
+var app = builder.Build();
+app.MapOpenApi();
+```
+
+`AddOpenApi()`/`MapOpenApi()` gives you a generated OpenAPI document without a third-party package - useful on its own, and a prerequisite if you want to point a UI like Swagger UI or Scalar at your API.
+
+## Core Workflow
+
+### Handler-parameter dependency injection, not constructors
+
+Minimal API handlers resolve dependencies as method parameters rather than through a constructor:
+
+```csharp
+private static async Task<IResult> GetOrder(int id, AppDbContext db, ILogger<Program> logger)
+{
+    logger.LogInformation("Fetching order {OrderId}", id);
+    return await db.Orders.FindAsync(id) is { } order
+        ? Results.Ok(order)
+        : Results.NotFound();
+}
+```
+
+There's no constructor to wire up - the framework resolves `AppDbContext` and `ILogger<Program>` from DI automatically based on the parameter types, the same way MVC model binding resolves route and query parameters.
+
+### Validation through a reusable endpoint filter
+
+Minimal APIs don't get `[ApiController]`'s automatic model validation for free - you add it deliberately, once, as a reusable filter:
+
+```csharp
+public static class ValidationFilterExtensions
+{
+    public static RouteHandlerBuilder WithValidation<T>(this RouteHandlerBuilder builder) =>
+        builder.AddEndpointFilter(async (context, next) =>
+        {
+            var validator = context.HttpContext.RequestServices.GetRequiredService<IValidator<T>>();
+            var argument = context.Arguments.OfType<T>().First();
+            var result = await validator.ValidateAsync(argument);
+
+            return result.IsValid
+                ? await next(context)
+                : Results.ValidationProblem(result.ToDictionary());
+        });
+}
+```
+
+```csharp
+group.MapPost("/", CreateOrder).WithValidation<CreateOrderRequest>();
+```
+
+Add `FluentValidation` (`dotnet add package FluentValidation.DependencyInjectionExtensions`) and register your validators, and this single extension method gives every endpoint that opts in the same validation behavior Controllers get automatically - without tying validation logic to the endpoint definitions themselves.
+
+## Verifying Your Setup
+
+1. **Route groups keep `Program.cs` short** - confirm adding a new feature means adding a new `MapXEndpoints()` file and one line in `Program.cs`, not growing the top-level file
+2. **OpenAPI document generates correctly** - hit the `/openapi/v1.json` endpoint (or whatever route `MapOpenApi()` used) and confirm it reflects your actual endpoints
+3. **Validation filter runs before handler logic** - send an invalid request body and confirm you get a validation problem response, not a handler exception
+4. **Handlers resolve dependencies correctly** - confirm services registered in DI are being injected as method parameters without errors
+
+## Best Practices
+
+**Move to route groups and per-feature extension methods before `Program.cs` gets unwieldy, not after.** The migration is mechanical but tedious to do retroactively across a large file - start the pattern from your second or third feature.
+
+**Add validation deliberately through a filter, don't skip it because it's not automatic.** Minimal APIs not having `[ApiController]`'s built-in validation is a deliberate design choice, not a missing feature - the `WithValidation<T>()` pattern closes that gap in a few lines, once.
+
+**Keep handler methods as static methods on feature-specific classes.** This keeps the handler testable and the routing declaration readable, versus inline lambdas that grow past a few lines directly in the route mapping.
+
+**Use `Results.Xxx` helpers instead of returning raw objects for anything beyond simple `200 OK` responses.** `Results.Created`, `Results.NotFound`, `Results.ValidationProblem` all produce the correct status code and response shape without manual `StatusCode` juggling.
+
+**Reach for Controllers instead if your API's structure genuinely calls for it.** If you find yourself rebuilding `[ApiController]`'s model-binding and error-response conventions piece by piece, that's a signal worth listening to, not a reason to keep pushing through with Minimal APIs out of momentum.
+
+## Comparison with Controllers
+
+| | Minimal APIs | Controllers |
+| --- | --- | --- |
+| Ceremony per endpoint | Low - a few lines, no class required | Higher - controller class + action method |
+| Validation | Manual, via endpoint filters | Automatic via `[ApiController]` |
+| Organization at scale | Route groups + extension methods | Controller classes + conventions |
+| Default template | `dotnet new webapi` (as of recent SDKs) | `dotnet new webapi --use-controllers` |
+| Best for | New REST APIs, smaller-to-medium services | Large APIs benefiting from established conventions |
+
+## Frequently Asked Questions
+
+### Do Minimal APIs support the same routing features as Controllers?
+
+Yes - route parameters, constraints, and route groups all work the same way conceptually. The difference is organizational, not capability: Controllers group routes by class and attribute conventions, Minimal APIs group them explicitly via `MapGroup()` and extension methods.
+
+### How do I keep Program.cs from becoming unmanageable?
+
+Route groups paired with per-feature extension methods (`MapOrderEndpoints`, `MapCustomerEndpoints`) - each feature gets its own file, and `Program.cs` stays a short list of registration calls regardless of how many endpoints the API grows to.
+
+### Is there automatic model validation in Minimal APIs?
+
+Not automatically, unlike `[ApiController]`. You add it deliberately via a reusable `AddEndpointFilter`-based extension method paired with FluentValidation (or a similar library), which is a one-time setup cost that then applies uniformly to every endpoint that opts in.
+
+### Can I mix Minimal APIs and Controllers in the same project?
+
+Yes, they can coexist in the same ASP.NET Core application without conflict. This is uncommon as a permanent architecture but reasonable during a gradual migration from one style to the other.
+
+### What's the biggest structural difference from Controllers besides syntax?
+
+Dependency injection is per-handler-parameter in Minimal APIs instead of per-constructor in Controllers, and validation/model-binding conventions that Controllers give you automatically via `[ApiController]` are things you assemble yourself in Minimal APIs, deliberately, rather than inheriting for free.
+
+### What's the most common mistake in a first Minimal API setup?
+
+Letting every endpoint accumulate directly in `Program.cs` without adopting route groups and extension methods early, and skipping validation entirely because it isn't automatic the way it is with `[ApiController]` - both are avoidable with patterns that take only a little more setup than the naive approach.

--- a/src/posts/2027-04-13-getting-started-with-controllers-mvc.md
+++ b/src/posts/2027-04-13-getting-started-with-controllers-mvc.md
@@ -1,0 +1,179 @@
+---
+author: Steve Kaschimer
+date: 2027-04-13
+image: /images/posts/2027-04-13-hero.webp
+image_alt: "A single class-shaped icon issuing an automatic checkmark badge and a standardized error panel, with a small filter ring wrapped around it representing a cross-cutting action filter."
+image_prompt: "A dark-mode technical editorial illustration on a near-black background with electric teal, amber, and off-white accents. Composition centers on a solid rectangle representing a controller class, with a small amber checkmark badge automatically emitted from its top edge and a compact standardized error panel emitted from its base, both connected by short teal lines showing they come from the same source with no manual wiring. A thin ring shape wraps partway around the rectangle representing an action filter intercepting the flow. Mood is structured, conventions-driven, and mature. Avoid: vendor logos, brand colors, circuit-board textures, gears, or a sprawling class-diagram as the dominant motif."
+layout: post.njk
+site_title: Tech Notes
+summary: "Controllers earn their conventions at scale - automatic model validation, binding source inference, and standardized error responses that Minimal APIs make you assemble yourself. A setup guide for [ApiController], FluentValidation, and action filters."
+tags: ["dotnet", "api-design", "developer-productivity", "tooling"]
+title: "Getting Started with Controllers (MVC) in .NET"
+---
+
+Controllers are the original ASP.NET Core web API pattern, and while new project templates now default to Minimal APIs, Controllers remain the right call for large APIs that benefit from `[ApiController]`'s conventions. The part worth understanding isn't the syntax - it's what `[ApiController]` is actually doing for you behind the scenes, since that's exactly what you'd otherwise have to reconstruct by hand in Minimal APIs.
+
+This guide covers scaffolding a Controllers-based Web API, what `[ApiController]` actually provides (automatic model validation, binding source inference, standardized error responses), wiring up FluentValidation for cases the built-in validation doesn't cover, and using action filters for cross-cutting concerns. By the end you'll understand not just how to write a controller, but what convention it's leaning on and why.
+
+If you're deciding between API styles first, [a comparison of the top .NET API styles](/posts/2027-03-30-top-5-dotnet-api-styles-compared/) covers where Controllers fit relative to Minimal APIs, gRPC, GraphQL, and SignalR.
+
+## What You'll Need
+
+- .NET 8 SDK or later
+- Familiarity with attribute-based routing and standard MVC conventions is helpful but not required
+
+## Scaffolding a Controllers Project
+
+```bash
+dotnet new webapi --use-controllers
+```
+
+The `--use-controllers` flag is now required - without it, `dotnet new webapi` scaffolds a Minimal API project instead. This is a template default change, not a deprecation of Controllers themselves.
+
+## Bootstrapping the Ideal Environment
+
+### Register MVC services
+
+```csharp
+// Program.cs
+var builder = WebApplication.CreateBuilder(args);
+builder.Services.AddControllers();
+
+var app = builder.Build();
+app.MapControllers();
+app.Run();
+```
+
+### Define a controller and understand what [ApiController] does
+
+```csharp
+[ApiController]
+[Route("orders")]
+public class OrdersController(AppDbContext db) : ControllerBase
+{
+    [HttpGet("{id}")]
+    public async Task<ActionResult<Order>> GetOrder(int id)
+    {
+        var order = await db.Orders.FindAsync(id);
+        return order is null ? NotFound() : Ok(order);
+    }
+
+    [HttpPost]
+    public async Task<ActionResult<Order>> CreateOrder(CreateOrderRequest request)
+    {
+        var order = new Order { CustomerId = request.CustomerId };
+        db.Orders.Add(order);
+        await db.SaveChangesAsync();
+        return CreatedAtAction(nameof(GetOrder), new { id = order.Id }, order);
+    }
+}
+```
+
+`[ApiController]` isn't just a marker attribute - it enables three specific behaviors: automatic `400 Bad Request` responses when model validation fails (before your action method even runs), inference of binding sources (route, query, body) without explicit `[FromRoute]`/`[FromBody]` attributes in most cases, and standardized `ProblemDetails` error responses. Understanding these three is more useful than memorizing the attribute's existence.
+
+### Add FluentValidation for validation logic beyond data annotations
+
+`[ApiController]`'s automatic validation covers data-annotation attributes (`[Required]`, `[Range]`, etc.) on your request models, but real validation logic often needs more than annotations express:
+
+```bash
+dotnet add package FluentValidation.AspNetCore
+```
+
+```csharp
+public class CreateOrderRequestValidator : AbstractValidator<CreateOrderRequest>
+{
+    public CreateOrderRequestValidator()
+    {
+        RuleFor(x => x.CustomerId).GreaterThan(0);
+    }
+}
+```
+
+```csharp
+builder.Services.AddValidatorsFromAssemblyContaining<CreateOrderRequestValidator>();
+builder.Services.AddFluentValidationAutoValidation();
+```
+
+`AddFluentValidationAutoValidation()` hooks FluentValidation into the same automatic-validation pipeline `[ApiController]` already uses, so a failing FluentValidation rule produces the same standardized `400` response as a failing data annotation - one consistent validation experience, not two different error shapes depending on which validation mechanism caught the problem.
+
+## Core Workflow
+
+### Action filters for cross-cutting concerns
+
+```csharp
+public class LoggingActionFilter(ILogger<LoggingActionFilter> logger) : IActionFilter
+{
+    public void OnActionExecuting(ActionExecutingContext context) =>
+        logger.LogInformation("Executing {Action}", context.ActionDescriptor.DisplayName);
+
+    public void OnActionExecuted(ActionExecutedContext context) =>
+        logger.LogInformation("Executed {Action} with result {Result}",
+            context.ActionDescriptor.DisplayName, context.Result?.GetType().Name);
+}
+```
+
+```csharp
+builder.Services.AddControllers(options =>
+    options.Filters.Add<LoggingActionFilter>());
+```
+
+Registered globally like this, the filter runs around every action. Filters can also be applied per-controller or per-action via `[ServiceFilter(typeof(LoggingActionFilter))]` when you don't want the behavior everywhere.
+
+### Filters vs. middleware
+
+A common early point of confusion: middleware runs for every request regardless of whether it maps to a controller action, and operates on the raw `HttpContext`. Action filters run specifically around MVC action execution and have access to model-bound arguments and the action result - use middleware for concerns that apply to the whole pipeline (authentication, response compression), and filters for concerns specific to how MVC actions execute (logging action-level details, short-circuiting based on model state).
+
+## Verifying Your Setup
+
+1. **Automatic model validation actually triggers** - send a request with an invalid data-annotation-decorated field and confirm you get a `400` with `ProblemDetails`, without any manual `ModelState.IsValid` check in your action
+2. **Binding sources resolve correctly** - confirm route parameters, query parameters, and body content bind to the right action parameters without needing explicit `[From...]` attributes in the common cases
+3. **FluentValidation rules fire through the same pipeline** - confirm a failing FluentValidation rule produces the same response shape as a failing data annotation
+4. **Registered filters actually run** - confirm your `LoggingActionFilter` (or equivalent) output appears for controller actions
+
+## Best Practices
+
+**Lean on `[ApiController]`'s automatic behaviors instead of reimplementing them.** Manually checking `ModelState.IsValid` in every action, or hand-rolling error response shapes, duplicates what the attribute already does consistently across your whole API.
+
+**Use FluentValidation for validation logic beyond simple data annotations, wired through the same automatic pipeline.** Two different validation mechanisms producing two different error shapes is worse for API consumers than picking one consistent approach.
+
+**Reserve action filters for concerns specific to action execution, not general request handling.** If a concern applies to every request regardless of routing, it belongs in middleware, not a filter.
+
+**Don't add Controllers to a project just out of habit if it's small and greenfield.** The conventions `[ApiController]` provides pay off at scale - for a handful of endpoints, that structure is available but not necessarily needed, and Minimal APIs may be the better starting point.
+
+**Keep controllers thin - push business logic into services injected via the constructor.** A controller action should orchestrate (bind, call a service, return a result), not contain the actual business logic itself.
+
+## Comparison with Minimal APIs
+
+| | Controllers | Minimal APIs |
+| --- | --- | --- |
+| Validation | Automatic via `[ApiController]` | Manual, via endpoint filters |
+| Ceremony per endpoint | Higher - controller class + action method | Low - a few lines, no class required |
+| Cross-cutting concerns | Action filters (`IActionFilter`) | Endpoint filters (`AddEndpointFilter`) |
+| Scaffolding | `dotnet new webapi --use-controllers` | `dotnet new webapi` (default) |
+| Best for | Large APIs benefiting from established conventions | New REST APIs, smaller-to-medium services |
+
+## Frequently Asked Questions
+
+### What does [ApiController] actually do, beyond marking a class as an API controller?
+
+Three concrete things: automatic `400` responses on model validation failure (without you calling `ModelState.IsValid`), inference of binding sources so you rarely need explicit `[FromRoute]`/`[FromQuery]`/`[FromBody]` attributes, and standardized `ProblemDetails` error response shapes. All three are things you'd otherwise assemble yourself in a Minimal API.
+
+### Why does dotnet new webapi scaffold Minimal APIs instead of Controllers now?
+
+Microsoft changed the default template to favor Minimal APIs as the lighter-weight, more modern starting point. Controllers aren't deprecated - `--use-controllers` still scaffolds the full MVC pattern - it's purely a change in which one you get without an explicit flag.
+
+### What's the difference between middleware and action filters?
+
+Middleware runs for every request in the pipeline regardless of whether it reaches a controller action, and works with the raw `HttpContext`. Action filters run specifically around MVC action execution, with access to bound arguments and the action's result - use middleware for pipeline-wide concerns, filters for action-execution-specific ones.
+
+### Do I still need FluentValidation if I'm using data annotations?
+
+Not necessarily - data annotations cover simple, declarative rules fine. FluentValidation earns its place when validation logic needs conditional rules, cross-field checks, or reuse across multiple request types that data annotations can't express cleanly. Both can coexist through the same automatic-validation pipeline when wired up correctly.
+
+### Can Controllers and Minimal APIs coexist in one project?
+
+Yes - both can be registered and used in the same ASP.NET Core application. It's uncommon as a permanent architecture, but a reasonable interim state during a gradual migration between the two styles.
+
+### What's the most common mistake in a first Controllers setup?
+
+Manually reimplementing behaviors `[ApiController]` already provides for free - explicit `ModelState.IsValid` checks, hand-written error response shapes - usually because the developer isn't aware those come automatically with the attribute, producing inconsistent behavior across the API where some actions get the automatic treatment and others don't.

--- a/src/posts/2027-04-20-getting-started-with-graphql-hotchocolate.md
+++ b/src/posts/2027-04-20-getting-started-with-graphql-hotchocolate.md
@@ -1,0 +1,179 @@
+---
+author: Steve Kaschimer
+date: 2027-04-20
+image: /images/posts/2027-04-20-hero.webp
+image_alt: "A flexible bracket shape with several thin branches fanning out to represent selectable fields, converging into a single batched query icon instead of many separate ones."
+image_prompt: "A dark-mode technical editorial illustration on a near-black background with electric teal, amber, and off-white accents. Composition centers on a flexible bracket-shaped glyph on the left with several thin teal branches fanning outward, each ending in a small selectable-field dot, representing client-selected fields. On the right, all branches converge through a narrow batching funnel into a single amber query icon, representing a DataLoader collapsing many lookups into one. Below, a small depth-limit ruler icon caps a short vertical stack of nested brackets. Mood is flexible, deliberate, and precise. Avoid: vendor logos, brand colors, circuit-board textures, gears, or generic database-cylinder clip art."
+layout: post.njk
+site_title: Tech Notes
+summary: "Hot Chocolate lets clients request exactly the fields they need instead of the server dictating a fixed shape - but the N+1 problem and unbounded query cost are real, common pitfalls. A setup guide for projections, DataLoader batching, and depth limiting."
+tags: ["dotnet", "api-design", "graphql", "performance", "architecture"]
+title: "Getting Started with GraphQL (Hot Chocolate) in .NET"
+---
+
+Hot Chocolate is the standard GraphQL server library for .NET, and its core pitch is real: clients get to request exactly the fields they need in a single query, instead of the server dictating a fixed response shape the way REST does. What the pitch leaves out is that this flexibility comes with two problems you'll hit almost immediately on any non-trivial schema - the N+1 query problem, and clients being able to construct expensive queries you didn't anticipate. Both have well-established fixes, but only if you know to apply them from the start.
+
+This guide covers installing Hot Chocolate, defining a code-first schema with projections, solving the N+1 problem with `DataLoader`, and limiting query cost before a client can accidentally (or deliberately) construct an expensive query. By the end you'll have a GraphQL API that stays fast as your schema grows, not one that works fine in a demo and falls over on a real dataset.
+
+If you're deciding between API styles first, [a comparison of the top .NET API styles](/posts/2027-03-30-top-5-dotnet-api-styles-compared/) covers where GraphQL fits relative to Minimal APIs, Controllers, gRPC, and SignalR.
+
+## What You'll Need
+
+- .NET 8 SDK or later
+- An EF Core-backed data model, since this guide uses `HotChocolate.Data.EntityFramework` for its examples
+- Comfort with the idea that a single `/graphql` endpoint replaces multiple REST endpoints, since that's a mental model shift for teams coming from REST
+
+## Installing Hot Chocolate
+
+```bash
+dotnet add package HotChocolate.AspNetCore
+dotnet add package HotChocolate.Data
+dotnet add package HotChocolate.Data.EntityFramework
+```
+
+## Bootstrapping the Ideal Environment
+
+### Define a code-first schema
+
+```csharp
+public class Query
+{
+    [UseProjection, UseFiltering, UseSorting]
+    public IQueryable<Order> GetOrders(AppDbContext db) => db.Orders;
+}
+
+public class Mutation
+{
+    public async Task<Order> CreateOrder(CreateOrderInput input, AppDbContext db)
+    {
+        var order = new Order { CustomerId = input.CustomerId };
+        db.Orders.Add(order);
+        await db.SaveChangesAsync();
+        return order;
+    }
+}
+```
+
+```csharp
+// Program.cs
+builder.Services
+    .AddGraphQLServer()
+    .AddQueryType<Query>()
+    .AddMutationType<Mutation>()
+    .AddProjections()
+    .AddFiltering()
+    .AddSorting();
+
+var app = builder.Build();
+app.MapGraphQL();
+```
+
+`[UseProjection]` is what makes field selection actually efficient - without it, Hot Chocolate would fetch every column of every `Order` row regardless of which fields the client asked for, then discard the rest in memory. With it, the projection pushes down into the EF Core query itself, so the client selecting three fields out of fifteen produces a query that only selects those three columns.
+
+### Explore the schema with Banana Cake Pop
+
+Hot Chocolate ships an interactive GraphQL IDE at `/graphql` by default (Banana Cake Pop) - a query explorer and schema browser without needing a separate API client, useful during development for constructing and testing queries against your actual schema.
+
+## Core Workflow
+
+### The N+1 problem, and fixing it with DataLoader
+
+Resolving a list of orders, then a related field (say, `Customer`) on each one, naively issues one query per order instead of one query for the whole batch:
+
+```csharp
+public class CustomerByIdDataLoader(IServiceScopeFactory scopeFactory, IBatchScheduler batchScheduler)
+    : BatchDataLoader<int, Customer>(batchScheduler)
+{
+    protected override async Task<IReadOnlyDictionary<int, Customer>> LoadBatchAsync(
+        IReadOnlyList<int> keys, CancellationToken cancellationToken)
+    {
+        using var scope = scopeFactory.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<AppDbContext>();
+
+        return await db.Customers
+            .Where(c => keys.Contains(c.Id))
+            .ToDictionaryAsync(c => c.Id, cancellationToken);
+    }
+}
+```
+
+```csharp
+public class OrderResolvers
+{
+    public async Task<Customer> GetCustomer([Parent] Order order, CustomerByIdDataLoader dataLoader) =>
+        await dataLoader.LoadAsync(order.CustomerId);
+}
+```
+
+`BatchDataLoader` collects every `CustomerId` requested during a single GraphQL request execution and issues one query for the whole batch instead of one per order - this is the standard fix for the N+1 problem in any GraphQL server, not a Hot Chocolate-specific workaround.
+
+### Limiting query cost before it's a problem
+
+A GraphQL schema without limits lets a client construct a deeply nested query that's expensive to resolve - unlike REST, where the server controls the response shape and implicitly bounds the cost:
+
+```csharp
+builder.Services
+    .AddGraphQLServer()
+    // ...
+    .AddMaxExecutionDepthRule(15)
+    .SetPagingOptions(new PagingOptions { MaxPageSize = 50, DefaultPageSize = 20 });
+```
+
+`AddMaxExecutionDepthRule` caps how deeply a query can nest, and `SetPagingOptions` caps how many items a paginated field can return per request - both are cheap to set up and protect against both accidental and deliberate abuse of the schema's flexibility.
+
+## Verifying Your Setup
+
+1. **Projections actually reduce the generated SQL** - log EF Core's generated queries and confirm selecting fewer fields in a GraphQL query produces a narrower `SELECT`
+2. **DataLoader is batching, not issuing N queries** - log or profile a query resolving a list plus a related field per item, and confirm one batched query for the related data, not one per item
+3. **Depth and paging limits actually reject over-limit queries** - send a deliberately over-nested query or an oversized page request and confirm it's rejected, not silently executed
+4. **Banana Cake Pop reflects your actual schema** - open `/graphql` and confirm the schema explorer matches your defined types and fields
+
+## Best Practices
+
+**Apply `[UseProjection]` to every query resolver returning entity data, not selectively.** The efficiency gain scales with schema size - the more fields a type has, the more a naive full-row fetch wastes when the client only wanted a few.
+
+**Use DataLoader for every resolver that fetches related data per-item, as a default habit rather than a fix applied after noticing a performance problem.** The N+1 problem is easy to introduce and easy to miss in a demo with a small dataset - assume it will happen and batch from the start.
+
+**Set depth and paging limits before shipping the schema publicly, not after an expensive query shows up in production.** These are cheap, one-time configuration - there's no good reason to defer them.
+
+**Keep resolvers thin and push filtering/sorting/projection down to the data layer via the built-in middleware, rather than hand-rolling equivalents.** `[UseFiltering]`/`[UseSorting]` compose with `[UseProjection]` and translate to efficient EF Core queries; hand-written equivalents rarely do as well without significant effort.
+
+**Version schema changes with `@deprecated` rather than breaking changes.** GraphQL's single-endpoint model means there's no URL versioning escape hatch the way REST has - deprecate fields deliberately and give clients time to migrate before removal.
+
+## Comparison with gRPC
+
+| | GraphQL (Hot Chocolate) | gRPC |
+| --- | --- | --- |
+| Client flexibility | Client selects exact fields needed | Server dictates message shape |
+| Transport | HTTP, JSON | HTTP/2, Protobuf |
+| Browser support | Full | None without gRPC-Web + proxy |
+| Performance | Good, resolver cost needs managing | Fastest - binary serialization |
+| Best for | Client-driven, varied data needs | Internal service-to-service calls |
+
+Both solve very different problems despite both being alternatives to plain REST - GraphQL optimizes for client flexibility over a public or semi-public API, gRPC optimizes for raw speed between services you control. They're rarely direct substitutes for the same use case.
+
+## Frequently Asked Questions
+
+### What is the N+1 problem in GraphQL, in plain terms?
+
+Resolving a list of parent entities, then a related field on each one individually, issues one query per item instead of a single batched query - so a list of 100 orders with a `Customer` field naively issues 101 queries instead of 2. `DataLoader` fixes this by collecting all the keys requested during one execution and batching them into a single query.
+
+### Does DataLoader need to be scoped per-request?
+
+Yes - Hot Chocolate registers DataLoaders per GraphQL request execution by default, so the batching window is exactly one request, not shared or cached across unrelated requests. This is what makes it safe to use without stale-data concerns.
+
+### How do I prevent clients from writing expensive queries?
+
+`AddMaxExecutionDepthRule` limits nesting depth, and `SetPagingOptions` bounds how many items a paginated field returns per request. Together these cap the two most common ways a GraphQL query becomes expensive: deep nesting and unbounded list sizes.
+
+### Should my GraphQL types mirror my EF Core entities directly, or use separate DTOs?
+
+Either is workable, but separate DTOs (or dedicated GraphQL types) give you more control over what's exposed and avoid accidentally leaking internal entity structure or triggering unwanted lazy-loading behavior through the GraphQL layer. Mirroring entities directly is faster to set up initially and reasonable for smaller, less public-facing schemas.
+
+### Can GraphQL coexist with REST or gRPC endpoints in the same application?
+
+Yes - it's common for a service to expose a GraphQL endpoint for flexible client queries alongside REST or gRPC endpoints for other purposes (webhooks, service-to-service calls). There's no architectural conflict in running multiple API styles in the same ASP.NET Core application.
+
+### What's the most common mistake in a first Hot Chocolate setup?
+
+Not using `DataLoader` for resolvers that fetch related data per-item, which works fine in development against a small dataset and then produces an N+1 query explosion in production. Skipping depth/paging limits is the second most common - both are cheap to add early and expensive to retrofit after a real client is already depending on the unbounded schema.

--- a/src/posts/2027-04-27-getting-started-with-signalr.md
+++ b/src/posts/2027-04-27-getting-started-with-signalr.md
@@ -1,0 +1,176 @@
+---
+author: Steve Kaschimer
+date: 2027-04-27
+image: /images/posts/2027-04-27-hero.webp
+image_alt: "A pulsing broadcast-wave glyph radiating from a small central hub icon, with a second faint hub silhouette in the background connected by a thin backplane line to keep both in sync."
+image_prompt: "A dark-mode technical editorial illustration on a near-black background with electric teal, amber, and off-white accents. Composition centers on a solid central hub-shaped glyph emitting concentric broadcast-wave rings outward in teal. A second, fainter hub silhouette sits in the background at a slight offset, connected to the first by a thin amber line labeled subtly as a backplane, implying two coordinated instances. A small automatic-reconnect loop icon sits near the base. Mood is live, connected, and slightly urgent. Avoid: vendor logos, brand colors, circuit-board textures, gears, or literal radio-tower clip art."
+layout: post.njk
+site_title: Tech Notes
+summary: "SignalR isn't a REST replacement, it's for real-time push - and the moment you scale past one server instance without a Redis backplane, some clients silently stop getting updates. A setup guide for Hubs, IHubContext pushes, and the backplane fix."
+tags: ["dotnet", "api-design", "real-time", "architecture", "devops"]
+title: "Getting Started with SignalR in .NET"
+---
+
+SignalR solves a different problem than every other API style in this series: not "how does a client request data," but "how does a client find out the moment something changed, without asking." That distinction matters because SignalR is additive to your API surface, not a replacement for it - and it has exactly one setup mistake that's both extremely common and completely silent: skip the Redis backplane past one server instance, and some clients will simply stop receiving updates, with no error anywhere in your logs telling you why.
+
+This guide covers installing SignalR on both server and client, building a Hub, the more common pattern of pushing updates from application services rather than only from Hub methods, client-side automatic reconnection, and the Redis backplane that becomes mandatory the moment you run more than one instance. By the end you'll have a real-time setup that keeps working after your first horizontal scale-out, not one that quietly breaks.
+
+If you're deciding between API styles first, [a comparison of the top .NET API styles](/posts/2027-03-30-top-5-dotnet-api-styles-compared/) covers where SignalR fits relative to Minimal APIs, Controllers, gRPC, and GraphQL - including why it isn't really a competitor to any of them.
+
+## What You'll Need
+
+- .NET 8 SDK or later
+- A JavaScript or .NET client application to receive pushed updates
+- Redis (or an equivalent) available before scaling past a single server instance - budget for this now, not after
+
+## Installing SignalR
+
+```bash
+dotnet new web
+```
+
+SignalR ships as part of ASP.NET Core - no separate server package needed. For clients:
+
+```bash
+npm install @microsoft/signalr
+```
+
+```bash
+dotnet add package Microsoft.AspNetCore.SignalR.Client
+```
+
+## Bootstrapping the Ideal Environment
+
+### Define a Hub
+
+```csharp
+public class OrderHub : Hub
+{
+    public async Task JoinOrderGroup(int orderId) =>
+        await Groups.AddToGroupAsync(Context.ConnectionId, $"order-{orderId}");
+}
+```
+
+```csharp
+// Program.cs
+var builder = WebApplication.CreateBuilder(args);
+builder.Services.AddSignalR();
+
+var app = builder.Build();
+app.MapHub<OrderHub>("/hubs/orders");
+app.Run();
+```
+
+`Groups.AddToGroupAsync` is how you scope pushes to interested clients - here, clients that care about a specific order join a group named for that order, rather than every connected client receiving every update.
+
+### Push updates from application services, not just Hub methods
+
+The tutorial-friendly pattern - a Hub method that immediately messages back to the caller - is less common in real applications than pushing updates from wherever the actual state change happens, which is often nowhere near the Hub itself:
+
+```csharp
+public class OrderService(IHubContext<OrderHub> hubContext, AppDbContext db)
+{
+    public async Task UpdateOrderStatusAsync(int orderId, OrderStatus status)
+    {
+        var order = await db.Orders.FindAsync(orderId);
+        order!.Status = status;
+        await db.SaveChangesAsync();
+
+        await hubContext.Clients.Group($"order-{orderId}")
+            .SendAsync("OrderStatusChanged", new { orderId, status });
+    }
+}
+```
+
+`IHubContext<OrderHub>` lets any service - not just code running inside a Hub - push messages to connected clients. This is the pattern most production SignalR usage actually follows: an order status changes somewhere in application logic, and that's where the push originates, not from a client-initiated Hub call.
+
+### Client-side connection with automatic reconnection
+
+```javascript
+const connection = new signalR.HubConnectionBuilder()
+    .withUrl("/hubs/orders")
+    .withAutomaticReconnect()
+    .build();
+
+connection.on("OrderStatusChanged", (update) => {
+    console.log(`Order ${update.orderId} is now ${update.status}`);
+});
+
+await connection.start();
+await connection.invoke("JoinOrderGroup", orderId);
+```
+
+`.withAutomaticReconnect()` handles transient network drops without you writing reconnection logic by hand - without it, a dropped connection stays dropped until the client explicitly reconnects.
+
+## Core Workflow
+
+### The Redis backplane - mandatory past one instance
+
+A single SignalR server instance tracks its own connections in memory, which is fine until you run more than one instance behind a load balancer. At that point, a message sent from one instance only reaches clients connected to *that* instance - clients connected to a different instance never receive it, with no error or exception anywhere:
+
+```bash
+dotnet add package Microsoft.AspNetCore.SignalR.StackExchangeRedis
+```
+
+```csharp
+builder.Services.AddSignalR()
+    .AddStackExchangeRedis(builder.Configuration.GetConnectionString("Redis")!);
+```
+
+This one line is the entire fix - it fans messages out across all connected instances via Redis pub/sub instead of relying on any single instance's in-memory connection state. Add it as part of your initial setup if there's any chance of scaling past one instance, not as a reactive fix once someone reports "some users aren't getting updates."
+
+## Verifying Your Setup
+
+1. **Connections join the right groups** - confirm `JoinOrderGroup` (or your equivalent) actually scopes a client's connection ID to the intended group
+2. **IHubContext pushes reach connected clients** - trigger the application-service code path that calls `hubContext.Clients...SendAsync` and confirm the connected client receives it
+3. **Automatic reconnection actually reconnects** - simulate a network interruption and confirm the client reconnects and resumes receiving updates without a manual page reload
+4. **The backplane works across instances** - this is the one to specifically test before production if you're running more than one instance: connect two clients to different instances (or simulate it locally with two processes sharing the same Redis backplane) and confirm both receive a push originating from either instance
+
+## Best Practices
+
+**Add the Redis backplane as part of initial setup if there's any chance you'll scale past one instance, not after.** The failure mode without it - some clients silently missing updates - is hard to diagnose after the fact because nothing throws an error; it just looks like flaky client behavior.
+
+**Push updates via `IHubContext<T>` from wherever the actual state change happens, not exclusively from Hub methods.** Most real-world SignalR usage is server-initiated push triggered by application logic, not a client asking the Hub for something and getting an immediate reply.
+
+**Use groups to scope pushes to interested clients, not a global broadcast to everyone connected.** Broadcasting to all clients when only a subset care about a given update wastes bandwidth and forces every client to filter messages it should never have received.
+
+**Always enable `.withAutomaticReconnect()` on the client.** Real networks drop connections regularly - mobile clients, sleeping laptops, flaky Wi-Fi - and without automatic reconnection, a dropped connection requires a manual page reload to recover.
+
+**Remember SignalR is additive, not a REST/GraphQL/gRPC replacement.** Don't reach for it to solve request-response problems just because it's already in the project for a real-time feature - it solves a genuinely different problem and forcing request-response patterns through it fights the tool.
+
+## Comparison with GraphQL Subscriptions
+
+| | SignalR | GraphQL Subscriptions |
+| --- | --- | --- |
+| Purpose | Dedicated real-time push library | Real-time updates integrated into a GraphQL schema |
+| Setup | Standalone, own connection model | Requires an existing GraphQL server (e.g., Hot Chocolate) |
+| Scaling | Redis backplane past one instance | Depends on the underlying GraphQL server's subscription transport |
+| Best for | Pure real-time push use cases | Teams already using GraphQL who want events in the same schema |
+
+If you're not already running a GraphQL API, SignalR is the more direct, purpose-built choice for real-time push. If you are, GraphQL subscriptions may be a more natural fit since events flow through the same schema and client tooling you're already using.
+
+## Frequently Asked Questions
+
+### Why did some of my users stop receiving SignalR updates after I scaled to multiple instances?
+
+Almost certainly a missing Redis backplane. Each SignalR server instance tracks its own connections in memory by default, so a message sent from one instance only reaches clients connected to that same instance - clients on other instances silently miss it, with no exception or error logged anywhere. `AddStackExchangeRedis(...)` fixes this by fanning messages across all instances via Redis pub/sub.
+
+### Should I push messages from inside Hub methods or from application services?
+
+Application services, in most real-world cases - via `IHubContext<T>` injected wherever the actual state change happens. Hub methods responding directly to the client that called them is the simpler tutorial pattern, but production systems more often need to push updates triggered by something that has nothing to do with a client-initiated Hub call, like a background job or another service completing work.
+
+### Is SignalR a replacement for REST or GraphQL?
+
+No - it solves a fundamentally different problem (real-time push vs. request-response) and is meant to be additive to an existing API, not a replacement for it. A typical application uses REST or GraphQL for its request-response surface and SignalR specifically for the subset of features that need live updates.
+
+### What transports does SignalR use besides WebSockets?
+
+WebSockets is the preferred transport, with automatic fallback to Server-Sent Events and then long polling if WebSockets aren't available in a given client/network environment. This fallback happens transparently - your application code doesn't need to handle each transport differently.
+
+### How do groups work, and why use them instead of broadcasting to everyone?
+
+Groups let you scope a push to a subset of connected clients (e.g., everyone viewing a specific order) instead of every connected client. Broadcasting everything to everyone wastes bandwidth and forces clients to filter out irrelevant messages - groups push the filtering to the server, where it belongs.
+
+### What's the most common mistake in a first SignalR setup?
+
+Deploying to more than one server instance without a Redis backplane, which fails silently rather than with an obvious error - some clients simply stop getting updates, and it's easy to mistake for a flaky client issue rather than a missing backplane. Add the backplane during initial setup if scaling is even a possibility, not after the symptom shows up.

--- a/src/posts/2027-05-04-getting-started-with-grpc-dotnet.md
+++ b/src/posts/2027-05-04-getting-started-with-grpc-dotnet.md
@@ -1,0 +1,214 @@
+---
+author: Steve Kaschimer
+date: 2027-05-04
+image: /images/posts/2027-05-04-hero.webp
+image_alt: "A solid amber lightning-bolt glyph channeled through a narrow binary duct into a locked TLS padlock, with a shared contract file icon bridging two identical endpoint shapes."
+image_prompt: "A dark-mode technical editorial illustration on a near-black background with electric teal, amber, and off-white accents. Composition centers on a solid amber lightning-bolt glyph on the left, funneled through a narrow rectangular duct into a small teal padlock shape, implying speed gated by required TLS. To the right, a single flat contract-file icon sits equidistant between two identical small endpoint rectangles, connected by matching thin lines to each, representing a shared .proto contract. Mood is fast, strict, and precise. Avoid: vendor logos, brand colors, circuit-board textures, gears, or generic database-cylinder clip art."
+layout: post.njk
+site_title: Tech Notes
+summary: "gRPC is the fastest option in the .NET API landscape, but it demands TLS even locally and has zero direct browser support. A setup guide for shared .proto contracts, streaming RPCs, and RpcException error mapping."
+tags: ["dotnet", "api-design", "grpc", "performance", "microservices"]
+title: "Getting Started with gRPC in .NET"
+---
+
+gRPC is the fastest of the API styles covered in this series, and the least forgiving about it - binary Protobuf serialization and HTTP/2 multiplexing buy you real performance, but only if every caller is a service you control, since there's no direct browser support and Kestrel refuses to negotiate a gRPC connection without TLS, even on localhost. Understanding that trade-off upfront saves you from reaching for gRPC in the one place it structurally can't go: a public API a frontend calls directly.
+
+This guide covers scaffolding a gRPC service, defining a `.proto` contract and sharing it across client and server through a common project reference, the core unary and streaming RPC patterns, and mapping errors through `RpcException`. By the end you'll have a service-to-service setup that's fast, strongly-typed, and won't drift out of sync between client and server.
+
+If you're deciding between API styles first, [a comparison of the top .NET API styles](/posts/2027-03-30-top-5-dotnet-api-styles-compared/) covers where gRPC fits relative to Minimal APIs, Controllers, GraphQL, and SignalR - including exactly why it isn't the right choice for a public-facing API.
+
+## What You'll Need
+
+- .NET 8 SDK or later
+- A clear sense that every caller of this service will be another service you control, not a browser - if that's not true, gRPC is the wrong tool here
+- Comfort with TLS being a hard requirement, not an optional hardening step, even in local development
+
+## Scaffolding a gRPC Project
+
+```bash
+dotnet new grpc
+```
+
+This scaffolds a gRPC service project with an example `.proto` file, generated code wiring, and Kestrel already configured for HTTP/2.
+
+## Bootstrapping the Ideal Environment
+
+### Define the contract in a .proto file
+
+```protobuf
+// order.proto
+syntax = "proto3";
+
+option csharp_namespace = "OrderService";
+
+service OrderService {
+    rpc GetOrder (GetOrderRequest) returns (OrderReply);
+    rpc ProcessOrder (ProcessOrderRequest) returns (OrderReply);
+}
+
+message GetOrderRequest {
+    int32 order_id = 1;
+}
+
+message ProcessOrderRequest {
+    int32 order_id = 1;
+}
+
+message OrderReply {
+    int32 order_id = 1;
+    string status = 2;
+}
+```
+
+### Wire the .proto file into the project
+
+```xml
+<ItemGroup>
+    <Protobuf Include="Protos/order.proto" GrpcServices="Server" />
+</ItemGroup>
+```
+
+`GrpcServices="Server"` generates the server-side base class to implement; a client project referencing the same `.proto` file uses `GrpcServices="Client"` instead to generate a strongly-typed client.
+
+### Implement the service
+
+```csharp
+public class OrderServiceImpl(AppDbContext db) : OrderService.OrderServiceBase
+{
+    public override async Task<OrderReply> GetOrder(GetOrderRequest request, ServerCallContext context)
+    {
+        var order = await db.Orders.FindAsync(request.OrderId);
+        return order is null
+            ? throw new RpcException(new Status(StatusCode.NotFound, $"Order {request.OrderId} not found"))
+            : new OrderReply { OrderId = order.Id, Status = order.Status.ToString() };
+    }
+}
+```
+
+```csharp
+// Program.cs
+var builder = WebApplication.CreateBuilder(args);
+builder.Services.AddGrpc();
+
+var app = builder.Build();
+app.MapGrpcService<OrderServiceImpl>();
+app.Run();
+```
+
+### Why Kestrel needs HTTP/2 and TLS, even locally
+
+gRPC requires HTTP/2, and browsers and most HTTP clients negotiate protocol version through TLS's ALPN extension during the TLS handshake itself - there's no clear-text (plain HTTP) mechanism for negotiating HTTP/2 on an endpoint that also needs to support other protocols. This is why a gRPC endpoint needs TLS configured even when you're just running it on your own machine during development; it's not optional hardening, it's how the protocol negotiation actually works.
+
+## Core Workflow
+
+### Calling the service from a client
+
+```csharp
+using var channel = GrpcChannel.ForAddress("https://localhost:5001");
+var client = new OrderService.OrderServiceClient(channel);
+
+var reply = await client.GetOrderAsync(new GetOrderRequest { OrderId = 123 });
+```
+
+### Share the .proto file via a common project reference
+
+The single most important discipline in a multi-service gRPC setup: put the `.proto` file in a shared project both the server and every client reference, rather than copying it into each project individually.
+
+```xml
+<!-- In both the server project and each client project -->
+<ItemGroup>
+    <Protobuf Include="..\Contracts\Protos\order.proto" GrpcServices="Server" />
+    <!-- or GrpcServices="Client" in the client project -->
+</ItemGroup>
+```
+
+Copied `.proto` files drift - someone updates the server's copy, forgets the client's, and you get a runtime contract mismatch that the compiler had no way to catch. A shared reference makes that class of bug structurally impossible instead of a matter of remembering to keep two files in sync.
+
+### Streaming RPCs
+
+gRPC supports streaming in a way none of the request-response styles in this series do natively:
+
+```protobuf
+rpc StreamOrderUpdates (GetOrderRequest) returns (stream OrderReply);
+```
+
+```csharp
+public override async Task StreamOrderUpdates(
+    GetOrderRequest request, IServerStreamWriter<OrderReply> responseStream, ServerCallContext context)
+{
+    await foreach (var update in GetOrderUpdatesAsync(request.OrderId, context.CancellationToken))
+    {
+        await responseStream.WriteAsync(update);
+    }
+}
+```
+
+Server streaming, client streaming, and bidirectional streaming are all supported - useful for scenarios like live order status updates between services, without needing a separate real-time mechanism like SignalR for service-to-service communication specifically.
+
+### Error handling with RpcException
+
+```csharp
+catch (RpcException ex) when (ex.StatusCode == StatusCode.NotFound)
+{
+    // handle not-found specifically
+}
+```
+
+`RpcException`/`StatusCode` gives you a structured error model that maps cleanly across the wire - a `StatusCode.NotFound` thrown on the server surfaces as the same status code on the client, unlike hand-rolled error conventions that can drift between what the server sends and what the client expects.
+
+## Verifying Your Setup
+
+1. **TLS is actually configured, not skipped** - confirm the service is reachable over `https://`, not `http://`, and that the client trusts the certificate in use (a dev cert is fine for local development)
+2. **The shared .proto reference actually eliminates drift** - confirm both server and client projects reference the same physical `.proto` file, not independently maintained copies
+3. **Streaming RPCs deliver messages incrementally** - confirm a streaming call's messages arrive as they're written server-side, not buffered and delivered all at once
+4. **RpcException status codes map correctly end-to-end** - throw a specific `StatusCode` server-side and confirm the client observes the same code, not a generic failure
+
+## Best Practices
+
+**Share the `.proto` file via a common project reference from the start, never copy it between projects.** This is the single highest-leverage practice in this guide - it converts a class of bug that's easy to introduce and hard to diagnose (contract drift) into something the build system prevents outright.
+
+**Don't reach for gRPC for a public API a browser calls directly.** It's the wrong tool structurally, not just a style preference - browsers can't speak gRPC's native framing without gRPC-Web plus a compatible proxy, and even then it's a workaround, not a first-class use case.
+
+**Use streaming RPCs for cases that are naturally continuous, not to avoid a service call you find inconvenient.** Streaming adds real complexity (backpressure, cancellation, connection lifetime) - reach for it when the data genuinely arrives over time, not as a general substitute for repeated unary calls.
+
+**Map domain errors to `RpcException`/`StatusCode` deliberately, not just letting unhandled exceptions surface as generic failures.** A structured status code the client can branch on is far more useful than an opaque `Internal` error for every failure case.
+
+**Keep Protobuf field numbers stable once a message ships.** Reusing or renumbering existing field numbers breaks binary compatibility for clients still running an older contract version - append new fields with new numbers instead of altering existing ones.
+
+## Comparison with GraphQL
+
+| | gRPC | GraphQL (Hot Chocolate) |
+| --- | --- | --- |
+| Transport | HTTP/2, Protobuf | HTTP, JSON |
+| Browser support | None without gRPC-Web + proxy | Full |
+| Client flexibility | Server dictates message shape | Client selects exact fields |
+| Performance | Fastest - binary serialization | Good, resolver cost needs managing |
+| Best for | Internal service-to-service calls | Client-driven, varied data needs |
+
+The two rarely compete for the same use case in practice - gRPC's lack of direct browser support alone rules it out for most GraphQL scenarios, and GraphQL's flexibility overhead is unnecessary for tightly-controlled internal service calls where gRPC's speed and strict contracts are the priority.
+
+## Frequently Asked Questions
+
+### Why does gRPC require TLS even for local development?
+
+Protocol negotiation between HTTP/1.1 and HTTP/2 on a shared endpoint happens through TLS's ALPN extension during the handshake - there's no clear-text equivalent for that negotiation. This means a gRPC endpoint needs TLS configured from the start, including locally, not as a production-only hardening step.
+
+### Can I call a gRPC service directly from a browser?
+
+Not natively - browsers can't produce gRPC's native HTTP/2 framing. gRPC-Web plus a compatible proxy (like Envoy) bridges the gap, but it's a workaround for a specific need, not a reason to treat gRPC as browser-ready by default. For a public API a frontend calls directly, REST or GraphQL are the more natural fit.
+
+### How do I keep the client and server .proto contracts from drifting apart?
+
+Reference the same physical `.proto` file from a shared project in both the server and every client project, rather than maintaining separate copies. This turns contract drift from an easy-to-miss manual synchronization problem into something the build system structurally prevents.
+
+### What happens if I change a Protobuf message's field numbers after it's shipped?
+
+You break binary compatibility for any client still running the older contract - Protobuf's wire format is positional by field number, not by name. Add new fields with new, unused numbers instead of renumbering or reusing existing ones; that's what keeps old and new clients compatible with the same service.
+
+### When does gRPC's performance advantage actually matter?
+
+Most noticeably in high-throughput, latency-sensitive service-to-service communication, where binary serialization and HTTP/2 multiplexing add up across many calls. For low-volume internal calls or anything a browser needs to reach directly, the performance gain is smaller in absolute terms and doesn't offset the browser-compatibility trade-off.
+
+### Is gRPC worth adopting for a small internal system with just two or three services?
+
+Often not the highest-priority choice at that scale - the setup cost (shared contracts, TLS, tooling) pays off more clearly as the number of services and call volume grows. For a small number of services, a simpler REST-based internal API may be less overhead for comparable practical performance, though gRPC remains a reasonable choice if the team already has the tooling in place.


### PR DESCRIPTION
## Summary

- Schedules and drafts the .NET API Styles Tuesday track: a comparison anchor post plus five getting-started guides, running weekly Tuesdays 2027-03-30 through 2027-05-04, picking up the cadence directly after the .NET ORMs track
- Moves the series from `editorial-plan.md`'s Backlog into a dated `## 📅 Tuesday Track - .NET API Styles (March-May 2027)` section, all entries `Status: draft` with `File:` paths

### Posts added

- **Anchor:** The Top 5 .NET API Styles Compared: Which One Should You Choose? (2027-03-30) - Minimal APIs, Controllers, gRPC, GraphQL (Hot Chocolate), and SignalR compared on one axis: fixed response shape vs. real-time push
- Getting Started with Minimal APIs in .NET (2027-04-06)
- Getting Started with Controllers (MVC) in .NET (2027-04-13)
- Getting Started with GraphQL (Hot Chocolate) in .NET (2027-04-20)
- Getting Started with SignalR in .NET (2027-04-27)
- Getting Started with gRPC in .NET (2027-05-04)

Each setup guide cross-links back to the anchor post, mirroring the structure of the prior .NET ORMs/Testing/Logging/Architecture tracks.

## Test plan

- [x] `npm run deploy` builds cleanly, all 6 posts render
- [x] `node scripts/a11y-check.js` (axe-core + Playwright) - zero violations across home/post/about/privacy/terms/404 in light and dark mode
- [x] Verified all 5 setup-guide cross-links resolve to the anchor post's output URL


---
_Generated by [Claude Code](https://claude.ai/code/session_01WKyNF7L5qzrfct8cec6A32)_