### PR TITLE
Add .NET Validation Approaches Tuesday track (6 posts)

### DIFF
--- a/editorial-plan.md
+++ b/editorial-plan.md
@@ -878,17 +878,69 @@ Six posts on how a .NET service talks to the outside world, picking up the Tuesd
 
 ---
 
-## 📅 Backlog - Unscheduled Series
+## 📅 Tuesday Track - .NET Validation Approaches (May-June 2027)
 
-Eleven six-post series remain unscheduled, drawn from the drafts in `docs/article-ideas/`. They continue the Tuesday cadence once the .NET API Styles series ends on 2027-05-04, and they're listed here in priority order. They're deliberately undated - that horizon is too far out to put honest dates against - so each series gets one entry rather than six speculative ones, and entries are expanded into individual dated posts when a series moves onto the calendar.
+Six posts on how a .NET service validates incoming data, picking up the Tuesday cadence directly from the API Styles track. A comparison post anchors the track and each of the five follow-ups is a complete setup for one validation approach.
 
-### .NET Validation Approaches (6 posts)
-- **Status:** `idea`
-- **Source:** `docs/article-ideas/top-5-dotnet-validation-approaches-compared.md` + 5 getting-started drafts
-- **Series:** Top 5 comparison, then FluentValidation, DataAnnotations, custom validation, native Minimal API validation (.NET 10+), MiniValidation
+### The Top 5 .NET Validation Approaches Compared: Which One Should You Choose?
+- **Status:** `draft`
+- **Scheduled:** 2027-05-11
+- **Source:** `docs/article-ideas/top-5-dotnet-validation-approaches-compared.md`
+- **File:** `src/posts/2027-05-11-top-5-dotnet-validation-approaches-compared.md`
 - **Pitch:** .NET 10 shipped first-party validation for Minimal APIs using the same DataAnnotations attributes MVC has relied on for over a decade. That closes the exact gap that pushed teams toward FluentValidation or MiniValidation in the first place, and it changes the calculus for a large share of new projects.
 - **Angle:** Compares the five on style, where each fits natively, performance, and how well each handles conditional and cross-property rules. Leads with a genuinely counterintuitive benchmark result - FluentValidation is the most popular option and routinely the slowest, sometimes by a factor of two - without pretending performance is the whole decision. Resolves on complexity rather than popularity: attributes for straightforward rules, FluentValidation only where conditional and cross-property logic actually earns its ceremony, and hand-written checks for business rules that need database lookups or span entities.
 - **Tags:** `dotnet`, `validation`, `security`, `performance`, `developer-productivity`
+
+### Getting Started with FluentValidation in .NET
+- **Status:** `draft`
+- **Scheduled:** 2027-05-18
+- **Source:** `docs/article-ideas/getting-started-with-fluentvalidation.md`
+- **File:** `src/posts/2027-05-18-getting-started-with-fluentvalidation.md`
+- **Pitch:** FluentValidation's rules read like sentences and handle conditional logic naturally, but it's consistently one of the slowest validation options in independent benchmarks. Both facts should shape where in an application it actually gets used.
+- **Angle:** Covers validator classes and DI registration via assembly scanning, MVC auto-validation versus the endpoint-filter pattern Minimal APIs need instead, and `.When()`/`RuleForEach` as the concrete mechanisms that justify its ceremony. Argues against reaching for it uniformly - reserve it for genuinely complex conditional or cross-property rules, and let DataAnnotations or native Minimal API validation cover the simpler models in the same codebase.
+- **Tags:** `dotnet`, `validation`, `developer-productivity`, `tooling`
+
+### Getting Started with DataAnnotations in .NET
+- **Status:** `draft`
+- **Scheduled:** 2027-05-25
+- **Source:** `docs/article-ideas/getting-started-with-dataannotations.md`
+- **File:** `src/posts/2027-05-25-getting-started-with-dataannotations.md`
+- **Pitch:** DataAnnotations' biggest advantage is that they're already there - no package, no configuration, automatic validation in MVC since ASP.NET Core's earliest versions. The part worth understanding is exactly where that automatic convenience ends.
+- **Angle:** Covers `[ApiController]`'s automatic model validation, `IValidatableObject` as the built-in answer to conditional and cross-property rules, `Validator.TryValidateObject` for validation outside MVC's pipeline, and custom `ValidationAttribute` classes for reusable rules. Draws the line where `IValidatableObject` starts getting unwieldy enough that FluentValidation would express the same logic more readably.
+- **Tags:** `dotnet`, `validation`, `developer-productivity`, `tooling`
+
+### Getting Started with Custom Validation in .NET
+- **Status:** `draft`
+- **Scheduled:** 2027-06-01
+- **Source:** `docs/article-ideas/getting-started-with-custom-validation.md`
+- **File:** `src/posts/2027-06-01-getting-started-with-custom-validation.md`
+- **Pitch:** Every validation library in this series eventually admits some rules just don't fit its model - a check spanning three related entities in a database, or logic specific enough that a declarative abstraction would be more convoluted than the code itself.
+- **Angle:** Distinguishes guard clauses (fail-fast, for internal invariants) from a result-collecting `ValidationResult` pattern (for user-facing input validation), then builds a validator class with injected dependencies for the one scenario no attribute-based library handles cleanly - rules requiring a database lookup or another service call. Names inconsistency, not capability, as custom validation's real risk without a library enforcing structure.
+- **Tags:** `dotnet`, `validation`, `architecture`, `developer-productivity`
+
+### Getting Started with Native Minimal API Validation in .NET 10
+- **Status:** `draft`
+- **Scheduled:** 2027-06-08
+- **Source:** `docs/article-ideas/getting-started-with-native-minimal-api-validation.md`
+- **File:** `src/posts/2027-06-08-getting-started-with-native-minimal-api-validation.md`
+- **Pitch:** Minimal APIs went four major versions without a first-party answer to a question MVC solved on day one. .NET 10's `AddValidation()` closes that gap directly, using the same DataAnnotations attributes MVC has used for over a decade.
+- **Angle:** Covers the two-line `AddValidation()` setup, automatic validation of nested objects and collections with no extra configuration, and `IValidatableObject` continuing to work for conditional rules through the same automatic pass. Clear that this is a delivery mechanism, not new expressiveness - it doesn't extend what DataAnnotations and `IValidatableObject` already cover, so FluentValidation remains the answer once a rule outgrows that ceiling.
+- **Tags:** `dotnet`, `validation`, `developer-productivity`, `tooling`
+
+### Getting Started with MiniValidation in .NET
+- **Status:** `draft`
+- **Scheduled:** 2027-06-15
+- **Source:** `docs/article-ideas/getting-started-with-minivalidation.md`
+- **File:** `src/posts/2027-06-15-getting-started-with-minivalidation.md`
+- **Pitch:** MiniValidation's pitch is one sentence: the same DataAnnotations attributes you already know, running through a validator optimized specifically to be fast, with none of FluentValidation's ceremony.
+- **Angle:** Covers the single-line `MiniValidator.TryValidate` call, the endpoint-filter pattern for consistency across multiple routes, and `TryValidateAsync` with a service provider for `IValidatableObject` rules needing DI. Positions it honestly against .NET 10's native validation - its clearest remaining niche is pre-.NET 10 projects and non-Minimal-API application types like console apps, not a reason to add a dependency where native validation already covers the need.
+- **Tags:** `dotnet`, `validation`, `performance`, `developer-productivity`
+
+---
+
+## 📅 Backlog - Unscheduled Series
+
+Ten six-post series remain unscheduled, drawn from the drafts in `docs/article-ideas/`. They continue the Tuesday cadence once the .NET Validation Approaches series ends on 2027-06-15, and they're listed here in priority order. They're deliberately undated - that horizon is too far out to put honest dates against - so each series gets one entry rather than six speculative ones, and entries are expanded into individual dated posts when a series moves onto the calendar.
 
 ### .NET Mapping Libraries (6 posts)
 - **Status:** `idea`

--- a/src/posts/2027-05-11-top-5-dotnet-validation-approaches-compared.md
+++ b/src/posts/2027-05-11-top-5-dotnet-validation-approaches-compared.md
@@ -1,0 +1,167 @@
+---
+author: Steve Kaschimer
+date: 2027-05-11
+image: /images/posts/2027-05-11-hero.webp
+image_alt: "Five columns of abstract validation glyphs positioned along a horizontal axis running from declarative attributes on the left to unlimited hand-written logic on the right."
+image_prompt: "A dark-mode technical editorial illustration on a near-black background with electric teal, amber, and off-white accents. Composition is five vertical columns of equal width separated by thin hairline rules, each column topped by a distinct abstract glyph rendered in flat geometry: a fluent sentence-shaped bracket glyph with a small branching condition arrow, a compact checkmark badge pinned directly to a flat rectangle representing an attribute on a model, a minimal single-function-call glyph with a lightning-bolt accent implying speed, an open unbounded bracket shape with no fixed border implying limitless code, and a small two-line glyph built into a solid channel implying a first-party pipeline. Beneath the glyphs, a shared horizontal axis labeled in monospaced type runs from 'declarative attributes' on the left to 'unlimited code' on the right, with a small glowing teal dot positioned at a different point under each column. Mood is comparative, engineering-first, and non-partisan. Avoid: vendor logos, brand colors, circuit-board textures, gears, or generic checkmark clip art used as the dominant motif."
+layout: post.njk
+site_title: Tech Notes
+summary: ".NET 10 shipped first-party validation for Minimal APIs, closing the exact gap that pushed teams toward FluentValidation or MiniValidation in the first place. A practical breakdown of five validation approaches, including a counterintuitive benchmark result about the most popular one."
+tags: ["dotnet", "validation", "security", "performance", "developer-productivity"]
+title: "The Top 5 .NET Validation Approaches Compared: Which One Should You Choose?"
+---
+
+Validation in .NET quietly had one of its biggest shifts in years, and it's easy to miss if you're not reading release notes closely: .NET 10 shipped native, built-in validation support for Minimal APIs, using the same `DataAnnotations` attributes MVC has relied on for over a decade. Before this, validating a Minimal API request meant reaching for a third-party package or writing manual checks in every handler - there was no first-party answer. Now there is, and it changes the calculus for a genuinely large share of new ASP.NET Core projects.
+
+This guide compares five ways to validate data in .NET - FluentValidation, classic DataAnnotations, MiniValidation, custom/manual validation, and .NET 10's native Minimal API validation - and which project profile fits each. A genuinely useful, counterintuitive fact worth knowing upfront: FluentValidation, despite being the most popular third-party option, is not the fastest. In independent benchmarks it's often the slowest of the group, sometimes by a wide margin. Performance isn't everything, but it's worth knowing before assuming popularity implies speed. This series continues with dedicated getting-started walkthroughs for each approach.
+
+## Quick Comparison
+
+| | FluentValidation | DataAnnotations (classic) | MiniValidation | Custom Validation | Native Minimal API Validation (.NET 10+) |
+| --- | --- | --- | --- | --- | --- |
+| **Style** | Fluent C# rule-builder, separate validator classes | Attributes on model properties | Attributes + lightweight runtime validator | Hand-written validation logic | Attributes, built into the Minimal API pipeline |
+| **Where it fits natively** | Any .NET code, via packages for MVC and Minimal APIs | MVC out of the box; Minimal APIs needed a package before .NET 10 | Minimal APIs, console apps, anywhere lightweight | Anywhere | Minimal APIs specifically, first-party as of .NET 10 |
+| **Performance** | Often the slowest of the group in benchmarks | Fast | Fastest of the library options in most benchmarks | Depends entirely on what you write | Fast - built on the same model as MiniValidation |
+| **Complex/conditional rules** | Excellent - built for this | Limited without custom attributes or `IValidatableObject` | Limited, same ceiling as DataAnnotations | Unlimited - it's just code | Same ceiling as classic DataAnnotations |
+| **Best for** | Complex, conditional, cross-property validation | Simple MVC model validation, teams already using it | Lightweight Minimal API/console validation | Truly unique or business-rule-heavy logic | New Minimal API projects on .NET 10+, simple to moderate needs |
+
+## FluentValidation
+
+FluentValidation is the most widely adopted third-party validation library in .NET - a fluent, strongly-typed API for building validation rules in dedicated validator classes, separate from the model being validated. Its expressiveness for complex scenarios is real and remains its strongest differentiator.
+
+**Strengths:**
+
+- Genuinely excellent for complex, conditional, and cross-property validation - rules like "this field is required only when that other field has a specific value" are natural to express and read clearly
+- Keeps validation logic in dedicated validator classes, separate from your models - useful for teams that want clean POCOs with no validation attributes cluttering the model definition itself
+- Mature ASP.NET Core integration for both MVC and Minimal APIs, plus support for async validation rules
+- The most battle-tested option here for genuinely complex validation logic in production .NET systems
+
+**Weaknesses:**
+
+- Consistently benchmarks as the slowest option in independent performance comparisons - sometimes twice as slow as DataAnnotations-based approaches for equivalent validation
+- More ceremony than attribute-based approaches for simple validation - a separate validator class for a model with three basic required-field checks is real overhead for not much benefit
+- As of .NET 10, some of the specific reasons teams reached for FluentValidation in Minimal APIs no longer apply for simpler scenarios
+
+**Choose this when:** your validation logic is genuinely complex - conditional rules, cross-property dependencies, business-rule-heavy checks - where the expressiveness earns back the performance cost and additional ceremony.
+
+## DataAnnotations (Classic)
+
+DataAnnotations - `[Required]`, `[StringLength]`, `[Range]`, and friends - have been the default validation mechanism for ASP.NET MVC since long before ASP.NET Core existed. They remain the most broadly familiar validation approach to any .NET developer.
+
+**Strengths:**
+
+- Built directly into the .NET base class libraries - no package to install, and MVC's model binding pipeline validates them automatically with zero extra configuration
+- The most broadly recognized validation syntax in .NET
+- `IValidatableObject` extends attribute-based validation with custom logic encapsulated directly in the model, for validation that doesn't fit neatly into a single attribute
+- Genuinely fast in benchmarks, especially relative to FluentValidation
+
+**Weaknesses:**
+
+- Attributes live directly on the model, which some teams consider a separation-of-concerns problem
+- Complex or conditional validation is awkward to express purely through attributes - you end up reaching for `IValidatableObject` or custom attribute classes, more work than FluentValidation's fluent conditional syntax
+- Historically had no first-party story for Minimal APIs at all - exactly the gap .NET 10's native validation support closes
+
+**Choose this when:** you're building an MVC-based application, where this remains the default, zero-setup option, or your validation needs are straightforward enough that attribute-based rules don't feel constraining.
+
+## MiniValidation
+
+MiniValidation is a minimalist library built directly atop `System.ComponentModel.DataAnnotations`, created specifically to give lightweight applications a fast, low-ceremony validation option without pulling in FluentValidation's larger footprint.
+
+**Strengths:**
+
+- Consistently the fastest option among the library-based approaches in independent benchmarks, due to metadata caching optimizations
+- Extremely lightweight - a single-line `MiniValidator.TryValidate(model, out errors)` call, no separate validator classes or complex configuration
+- Built on the same familiar DataAnnotations attributes rather than introducing a new syntax to learn
+- Well-suited specifically to Minimal APIs and console applications where FluentValidation's ceremony feels disproportionate
+
+**Weaknesses:**
+
+- Same expressiveness ceiling as classic DataAnnotations - complex, conditional, cross-property validation is just as awkward
+- Smaller community and less name recognition than FluentValidation
+- With .NET 10's native Minimal API validation now covering much of MiniValidation's original niche, its most distinctive use case has narrowed, though it remains valid for non-Minimal-API scenarios
+
+**Choose this when:** you want the fastest, lowest-ceremony validation option built on familiar DataAnnotations attributes, particularly for Minimal APIs on .NET versions before 10, or for console/non-web applications.
+
+## Custom Validation
+
+Writing validation logic by hand - guard clauses, manual checks in a service method, or a hand-rolled validator class - remains a completely reasonable approach for validation that's either simple enough not to need a library, or specific enough that no library's abstraction fits naturally.
+
+**Strengths:**
+
+- Unlimited expressiveness - there's no ceiling on what you can validate, since it's just ordinary C# with no framework constraints
+- Zero dependency, full transparency
+- No abstraction to learn - any developer can read and modify hand-written validation logic immediately
+- Often the most natural fit for genuinely complex business rules that don't map cleanly onto any validation library's model - rules spanning multiple entities, requiring database lookups, or involving significant domain logic
+
+**Weaknesses:**
+
+- No built-in error aggregation or standardized result shape - you're responsible for collecting and formatting validation errors consistently yourself
+- Easy to end up with inconsistent validation patterns across a codebase if different developers solve "how do I validate this" differently each time
+- Doesn't integrate automatically with ASP.NET Core's model binding pipeline the way DataAnnotations does - you're responsible for wiring the check into your endpoint or action yourself
+
+**Choose this when:** your validation logic is either trivially simple or genuinely complex in a way that doesn't map onto any validation library's abstraction - particularly validation requiring cross-entity checks, database lookups, or deep domain logic.
+
+## Native Minimal API Validation (.NET 10+)
+
+This is the newest entry in .NET's validation landscape - first-party, built-in validation support for Minimal APIs, using the same `DataAnnotations` attributes that have always worked in MVC, now automatically applied to Minimal API endpoint parameters with no third-party package required.
+
+**Strengths:**
+
+- Genuinely closes a real gap - before .NET 10, Minimal APIs had no first-party validation story at all
+- Uses the same familiar DataAnnotations attributes as MVC, meaning no new syntax to learn
+- Enabled with minimal configuration - roughly two lines of setup for standardized, automatic validation and error responses
+- Built on the same underlying model as MiniValidation, meaning strong performance characteristics rather than an unproven new mechanism
+
+**Weaknesses:**
+
+- Requires .NET 10 or later - a real constraint for teams not yet upgraded
+- Same expressiveness ceiling as classic DataAnnotations and MiniValidation
+- Genuinely new as of .NET 10, meaning less real-world production track record than the more established options here
+
+**Choose this when:** you're building a new Minimal API project on .NET 10 or later with straightforward to moderate validation needs, and want the lowest-friction, first-party option without adding a third-party dependency.
+
+## How to Decide
+
+A few heuristics that cover most real-world decisions:
+
+**Building a new Minimal API project on .NET 10+, with simple to moderate validation needs?** Native validation is the obvious first choice - first-party, fast, and no new dependency to add.
+
+**Validation logic is genuinely complex - conditional rules, cross-property dependencies, business-rule-heavy checks?** FluentValidation's expressiveness is worth its performance cost and ceremony for this specific case, regardless of which project style you're using.
+
+**Building an MVC application, or already have DataAnnotations-based models?** Classic DataAnnotations remains the zero-setup default MVC has always used.
+
+**Want the fastest, lightest option and aren't on .NET 10+ yet, or you're building a console app?** MiniValidation fills that specific niche well.
+
+**Validation is either trivially simple or genuinely doesn't fit any library's model?** Custom validation remains completely reasonable - don't feel obligated to adopt a library for a handful of straightforward checks or deeply domain-specific rules.
+
+A pattern worth knowing: nothing stops a single application from using more than one of these for different scenarios - native or classic DataAnnotations for straightforward request-shape validation, FluentValidation for a handful of genuinely complex business rules, and custom validation for anything requiring a database lookup or cross-entity check. Match the tool to each specific validation need rather than forcing one approach to cover everything.
+
+## Frequently Asked Questions
+
+### Is FluentValidation actually slower than DataAnnotations-based approaches?
+
+Yes, in independently reported benchmarks - sometimes by roughly double, depending on the validation scenario. This is a genuinely counterintuitive result given FluentValidation's popularity, and worth knowing if performance in a high-throughput validation path matters to your specific use case. For most applications the absolute difference is small enough not to matter, but it's not a reason to assume FluentValidation is the fast choice by default.
+
+### Does .NET 10's native Minimal API validation replace the need for FluentValidation?
+
+Not entirely - it closes the gap for straightforward, attribute-expressible validation in Minimal APIs, which previously had no first-party answer. FluentValidation remains the stronger choice for genuinely complex, conditional, or cross-property validation logic that doesn't map cleanly onto DataAnnotations attributes.
+
+### Do I need to upgrade to .NET 10 to get built-in Minimal API validation?
+
+Yes - this is a .NET 10-specific feature. Projects on .NET 8 or earlier need to continue using MiniValidation, FluentValidation, or manual validation for Minimal APIs.
+
+### What's the difference between MiniValidation and .NET 10's native validation, since both use DataAnnotations?
+
+They're closely related - both build on the same `System.ComponentModel.DataAnnotations` foundation and have similar performance characteristics. The practical difference is that native validation is first-party, requires no separate package, and is built directly into the Minimal API pipeline as of .NET 10, while MiniValidation is a third-party library that works across a broader range of application types and .NET versions predating native support.
+
+### Should I keep validation attributes on my model, or use a separate validator class?
+
+It's a genuine trade-off. Attribute-based approaches keep validation co-located with the model, which is convenient but mixes validation concerns into your data shape. FluentValidation's separate validator classes keep models clean at the cost of an extra file and more indirection. Team preference and how complex your validation logic is both factor into which trade-off is worth making.
+
+### Can I mix validation approaches within the same application?
+
+Yes, and it's a reasonable, common pattern - using attribute-based validation for simple request-shape checks, FluentValidation for a specific set of genuinely complex business rules, and custom validation for anything requiring a database lookup or cross-entity logic. There's no requirement to standardize on exactly one approach across an entire application.
+
+### Is custom, hand-written validation actually a reasonable choice, or just what you do before adopting a library?
+
+It's a completely legitimate, permanent choice for the right scenarios - either validation simple enough that a library's ceremony isn't worth it, or complex enough that no library's model fits naturally. The "you need a validation library" assumption is worth questioning the same way it's worth questioning for object mapping - match the tool to the actual complexity of what you're validating.

--- a/src/posts/2027-05-18-getting-started-with-fluentvalidation.md
+++ b/src/posts/2027-05-18-getting-started-with-fluentvalidation.md
@@ -1,0 +1,190 @@
+---
+author: Steve Kaschimer
+date: 2027-05-18
+image: /images/posts/2027-05-18-hero.webp
+image_alt: "A fluent sentence-shaped bracket glyph with a small branching condition arrow feeding into a separate validator-class panel, set apart from a plain model rectangle beside it."
+image_prompt: "A dark-mode technical editorial illustration on a near-black background with electric teal, amber, and off-white accents. Composition centers on a thin bracket-shaped glyph on the left resembling a flowing sentence, with a small amber branching arrow breaking off it to represent a conditional rule. It connects by a short line to a separate rectangular panel on the right, deliberately apart from a plain, unmarked model rectangle beneath it, emphasizing that validation logic lives outside the model. A small stopwatch glyph with a slower-than-average marker sits faintly in the corner. Mood is expressive, deliberate, and slightly weighty. Avoid: vendor logos, brand colors, circuit-board textures, gears, or generic checkmark clip art."
+layout: post.njk
+site_title: Tech Notes
+summary: "FluentValidation's rules read like sentences and handle conditional logic naturally - but it's consistently one of the slower validation options in independent benchmarks. A setup guide for validator classes, MVC and Minimal API integration, and knowing exactly where its ceremony earns its keep."
+tags: ["dotnet", "validation", "developer-productivity", "tooling"]
+title: "Getting Started with FluentValidation in .NET"
+---
+
+FluentValidation's core appeal is genuinely simple to state: validation rules read like sentences, live in their own class away from your model, and handle conditional logic naturally. What's less obvious until you've profiled it is that this expressiveness has a real performance cost - FluentValidation is consistently one of the slower validation options in independent benchmarks, sometimes by a wide margin. Neither fact should be a surprise by the time you're setting it up; they should shape where in your application you actually reach for it.
+
+This guide covers installing FluentValidation, bootstrapping validators and ASP.NET Core integration correctly, the core patterns for conditional and cross-property rules, and the best practices that make the most of its expressiveness without paying its performance cost where you don't need to. By the end you'll have validation logic that's genuinely easier to read for complex rules, deployed specifically where that complexity exists.
+
+If you're deciding between validation approaches first, [a comparison of the top .NET validation approaches](/posts/2027-05-11-top-5-dotnet-validation-approaches-compared/) covers where FluentValidation fits relative to DataAnnotations, MiniValidation, custom validation, and .NET 10's native Minimal API validation.
+
+## What You'll Need
+
+- .NET 8 SDK or later
+- An ASP.NET Core project - MVC or Minimal APIs both work, with slightly different integration steps
+
+## Installing FluentValidation
+
+```bash
+dotnet add package FluentValidation
+dotnet add package FluentValidation.AspNetCore
+```
+
+`FluentValidation.AspNetCore` provides the MVC-specific integration; for Minimal APIs, you'll wire validation in through an endpoint filter instead, using just the core `FluentValidation` package.
+
+## Bootstrapping the Ideal Environment
+
+### Defining a validator
+
+```csharp
+public class CreateOrderRequestValidator : AbstractValidator<CreateOrderRequest>
+{
+    public CreateOrderRequestValidator()
+    {
+        RuleFor(x => x.CustomerId)
+            .GreaterThan(0).WithMessage("A valid customer is required");
+
+        RuleFor(x => x.Items)
+            .NotEmpty().WithMessage("An order must contain at least one item");
+
+        RuleFor(x => x.DiscountCode)
+            .NotEmpty()
+            .When(x => x.HasDiscount)
+            .WithMessage("A discount code is required when a discount is applied");
+
+        RuleForEach(x => x.Items).ChildRules(item =>
+        {
+            item.RuleFor(i => i.Quantity).GreaterThan(0);
+        });
+    }
+}
+```
+
+Notice the conditional rule (`.When(x => x.HasDiscount)`) and the nested collection rule (`RuleForEach`) - this is exactly the kind of validation logic that's genuinely awkward to express with attribute-based approaches, and where FluentValidation earns its ceremony.
+
+### Registering validators with dependency injection
+
+```csharp
+var builder = WebApplication.CreateBuilder(args);
+
+builder.Services.AddValidatorsFromAssemblyContaining<CreateOrderRequestValidator>();
+```
+
+`AddValidatorsFromAssemblyContaining<T>()` scans the given assembly and registers every `AbstractValidator<T>` it finds - no need to register each validator individually as your validation surface grows.
+
+### MVC integration
+
+```csharp
+builder.Services.AddControllers();
+builder.Services.AddFluentValidationAutoValidation();
+```
+
+With auto-validation registered, `[ApiController]`'s automatic model validation now runs your FluentValidation validators instead of relying purely on DataAnnotations, with no change to the controller action itself.
+
+### Minimal API integration via an endpoint filter
+
+```csharp
+public static class ValidationFilterExtensions
+{
+    public static RouteHandlerBuilder WithValidation<T>(this RouteHandlerBuilder builder) =>
+        builder.AddEndpointFilter(async (context, next) =>
+        {
+            var arg = context.Arguments.OfType<T>().FirstOrDefault();
+            var validator = context.HttpContext.RequestServices.GetService<IValidator<T>>();
+            if (validator is not null && arg is not null)
+            {
+                var result = await validator.ValidateAsync(arg);
+                if (!result.IsValid)
+                    return Results.ValidationProblem(result.ToDictionary());
+            }
+            return await next(context);
+        });
+}
+```
+
+```csharp
+app.MapPost("/orders", CreateOrder).WithValidation<CreateOrderRequest>();
+```
+
+Since FluentValidation has no first-party Minimal API integration package the way it does for MVC, this filter pattern is the standard way to wire validation into an endpoint automatically rather than calling `ValidateAsync` manually inside every handler.
+
+### Manual validation, outside the request pipeline
+
+```csharp
+var validator = new CreateOrderRequestValidator();
+var result = validator.Validate(request);
+
+if (!result.IsValid)
+{
+    foreach (var failure in result.Errors)
+        Console.WriteLine($"{failure.PropertyName}: {failure.ErrorMessage}");
+}
+```
+
+Useful for validating outside a web request entirely - a background job, a console app, or a service processing a message from a queue.
+
+## Core Workflow
+
+- **Reach for FluentValidation specifically where conditional or cross-property rules make attribute-based validation awkward.** Don't reflexively write a full validator class for a model with three simple required-field checks - that's real ceremony for minimal benefit.
+- **Use `.When()` for conditional rules and `RuleForEach` for collection validation**, FluentValidation's core mechanisms for the scenarios it's genuinely strongest at.
+- **Keep validators focused on one request/model type each.** A validator trying to cover multiple unrelated types is a sign it should be split.
+
+## Verifying Your Setup
+
+1. **Validators are discovered and registered correctly** - confirm `AddValidatorsFromAssemblyContaining<T>()` picked up every validator class in your assembly
+2. **MVC auto-validation triggers correctly** - confirm an invalid model returns a 400 with FluentValidation's error details, not a generic DataAnnotations-only response
+3. **Minimal API validation filter runs before the handler** - confirm an invalid request is rejected by the filter, never reaching your endpoint logic
+4. **Conditional rules behave as expected** - confirm a `.When()` condition correctly includes or excludes the rule based on the model's actual state
+
+## Best Practices
+
+**Reserve FluentValidation for genuinely complex validation, not every model in your application.** Given its measured performance cost relative to attribute-based alternatives, using it uniformly everywhere - including trivial cases - pays that cost without a corresponding benefit.
+
+**Use `.When()` and cross-property rules deliberately where they express real business logic**, not just because the syntax is available. This is exactly the scenario FluentValidation is worth its ceremony for.
+
+**Register validators via assembly scanning, not one-by-one.** `AddValidatorsFromAssemblyContaining<T>()` keeps registration maintenance-free as your validation surface grows.
+
+**For Minimal APIs, use a shared endpoint filter rather than calling `ValidateAsync` manually in every handler.** This keeps validation consistent and centralizes the error-response shape across your API.
+
+**Consider .NET 10's native Minimal API validation, or a lighter option like MiniValidation, for the simpler validation scenarios in the same application.** Nothing requires every model in a codebase to use FluentValidation just because some of them genuinely need it.
+
+## Comparison with DataAnnotations
+
+| | FluentValidation | DataAnnotations |
+| --- | --- | --- |
+| Style | Separate validator classes, fluent rules | Attributes directly on the model |
+| Conditional/cross-property rules | Excellent, built for this | Limited without `IValidatableObject` |
+| Performance | Often the slowest option in benchmarks | Fast |
+| Minimal API integration | Manual, via endpoint filter | Native as of .NET 10 |
+| Best fit | Complex, conditional validation logic | Simple validation, especially in MVC |
+
+FluentValidation's expressiveness advantage is real and specific - it's worth reaching for exactly where DataAnnotations' attribute model starts to feel constraining, not as a blanket replacement for simpler validation needs.
+
+## Frequently Asked Questions
+
+### Is FluentValidation slower than DataAnnotations-based validation?
+
+Yes, in independently reported benchmarks - often meaningfully slower, sometimes by roughly double for equivalent validation scenarios. For most applications this difference is negligible in absolute terms, but it's worth knowing before assuming FluentValidation is the performance-optimal choice, especially in high-throughput validation paths.
+
+### How do I integrate FluentValidation with Minimal APIs?
+
+There's no first-party integration package the way MVC has `FluentValidation.AspNetCore` - the standard approach is a custom endpoint filter that resolves the appropriate `IValidator<T>` from DI and runs it before the handler executes, returning a validation problem response if it fails.
+
+### Should I use FluentValidation for every model in my application?
+
+Not necessarily - its ceremony is worth it specifically for complex, conditional, or cross-property validation. For simple models with a few basic checks, DataAnnotations or .NET 10's native Minimal API validation is often less overhead for the same result.
+
+### How do I express a rule that only applies conditionally?
+
+Use `.When(predicate)` after a rule definition: `RuleFor(x => x.DiscountCode).NotEmpty().When(x => x.HasDiscount)`. This is one of FluentValidation's clearest advantages over attribute-based validation, which has no clean equivalent for expressing conditional rules directly.
+
+### Can I validate nested objects or collections with FluentValidation?
+
+Yes - `RuleForEach` validates each item in a collection, and you can chain `.ChildRules(...)` or reference a separate validator for nested object types via `SetValidator()`. This handles the same nested-graph validation scenarios that plain DataAnnotations handles more awkwardly.
+
+### Can I use FluentValidation outside of ASP.NET Core, like in a background job or console app?
+
+Yes - create a validator instance directly and call `.Validate()` or `.ValidateAsync()` on it manually. FluentValidation doesn't require a web request context at all; it's a general-purpose validation library that happens to have strong ASP.NET Core integration options.
+
+### What's the most common mistake in a first FluentValidation setup?
+
+Using it uniformly for every model regardless of complexity, paying its ceremony and performance cost for validation simple enough that DataAnnotations or native Minimal API validation would have handled just as well with less overhead. The second common mistake, specific to Minimal APIs, is calling `ValidateAsync` manually inside every handler instead of centralizing that logic in a shared endpoint filter.

--- a/src/posts/2027-05-25-getting-started-with-dataannotations.md
+++ b/src/posts/2027-05-25-getting-started-with-dataannotations.md
@@ -1,0 +1,196 @@
+---
+author: Steve Kaschimer
+date: 2027-05-25
+image: /images/posts/2027-05-25-hero.webp
+image_alt: "A compact checkmark badge pinned directly onto a flat model rectangle, with a smaller secondary badge branching off to represent a custom cross-property check."
+image_prompt: "A dark-mode technical editorial illustration on a near-black background with electric teal, amber, and off-white accents. Composition centers on a single flat rectangle representing a model, with a solid amber checkmark badge pinned directly to its top-right corner, implying validation attached inline rather than external. A thinner teal badge branches off from the rectangle's edge, connected by a short line, representing a conditional cross-property check layered on top. Mood is familiar, built-in, and unadorned. Avoid: vendor logos, brand colors, circuit-board textures, gears, or a class-diagram sprawl as the dominant motif."
+layout: post.njk
+site_title: Tech Notes
+summary: "DataAnnotations' biggest advantage is that they're already there - no package, no configuration, automatic validation in MVC since ASP.NET Core's earliest versions. A setup guide for [ApiController]'s automatic validation, IValidatableObject, and knowing exactly where attribute-based validation stops being enough."
+tags: ["dotnet", "validation", "developer-productivity", "tooling"]
+title: "Getting Started with DataAnnotations in .NET"
+---
+
+DataAnnotations have been quietly doing most of .NET's validation work since long before ASP.NET Core existed, and their biggest advantage is one that's easy to take for granted: they're already there. No package to add, no configuration to wire up - decorate a property with `[Required]`, and MVC's model binding pipeline validates it automatically. The parts worth understanding well are where that automatic convenience ends, and how `IValidatableObject` picks up the slack for anything an attribute can't express on its own.
+
+This guide covers using DataAnnotations for validation in .NET, bootstrapping automatic MVC validation and the manual validation you need elsewhere, the core patterns for built-in attributes and `IValidatableObject`, and the best practices for knowing when attribute-based validation is genuinely sufficient versus when it's time to reach for something more expressive. By the end you'll have validation that's fast, familiar, and correctly scoped to what it's actually good at.
+
+If you're deciding between validation approaches first, [a comparison of the top .NET validation approaches](/posts/2027-05-11-top-5-dotnet-validation-approaches-compared/) covers where DataAnnotations fit relative to FluentValidation, MiniValidation, custom validation, and .NET 10's native Minimal API validation.
+
+## What You'll Need
+
+- .NET 8 SDK or later
+- Nothing else - `System.ComponentModel.DataAnnotations` is part of the .NET base class libraries
+
+## Using DataAnnotations
+
+No installation step - the namespace is available in every .NET project by default:
+
+```csharp
+using System.ComponentModel.DataAnnotations;
+
+public class CreateOrderRequest
+{
+    [Required(ErrorMessage = "A customer is required")]
+    public int CustomerId { get; set; }
+
+    [Required, MinLength(1, ErrorMessage = "An order must contain at least one item")]
+    public List<OrderItem> Items { get; set; } = [];
+
+    [StringLength(20)]
+    public string? DiscountCode { get; set; }
+
+    [Range(0, 100)]
+    public int DiscountPercentage { get; set; }
+}
+```
+
+## Bootstrapping the Ideal Environment
+
+### Automatic validation in MVC
+
+```csharp
+[ApiController]
+[Route("api/[controller]")]
+public class OrdersController : ControllerBase
+{
+    [HttpPost]
+    public IActionResult Create(CreateOrderRequest request)
+    {
+        // If we reach here, request has already passed DataAnnotations validation
+        // [ApiController] returns 400 automatically on an invalid model
+        return Ok();
+    }
+}
+```
+
+`[ApiController]` is what makes this automatic - without it, you'd need to check `ModelState.IsValid` manually inside every action. This is one of the most understated conveniences DataAnnotations provides in MVC: zero explicit validation code, and it's been working this way since ASP.NET Core's early versions.
+
+### IValidatableObject for logic a single attribute can't express
+
+```csharp
+public class CreateOrderRequest : IValidatableObject
+{
+    public int CustomerId { get; set; }
+    public bool HasDiscount { get; set; }
+    public string? DiscountCode { get; set; }
+
+    public IEnumerable<ValidationResult> Validate(ValidationContext validationContext)
+    {
+        if (HasDiscount && string.IsNullOrEmpty(DiscountCode))
+        {
+            yield return new ValidationResult(
+                "A discount code is required when a discount is applied",
+                [nameof(DiscountCode)]);
+        }
+    }
+}
+```
+
+`IValidatableObject` is DataAnnotations' answer to conditional and cross-property validation - the model itself implements a `Validate` method with arbitrary logic, called automatically as part of the same validation pass as the attribute-based checks. It's more manual than FluentValidation's `.When()` syntax, but it stays within the DataAnnotations model without adding a dependency.
+
+### Manual validation outside MVC's automatic pipeline
+
+```csharp
+var request = new CreateOrderRequest { CustomerId = 0 };
+var context = new ValidationContext(request);
+var results = new List<ValidationResult>();
+
+bool isValid = Validator.TryValidateObject(request, context, results, validateAllProperties: true);
+
+foreach (var result in results)
+    Console.WriteLine(result.ErrorMessage);
+```
+
+`Validator.TryValidateObject` is the underlying mechanism MVC's automatic validation calls internally - useful directly for validating outside a web request context, such as a console app, a background job, or anywhere DataAnnotations-decorated models need checking without MVC's pipeline involved.
+
+### Custom validation attributes
+
+```csharp
+public class FutureDateAttribute : ValidationAttribute
+{
+    protected override ValidationResult? IsValid(object? value, ValidationContext validationContext)
+    {
+        if (value is DateTime date && date <= DateTime.UtcNow)
+            return new ValidationResult("Date must be in the future");
+        return ValidationResult.Success;
+    }
+}
+```
+
+```csharp
+public class ScheduleRequest
+{
+    [FutureDate]
+    public DateTime ScheduledFor { get; set; }
+}
+```
+
+For validation logic you want to reuse across multiple models as a single attribute, extending `ValidationAttribute` keeps it in the same declarative, attribute-based style as the built-in checks.
+
+## Core Workflow
+
+- **Rely on `[ApiController]`'s automatic model validation in MVC**, and don't manually check `ModelState.IsValid` unless you have a specific reason to - the attribute already handles it.
+- **Reach for `IValidatableObject` the moment a single attribute can't express the rule**, rather than trying to force conditional logic into a combination of built-in attributes that don't naturally support it.
+- **Use `Validator.TryValidateObject` for anything outside the MVC request pipeline** - background jobs, console apps, or message processing that still wants to validate DataAnnotations-decorated models.
+
+## Verifying Your Setup
+
+1. **MVC automatically rejects invalid requests** - confirm `[ApiController]` returns a 400 with validation details on an invalid model, without any manual check in the action
+2. **`IValidatableObject` logic runs as part of the same validation pass** - confirm conditional rules implemented there fire correctly alongside attribute-based checks
+3. **Custom validation attributes behave as expected** - confirm a custom `ValidationAttribute` correctly flags invalid values and passes valid ones
+4. **Manual validation outside MVC works correctly** - confirm `Validator.TryValidateObject` produces the same validation results a web request would have triggered automatically
+
+## Best Practices
+
+**Let `[ApiController]` handle automatic validation rather than manually checking `ModelState.IsValid`.** This is free, built-in behavior - reimplementing it manually is unnecessary work.
+
+**Use `IValidatableObject` for conditional and cross-property rules, and recognize when it's getting unwieldy.** If a model's `Validate` method starts accumulating a lot of complex branching logic, that's a legitimate signal to consider FluentValidation instead, which expresses the same logic more readably.
+
+**Write custom `ValidationAttribute` classes for logic you'll reuse across multiple models.** This keeps validation declarative and consistent with the built-in attributes, rather than duplicating the same `IValidatableObject` logic in several unrelated model classes.
+
+**Keep validation attributes focused on data shape, not deep business rules.** Attributes are well suited to "this field is required" or "this value must be in range" - rules requiring a database lookup or complex domain logic belong in a service layer, not crammed into a `ValidationAttribute`.
+
+**For Minimal APIs on .NET 10+, rely on native validation support rather than manually calling `Validator.TryValidateObject` in every handler.** The built-in pipeline integration handles this automatically, the same convenience `[ApiController]` provides in MVC.
+
+## Comparison with MiniValidation
+
+| | DataAnnotations (classic) | MiniValidation |
+| --- | --- | --- |
+| Where it's automatic | MVC, via `[ApiController]` | Requires an explicit `TryValidate` call, or the Minimal API extensions package |
+| Performance | Fast | Fastest of the library-based options |
+| Conditional rules | Via `IValidatableObject` | Same ceiling - built on the same DataAnnotations foundation |
+| Dependency | None - part of the BCL | A small NuGet package |
+| Best fit | MVC applications, or anywhere the automatic pipeline applies | Minimal APIs and console apps wanting a fast, explicit validation call |
+
+MiniValidation is best understood as DataAnnotations with a purpose-built runtime for scenarios that don't get MVC's automatic validation pipeline for free - both share the same underlying attribute vocabulary and expressiveness ceiling.
+
+## Frequently Asked Questions
+
+### Do I need to manually check ModelState.IsValid in my controllers?
+
+No, not if your controller has `[ApiController]` applied - it automatically validates the model and returns a 400 response with validation details if it's invalid, before your action method body ever runs. Manually checking `ModelState.IsValid` is redundant in that case.
+
+### When should I use IValidatableObject instead of a validation attribute?
+
+When the validation logic depends on more than one property, or requires conditional logic that a single declarative attribute can't express cleanly - "this field is required only when that other field is true" is the classic example. For validation scoped to a single property with no conditions, a `ValidationAttribute` is simpler.
+
+### Can DataAnnotations validate nested objects and collections?
+
+Yes, though it requires `validateAllProperties: true` when calling `Validator.TryValidateObject` manually, or relies on MVC's model binder handling nested validation automatically in the MVC pipeline. Deeply nested graphs are one area where MiniValidation's purpose-built recursive validator or FluentValidation's `RuleForEach` tend to feel more natural than DataAnnotations' more manual approach.
+
+### How do I write a reusable custom validation rule with DataAnnotations?
+
+Extend `ValidationAttribute` and override `IsValid`, then apply your custom attribute to any property needing that rule. This keeps custom validation logic declarative and consistent with the built-in attribute vocabulary, rather than duplicating logic across multiple `IValidatableObject` implementations.
+
+### Is DataAnnotations validation automatic in Minimal APIs?
+
+Not before .NET 10 - Minimal APIs historically had no first-party validation pipeline at all, requiring either manual `Validator.TryValidateObject` calls, a package like MiniValidation, or FluentValidation via an endpoint filter. As of .NET 10, native Minimal API validation applies DataAnnotations attributes automatically, closing this gap.
+
+### Is DataAnnotations validation fast?
+
+Yes, generally - it benchmarks well relative to FluentValidation in most comparisons, though naive hand-rolled implementations using reflection without caching can be slower than purpose-optimized libraries like MiniValidation that add metadata caching on top of the same underlying attributes.
+
+### What's the most common mistake in a first DataAnnotations setup?
+
+Manually checking `ModelState.IsValid` in every MVC action when `[ApiController]` already handles it automatically, adding redundant code. The second common mistake is trying to force genuinely complex conditional validation into a combination of built-in attributes rather than reaching for `IValidatableObject`, or once the logic gets unwieldy enough, FluentValidation, at the right point.

--- a/src/posts/2027-06-01-getting-started-with-custom-validation.md
+++ b/src/posts/2027-06-01-getting-started-with-custom-validation.md
@@ -1,0 +1,183 @@
+---
+author: Steve Kaschimer
+date: 2027-06-01
+image: /images/posts/2027-06-01-hero.webp
+image_alt: "An open, unbounded bracket shape with no fixed border, connected to a small injected-dependency socket representing a database lookup performed as part of validation."
+image_prompt: "A dark-mode technical editorial illustration on a near-black background with electric teal, amber, and off-white accents. Composition centers on an open bracket-shaped glyph on the left with a deliberately unclosed edge, implying unbounded, unrestricted code. A thin teal line connects it to a small socket-shaped icon on the right, representing an injected dependency, with a subtle database-row hint beyond it. Below, two small stacked rectangles differ in weight - one thin representing a fail-fast guard clause, one fuller representing a collected list of errors. Mood is direct, transparent, and unadorned. Avoid: vendor logos, brand colors, circuit-board textures, gears, or generic database-cylinder clip art as the dominant motif."
+layout: post.njk
+site_title: Tech Notes
+summary: "Every validation library eventually admits some rules just don't fit its model - a check spanning three related entities, or logic specific enough that a declarative abstraction would be more convoluted than the code itself. A setup guide for guard clauses, result-collecting validators, and validation requiring a database lookup."
+tags: ["dotnet", "validation", "architecture", "developer-productivity"]
+title: "Getting Started with Custom Validation in .NET"
+---
+
+Every validation library in this series eventually admits the same thing in its own documentation: some rules just don't fit the model. A rule that needs to check three related entities in a database, or one so specific to a single business process that expressing it declaratively would be more convoluted than just writing the logic - that's exactly where custom, hand-written validation stops being "what you do before adopting a real library" and becomes the actually correct tool.
+
+This guide covers structuring custom validation in .NET without a library, the patterns that keep hand-written validation consistent as a codebase grows, the core techniques for guard clauses and result-based validation, and the best practices that prevent custom validation from becoming an inconsistent mess across a team. By the end you'll have a validation approach with zero dependencies and no ceiling on what it can express.
+
+If you're deciding between validation approaches first, [a comparison of the top .NET validation approaches](/posts/2027-05-11-top-5-dotnet-validation-approaches-compared/) covers where custom validation fits relative to FluentValidation, DataAnnotations, MiniValidation, and .NET 10's native Minimal API validation.
+
+## What You'll Need
+
+- Nothing beyond the .NET SDK and C# itself
+
+## Structuring Custom Validation
+
+### Guard clauses for simple, fail-fast checks
+
+```csharp
+public class OrderService
+{
+    public async Task ProcessAsync(int orderId)
+    {
+        if (orderId <= 0)
+            throw new ArgumentOutOfRangeException(nameof(orderId), "Order ID must be positive");
+
+        var order = await repository.GetByIdAsync(orderId)
+            ?? throw new OrderNotFoundException(orderId);
+
+        if (order.Status != OrderStatus.Pending)
+            throw new InvalidOperationException($"Order {orderId} is not in a processable state");
+
+        order.Status = OrderStatus.Processing;
+        await repository.SaveAsync(order);
+    }
+}
+```
+
+Guard clauses are the simplest form of custom validation - immediate, fail-fast checks at the top of a method, throwing on the first violated invariant. Appropriate for internal, programmer-facing invariants (a method contract being violated) more than user-facing input validation, where a single exception on the first failure is less useful than collecting every error to show the user at once.
+
+### Result-based validation for user-facing scenarios
+
+```csharp
+public record ValidationResult(bool IsValid, IReadOnlyList<string> Errors)
+{
+    public static ValidationResult Success() => new(true, []);
+    public static ValidationResult Failure(params string[] errors) => new(false, errors);
+}
+
+public class CreateOrderValidator
+{
+    public ValidationResult Validate(CreateOrderRequest request)
+    {
+        var errors = new List<string>();
+
+        if (request.CustomerId <= 0)
+            errors.Add("A valid customer is required");
+
+        if (request.Items.Count == 0)
+            errors.Add("An order must contain at least one item");
+
+        if (request.HasDiscount && string.IsNullOrEmpty(request.DiscountCode))
+            errors.Add("A discount code is required when a discount is applied");
+
+        return errors.Count == 0 ? ValidationResult.Success() : ValidationResult.Failure(errors.ToArray());
+    }
+}
+```
+
+This mirrors what a validation library gives you - a collected list of every violation, not just the first one - but as plain, transparent C# with no framework dependency. Note this handles the exact conditional rule (`HasDiscount` requiring `DiscountCode`) that would otherwise need `IValidatableObject` or FluentValidation's `.When()`.
+
+### Validation requiring external checks (database, service calls)
+
+```csharp
+public class OrderValidator(IOrderRepository repository, ICustomerService customerService)
+{
+    public async Task<ValidationResult> ValidateAsync(CreateOrderRequest request)
+    {
+        var errors = new List<string>();
+
+        if (!await customerService.ExistsAsync(request.CustomerId))
+            errors.Add($"Customer {request.CustomerId} does not exist");
+
+        if (request.DiscountCode is not null &&
+            !await repository.IsValidDiscountCodeAsync(request.DiscountCode))
+            errors.Add("The discount code is invalid or has expired");
+
+        return errors.Count == 0 ? ValidationResult.Success() : ValidationResult.Failure(errors.ToArray());
+    }
+}
+```
+
+This is exactly the scenario custom validation handles most naturally that no attribute-based library manages cleanly - rules requiring a database lookup or a call to another service, injected via ordinary dependency injection into a validator class.
+
+### Wiring custom validation into a Minimal API endpoint
+
+```csharp
+app.MapPost("/orders", async (CreateOrderRequest request, OrderValidator validator) =>
+{
+    var result = await validator.ValidateAsync(request);
+    if (!result.IsValid)
+        return Results.BadRequest(new { errors = result.Errors });
+
+    // proceed with valid request
+    return Results.Created();
+});
+```
+
+## Core Workflow
+
+- **Use guard clauses for internal invariants and fail-fast method contracts**, where throwing immediately on the first violation is the right behavior.
+- **Use a result-collecting pattern (`ValidationResult` with a list of errors) for user-facing input validation**, where showing every problem at once is more useful than failing on the first one.
+- **Inject dependencies into validator classes the same way you would any other service**, taking full advantage of custom validation's unlimited expressiveness for rules requiring external checks.
+
+## Verifying Your Setup
+
+1. **Guard clauses fail fast and clearly** - confirm violated invariants throw immediately with a clear, actionable error message
+2. **Result-based validators collect all errors, not just the first** - confirm a request violating multiple rules returns every violation, not just the first one encountered
+3. **Validators with external dependencies work correctly** - confirm database or service-backed validation checks behave correctly against both valid and invalid inputs
+4. **Validation is applied consistently across the codebase** - audit whether different areas of the application solve "how do I validate this" the same way, or have drifted into inconsistent patterns
+
+## Best Practices
+
+**Pick one pattern (a shared `ValidationResult` type, a consistent validator class shape) and use it consistently.** Custom validation's biggest risk isn't capability - it's inconsistency, where different developers invent different validation shapes across the same codebase.
+
+**Reserve guard clauses for internal invariants, not user-facing input validation.** A guard clause throwing on the first violation is right for "this method was called incorrectly" - it's the wrong shape for "tell the user everything wrong with their form submission."
+
+**Inject external dependencies into validator classes rather than static service locator patterns.** This keeps custom validators testable the same way any other service is testable, with mockable dependencies rather than hidden static calls.
+
+**Write unit tests for custom validation logic, the same as any other business logic.** Validation rules are exactly the kind of code that benefits from explicit test coverage, since a validation bug either lets bad data through or incorrectly rejects good data - both have real consequences.
+
+**Recognize when custom validation is accumulating enough complexity that a library would express it more clearly.** If a hand-written validator is growing many conditional branches that start looking like what FluentValidation's fluent syntax handles more readably, that's a legitimate signal to reconsider, not a reason to keep pushing custom code further.
+
+## Comparison with FluentValidation
+
+| | Custom Validation | FluentValidation |
+| --- | --- | --- |
+| Expressiveness | Unlimited - it's just code | Excellent for conditional/cross-property rules, within its model |
+| Dependency | None | A NuGet package |
+| External checks (DB, services) | Natural via constructor injection | Supported, but less commonly the first reason to reach for it |
+| Consistency | Requires team discipline to maintain | Enforced by the library's structure |
+| Best fit | Simple validation, or genuinely unique business rules | Complex conditional validation with a consistent library-enforced shape |
+
+Custom validation's strength - unlimited expressiveness - is also its risk: without a library imposing structure, consistency across a team depends entirely on discipline rather than being enforced by the tool itself.
+
+## Frequently Asked Questions
+
+### When should I write custom validation instead of using a library?
+
+Two scenarios: when validation is simple enough that a library's ceremony isn't worth it, or when it's complex enough that no library's abstraction fits naturally - particularly validation requiring cross-entity checks, external service calls, or deep domain logic that doesn't map cleanly onto attributes or fluent rule builders.
+
+### What's the difference between a guard clause and a validation result pattern?
+
+A guard clause throws immediately on the first violated invariant, appropriate for internal method contracts where failing fast is the right behavior. A validation result pattern collects every violation into a list before returning, appropriate for user-facing input validation where showing all problems at once is more useful than stopping at the first one.
+
+### How do I keep custom validation consistent across a team without a library enforcing structure?
+
+Agree on and document one pattern - a shared `ValidationResult` type, a consistent validator class shape, clear conventions for where validation logic lives - and apply it consistently. This is genuinely more work than a library, which enforces structure by design, but it's manageable with clear team conventions and code review discipline.
+
+### Can custom validation handle rules that require a database lookup?
+
+Yes, and this is one of its most natural strengths - inject a repository or service into your validator class via ordinary dependency injection, and call it directly as part of your validation logic. This is exactly the kind of rule that attribute-based libraries handle awkwardly, if at all.
+
+### Should I write unit tests for custom validation logic?
+
+Yes, the same as any other business logic with real behavior. A bug in validation logic either lets invalid data through, a correctness problem, or incorrectly rejects valid data, a usability problem - both are worth catching with tests, especially for validation with any conditional branching.
+
+### Is custom validation actually more work than using a library?
+
+For simple validation, often less work - there's no library ceremony to set up. For complex validation with many conditional rules, it can become more work to maintain consistency without a library's enforced structure, which is exactly the trade-off point where FluentValidation starts looking more attractive.
+
+### What's the most common mistake with custom validation?
+
+Inconsistency - different parts of a codebase solving "how do I validate this" differently, making validation logic harder to find, trust, and maintain than it needs to be. The fix is agreeing on a shared pattern early, the same discipline that applies to manual object mapping, and applying it consistently rather than reinventing the approach in every new area of the codebase.

--- a/src/posts/2027-06-08-getting-started-with-native-minimal-api-validation.md
+++ b/src/posts/2027-06-08-getting-started-with-native-minimal-api-validation.md
@@ -1,0 +1,175 @@
+---
+author: Steve Kaschimer
+date: 2027-06-08
+image: /images/posts/2027-06-08-hero.webp
+image_alt: "A compact two-line setup glyph feeding directly into a solid endpoint channel with no separate filter or validator-class panel attached anywhere along it."
+image_prompt: "A dark-mode technical editorial illustration on a near-black background with electric teal, amber, and off-white accents. Composition centers on a small two-line code glyph on the left, connected by a short, direct teal line straight into a solid endpoint-shaped channel on the right, with no intermediate filter or validator-class panel anywhere along the path, emphasizing built-in simplicity. A small amber '10+' version marker sits near the base of the setup glyph. Mood is first-party, minimal, and confident. Avoid: vendor logos, brand colors, circuit-board textures, gears, or generic checkmark clip art."
+layout: post.njk
+site_title: Tech Notes
+summary: "Minimal APIs went four major versions without a first-party answer to how a request gets validated. .NET 10's AddValidation() closes that gap directly. A setup guide for the two-line native validation pipeline and exactly what it does and doesn't add over classic DataAnnotations."
+tags: ["dotnet", "validation", "developer-productivity", "tooling"]
+title: "Getting Started with Native Minimal API Validation in .NET 10"
+---
+
+Minimal APIs went four major versions without a first-party answer to a question MVC solved on day one: how does a request get validated before it reaches your handler. Every project either wrote manual checks, reached for MiniValidation, or brought in FluentValidation just to cover a gap that should have been built in. .NET 10 closes that gap directly - the same `DataAnnotations` attributes MVC has used for over a decade now work automatically in Minimal API endpoints, with no third-party package required.
+
+This guide covers enabling native validation in .NET 10, bootstrapping it correctly for both simple and nested request models, the core patterns for what it covers and what it doesn't, and the best practices for using it as the default for new Minimal API projects. By the end you'll have automatic, first-party request validation with the same attributes you already know from MVC.
+
+If you're deciding between validation approaches first, [a comparison of the top .NET validation approaches](/posts/2027-05-11-top-5-dotnet-validation-approaches-compared/) covers where native Minimal API validation fits relative to FluentValidation, DataAnnotations, MiniValidation, and custom validation.
+
+## What You'll Need
+
+- .NET 10 SDK or later - this feature is not available on earlier versions
+- A Minimal API project
+
+## Enabling Native Validation
+
+```csharp
+var builder = WebApplication.CreateBuilder(args);
+
+builder.Services.AddValidation();
+
+var app = builder.Build();
+```
+
+That's the entire setup - `AddValidation()` registers the validation services needed for the Minimal API pipeline to automatically validate `DataAnnotations`-decorated parameters, with no separate filter or manual wiring required.
+
+## Bootstrapping the Ideal Environment
+
+### Models use standard DataAnnotations attributes
+
+```csharp
+using System.ComponentModel.DataAnnotations;
+
+public class CreateOrderRequest
+{
+    [Required(ErrorMessage = "A customer is required")]
+    public int CustomerId { get; set; }
+
+    [Required, MinLength(1, ErrorMessage = "An order must contain at least one item")]
+    public List<OrderItem> Items { get; set; } = [];
+
+    [StringLength(20)]
+    public string? DiscountCode { get; set; }
+}
+```
+
+No new attribute vocabulary - if you've used DataAnnotations in MVC before, this is identical.
+
+### Validation runs automatically on the endpoint
+
+```csharp
+app.MapPost("/orders", (CreateOrderRequest request) =>
+{
+    // If we reach here, request has already passed validation.
+    // Invalid requests never reach this handler at all.
+    return Results.Created();
+});
+```
+
+There's no `TryValidate` call, no endpoint filter to write - once `AddValidation()` is registered, every Minimal API endpoint with a `DataAnnotations`-decorated parameter is validated automatically before the handler executes, and an invalid request receives a standardized `ValidationProblem` response without you writing that logic yourself.
+
+### Nested objects and collections
+
+```csharp
+public class OrderItem
+{
+    [Required]
+    public string ProductId { get; set; } = "";
+
+    [Range(1, 100)]
+    public int Quantity { get; set; }
+}
+```
+
+Nested types (like `OrderItem` inside `CreateOrderRequest.Items`) validate automatically as part of the same pass - you don't need separate configuration for nested validation the way some manual DataAnnotations approaches require.
+
+### IValidatableObject still works for conditional logic
+
+```csharp
+public class CreateOrderRequest : IValidatableObject
+{
+    public int CustomerId { get; set; }
+    public bool HasDiscount { get; set; }
+    public string? DiscountCode { get; set; }
+
+    public IEnumerable<ValidationResult> Validate(ValidationContext validationContext)
+    {
+        if (HasDiscount && string.IsNullOrEmpty(DiscountCode))
+        {
+            yield return new ValidationResult(
+                "A discount code is required when a discount is applied",
+                [nameof(DiscountCode)]);
+        }
+    }
+}
+```
+
+Native Minimal API validation runs `IValidatableObject.Validate()` as part of the same automatic pass - the same mechanism classic DataAnnotations has always used for conditional and cross-property rules, now working automatically in Minimal APIs without any extra wiring.
+
+## Core Workflow
+
+- **Enable `AddValidation()` once at startup, and rely on it for every endpoint with a `DataAnnotations`-decorated parameter.** There's no per-endpoint configuration needed - it applies broadly once registered.
+- **Use `IValidatableObject` for the same conditional/cross-property scenarios you'd use it for in MVC.** The mechanism is identical; only the automatic triggering context has changed.
+- **Reach for FluentValidation specifically when a rule genuinely needs more expressiveness than attributes and `IValidatableObject` provide.** Native validation doesn't extend DataAnnotations' capabilities - it just makes them automatic in a context where they previously weren't.
+
+## Verifying Your Setup
+
+1. **`AddValidation()` is registered** - confirm it's called during service configuration, or validation won't trigger automatically
+2. **Invalid requests are rejected automatically** - confirm a request violating a `[Required]` or other attribute is rejected with a standardized validation error response, without any explicit check in the handler
+3. **Nested validation works** - confirm a validation failure on a nested object property (like `OrderItem.Quantity`) is correctly reported
+4. **`IValidatableObject` logic runs as part of the same pass** - confirm conditional rules implemented there fire correctly alongside attribute-based checks
+
+## Best Practices
+
+**Use this as the default for new Minimal API projects on .NET 10+.** It's first-party, requires no new dependency, and covers the majority of straightforward validation needs with less setup than any third-party alternative.
+
+**Don't expect it to add expressiveness beyond what DataAnnotations and `IValidatableObject` already provide.** It's a delivery mechanism, not a new validation model - the same expressiveness ceiling that applies to classic DataAnnotations applies here.
+
+**Reach for FluentValidation specifically for genuinely complex conditional or cross-property rules**, the same guidance that applies to classic DataAnnotations. Native validation doesn't change when that trade-off point is reached.
+
+**Confirm your target .NET version before assuming this feature is available.** It's exclusive to .NET 10 and later - projects on earlier versions need MiniValidation, FluentValidation, or manual validation instead.
+
+**Keep validation attributes focused on data shape, the same discipline that applies to any DataAnnotations usage.** Rules requiring a database lookup or complex domain logic still belong in a service layer or custom validator, not crammed into an attribute or `IValidatableObject` implementation trying to do too much.
+
+## Comparison with FluentValidation
+
+| | Native Minimal API Validation | FluentValidation |
+| --- | --- | --- |
+| Dependency | None - built into .NET 10+ | A NuGet package |
+| .NET version | 10+ only | Any supported .NET version |
+| Conditional/cross-property rules | Via `IValidatableObject`, same ceiling as DataAnnotations | Excellent, built for this |
+| Setup | `AddValidation()`, two lines | Validator classes + registration + filter for Minimal APIs |
+| Performance | Fast, similar model to MiniValidation | Often the slowest option in benchmarks |
+
+Native validation is the right default for straightforward validation needs on .NET 10+; FluentValidation remains the better choice specifically where conditional or cross-property complexity exceeds what attributes and `IValidatableObject` express cleanly.
+
+## Frequently Asked Questions
+
+### Do I need a NuGet package for native Minimal API validation?
+
+No - it's built directly into the .NET 10 SDK. `builder.Services.AddValidation()` is all that's needed to enable it; there's no third-party package to install.
+
+### Can I use this on .NET 8 or .NET 9?
+
+No - native Minimal API validation is a .NET 10 feature specifically. Projects on earlier versions need to continue using MiniValidation, FluentValidation, or manual validation for Minimal APIs.
+
+### Does native validation support conditional or cross-property rules?
+
+Through `IValidatableObject`, yes - the same mechanism classic DataAnnotations has always used. It doesn't add new expressiveness beyond what `IValidatableObject` and built-in attributes already support; for genuinely complex conditional logic, FluentValidation remains more natural to read and write.
+
+### How is this different from just using MiniValidation in a Minimal API?
+
+Native validation is first-party and requires no separate package, built directly into the Minimal API request pipeline as of .NET 10. MiniValidation is a third-party library providing similar DataAnnotations-based validation, useful specifically for .NET versions before 10 or application types beyond Minimal APIs, like console apps, where native validation doesn't apply.
+
+### What response do I get when validation fails?
+
+A standardized `ValidationProblem` response following the Problem Details format, generated automatically - you don't need to construct this response yourself the way you would with a custom endpoint filter approach.
+
+### Should I migrate from MiniValidation or a manual endpoint filter to native validation once I'm on .NET 10?
+
+It's a reasonable simplification if your validation needs are the straightforward, attribute-expressible kind both approaches already handle similarly - removing a dependency and a custom filter in favor of the first-party mechanism reduces surface area with no loss of capability. If you were using FluentValidation for genuinely complex rules, there's no reason to migrate away from it, since native validation doesn't add expressiveness beyond DataAnnotations.
+
+### What's the most common mistake when adopting native Minimal API validation?
+
+Forgetting to call `builder.Services.AddValidation()`, so validation silently doesn't run despite the attributes being present on the model. The second common mistake is expecting it to handle complex conditional validation as naturally as FluentValidation, when it shares the exact same expressiveness ceiling as classic DataAnnotations underneath.

--- a/src/posts/2027-06-15-getting-started-with-minivalidation.md
+++ b/src/posts/2027-06-15-getting-started-with-minivalidation.md
@@ -1,0 +1,188 @@
+---
+author: Steve Kaschimer
+date: 2027-06-15
+image: /images/posts/2027-06-15-hero.webp
+image_alt: "A minimal single-function-call glyph with a lightning-bolt speed accent, feeding directly into a compact recursive-loop icon representing automatic nested validation."
+image_prompt: "A dark-mode technical editorial illustration on a near-black background with electric teal, amber, and off-white accents. Composition centers on a single small function-call glyph on the left with a solid amber lightning-bolt accent beside it implying speed, connected by a short teal line to a compact recursive loop icon on the right representing automatic nested and cyclic validation. Beneath, a tiny secondary marker distinguishes it faintly from a larger native-pipeline glyph, implying a lighter-weight cousin. Mood is fast, minimal, and purpose-built. Avoid: vendor logos, brand colors, circuit-board textures, gears, or generic checkmark clip art."
+layout: post.njk
+site_title: Tech Notes
+summary: "MiniValidation's pitch is one sentence: the same DataAnnotations attributes you already know, running through a validator optimized specifically to be fast, with none of FluentValidation's ceremony. A setup guide for the single-line TryValidate call and knowing when it's actually the right choice over native .NET 10 validation."
+tags: ["dotnet", "validation", "performance", "developer-productivity"]
+title: "Getting Started with MiniValidation in .NET"
+---
+
+MiniValidation's whole pitch fits in one sentence: it's the same DataAnnotations attributes you already know, running through a validator specifically optimized to be fast, with none of FluentValidation's ceremony. Built by Damian Edwards specifically for the gap Minimal APIs used to have - no automatic validation pipeline the way MVC has always had - it's a single-function-call library that stayed relevant even after .NET 10 introduced native Minimal API validation, since it still covers console apps and .NET versions before 10.
+
+This guide covers installing MiniValidation, bootstrapping validation calls for Minimal API endpoints and other application types, the core patterns for nested and recursive validation, and the best practices for using it in exactly the scenarios it's built for. By the end you'll have fast, low-ceremony validation using attributes you already know.
+
+If you're deciding between validation approaches first, [a comparison of the top .NET validation approaches](/posts/2027-05-11-top-5-dotnet-validation-approaches-compared/) covers where MiniValidation fits relative to FluentValidation, DataAnnotations, custom validation, and .NET 10's native Minimal API validation.
+
+## What You'll Need
+
+- .NET 8 SDK or later - MiniValidation works across a broad range of .NET versions, including those without native Minimal API validation
+- If targeting Minimal APIs specifically on ASP.NET Core 6+, consider `MinimalApis.Extensions`, which adds ASP.NET Core-specific integration on top of the core MiniValidation library
+
+## Installing MiniValidation
+
+```bash
+dotnet add package MiniValidation
+```
+
+For Minimal API-specific integration (an endpoint filter, request binding helpers):
+
+```bash
+dotnet add package MinimalApis.Extensions
+```
+
+## Bootstrapping the Ideal Environment
+
+### Models use the same DataAnnotations attributes you already know
+
+```csharp
+using System.ComponentModel.DataAnnotations;
+
+public class CreateOrderRequest
+{
+    [Required]
+    public int CustomerId { get; set; }
+
+    [Required, MinLength(1)]
+    public List<OrderItem> Items { get; set; } = [];
+}
+```
+
+No new attribute vocabulary to learn - MiniValidation runs the exact same `System.ComponentModel.DataAnnotations` attributes DataAnnotations and .NET 10's native Minimal API validation both use.
+
+### A single-line validation call
+
+```csharp
+var request = new CreateOrderRequest { CustomerId = 0 };
+
+var isValid = MiniValidator.TryValidate(request, out var errors);
+
+if (!isValid)
+{
+    foreach (var (member, memberErrors) in errors)
+        Console.WriteLine($"{member}: {string.Join(", ", memberErrors)}");
+}
+```
+
+This is the entirety of MiniValidation's core API - `TryValidate` in, a boolean and a dictionary of errors out. No configuration object, no validator class to instantiate first.
+
+### Wiring into a Minimal API endpoint
+
+```csharp
+app.MapPost("/orders", (CreateOrderRequest request) =>
+{
+    if (!MiniValidator.TryValidate(request, out var errors))
+        return Results.ValidationProblem(errors);
+
+    // proceed with valid request
+    return Results.Created();
+});
+```
+
+Or, using an endpoint filter for consistency across multiple endpoints:
+
+```csharp
+app.MapPost("/orders", CreateOrder)
+    .AddEndpointFilter(async (context, next) =>
+    {
+        var request = context.Arguments.OfType<CreateOrderRequest>().FirstOrDefault();
+        if (request is not null && !MiniValidator.TryValidate(request, out var errors))
+            return Results.ValidationProblem(errors);
+        return await next(context);
+    });
+```
+
+The filter pattern keeps validation consistent across many endpoints rather than repeating the `TryValidate` call in every handler - the same discipline that applies to FluentValidation's Minimal API integration.
+
+### Validation with dependency-injected services (for validators needing DI)
+
+```csharp
+var isValid = await MiniValidator.TryValidateAsync(request, serviceProvider, out var errors);
+```
+
+```csharp
+public class Widget : IValidatableObject
+{
+    [Required, MinLength(3)]
+    public string Name { get; set; } = "";
+
+    public IEnumerable<ValidationResult> Validate(ValidationContext validationContext)
+    {
+        var disallowedNames = validationContext.GetService(typeof(IDisallowedNamesService)) as IDisallowedNamesService;
+        if (disallowedNames?.IsDisallowedName(Name) == true)
+            yield return new ValidationResult($"'{Name}' is not an allowed name", [nameof(Name)]);
+    }
+}
+```
+
+Passing a `serviceProvider` lets `IValidatableObject` implementations resolve injected services during validation - useful for rules that need to check against a database or another registered service, the same `IValidatableObject` mechanism DataAnnotations uses more broadly.
+
+## Core Workflow
+
+- **Use `TryValidate` directly for straightforward cases**, and wrap it in an endpoint filter for consistency once you have more than a couple of validated endpoints.
+- **Rely on MiniValidation's built-in recursion and cycle detection for nested objects.** Unlike hand-rolled DataAnnotations validation, it handles object graphs, including circular references, correctly out of the box.
+- **Reach for `TryValidateAsync` with a `serviceProvider` when `IValidatableObject` logic needs dependency injection.**
+
+## Verifying Your Setup
+
+1. **Validation catches invalid models correctly** - confirm `TryValidate` returns `false` and populates errors for an invalid request
+2. **Nested objects and collections validate correctly** - confirm validation recurses into nested types and collection items, not just top-level properties
+3. **The endpoint filter (if used) runs consistently across endpoints** - confirm every validated route rejects invalid requests the same way
+4. **DI-dependent `IValidatableObject` rules work** - confirm `TryValidateAsync` with a `serviceProvider` correctly resolves and uses injected services during validation
+
+## Best Practices
+
+**Use MiniValidation specifically for Minimal APIs on .NET versions before 10, or for console/non-web applications.** On .NET 10+, native Minimal API validation covers much of the same ground with zero extra dependency - MiniValidation's clearest remaining niche is pre-.NET 10 projects and non-Minimal-API application types.
+
+**Centralize validation calls in an endpoint filter rather than repeating `TryValidate` in every handler**, once you have more than a couple of validated endpoints.
+
+**Reach for `TryValidateAsync` with a service provider whenever `IValidatableObject` logic needs injected dependencies.** This is a genuine capability MiniValidation supports cleanly, worth using rather than working around with static service locator patterns.
+
+**Recognize the same expressiveness ceiling as classic DataAnnotations.** MiniValidation is fast and low-ceremony, but it doesn't add expressiveness beyond what DataAnnotations attributes and `IValidatableObject` already support - for genuinely complex conditional rules, FluentValidation remains the more natural fit.
+
+**Don't add MiniValidation to a .NET 10+ Minimal API project by default without checking if native validation already covers your needs.** Adding a dependency for functionality now available natively is unnecessary overhead.
+
+## Comparison with Native Minimal API Validation (.NET 10+)
+
+| | MiniValidation | Native Minimal API Validation |
+| --- | --- | --- |
+| Dependency | Small NuGet package | None - built into .NET 10+ |
+| .NET version support | Broad - works on versions before .NET 10 | .NET 10+ only |
+| Application types | Minimal APIs, console apps, anywhere | Minimal APIs specifically |
+| Performance | Fastest of the library-based options | Fast, built on a similar underlying model |
+| Underlying attributes | Same DataAnnotations attributes | Same DataAnnotations attributes |
+
+They're close cousins built on the same foundation - native validation is the first-party evolution of what MiniValidation pioneered for Minimal APIs specifically, while MiniValidation remains relevant for broader application types and pre-.NET 10 projects.
+
+## Frequently Asked Questions
+
+### Is MiniValidation still relevant now that .NET 10 has native Minimal API validation?
+
+Yes, for two specific cases: projects still on .NET 8 or earlier that can't use native validation, and application types beyond Minimal APIs, like console apps or background services, where MiniValidation's general-purpose `TryValidate` call still applies but the native Minimal API feature doesn't.
+
+### Does MiniValidation use a different attribute syntax than DataAnnotations?
+
+No - it's built directly on top of `System.ComponentModel.DataAnnotations`, using the exact same `[Required]`, `[StringLength]`, and other attributes. There's no new syntax to learn; MiniValidation is a fast, purpose-built runtime for validating models decorated with attributes you already know.
+
+### How does MiniValidation handle nested objects and collections?
+
+Automatically, with built-in recursive traversal and cycle detection - this is one of its concrete advantages over naive hand-rolled DataAnnotations validation, which requires more manual work to handle nested graphs correctly, including guarding against circular references.
+
+### Can I use MiniValidation with dependency-injected services in my validation logic?
+
+Yes, via `TryValidateAsync(model, serviceProvider, out errors)`, which allows `IValidatableObject` implementations to resolve services from the provided service provider during validation - useful for rules requiring a database check or another registered service.
+
+### Is MiniValidation actually faster than DataAnnotations validation done manually?
+
+Yes, in independent benchmarks - MiniValidation adds metadata caching on top of the same reflection-based approach naive DataAnnotations validation would use, resulting in meaningfully better performance for repeated validation of the same model types.
+
+### Should I use MiniValidation or FluentValidation for a Minimal API project?
+
+Depends on your validation complexity - MiniValidation is faster and lower-ceremony for straightforward, attribute-expressible validation. FluentValidation is the better choice once you need genuinely complex conditional or cross-property rules that DataAnnotations' attribute model, which MiniValidation shares, doesn't express naturally.
+
+### What's the most common mistake when adopting MiniValidation?
+
+Adding it to a .NET 10+ Minimal API project without checking whether native validation already covers the same need, introducing an unnecessary dependency. The second common mistake is expecting MiniValidation to handle complex conditional validation as naturally as FluentValidation, when it shares the same expressiveness ceiling as classic DataAnnotations.


### PR DESCRIPTION
## Summary

- Schedules and drafts the .NET Validation Approaches Tuesday track: a comparison anchor post plus five getting-started guides, running weekly Tuesdays 2027-05-11 through 2027-06-15, picking up the cadence directly after the .NET API Styles track
- Moves the series from `editorial-plan.md`'s Backlog into a dated `## 📅 Tuesday Track - .NET Validation Approaches (May-June 2027)` section, all entries `Status: draft` with `File:` paths, and updates the Backlog intro count from eleven to ten remaining series

### Posts added

- **Anchor:** The Top 5 .NET Validation Approaches Compared: Which One Should You Choose? (2027-05-11) - FluentValidation, DataAnnotations, MiniValidation, custom validation, and .NET 10's native Minimal API validation compared, including a counterintuitive benchmark result about the most popular option
- Getting Started with FluentValidation in .NET (2027-05-18)
- Getting Started with DataAnnotations in .NET (2027-05-25)
- Getting Started with Custom Validation in .NET (2027-06-01)
- Getting Started with Native Minimal API Validation in .NET 10 (2027-06-08)
- Getting Started with MiniValidation in .NET (2027-06-15)

Each setup guide cross-links back to the anchor post, mirroring the structure of the prior .NET ORMs/API Styles/Testing/Logging/Architecture tracks.

## Test plan

- [x] `npm run deploy` builds cleanly, all 6 posts render
- [x] `node scripts/a11y-check.js` (axe-core + Playwright) - zero violations across home/post/about/privacy/terms/404 in light and dark mode
- [x] Verified all 5 setup-guide cross-links resolve to the anchor post's output URL


---
_Generated by [Claude Code](https://claude.ai/code/session_01WKyNF7L5qzrfct8cec6A32)_