### PR TITLE
Add .NET Caching Solutions Tuesday track (6 posts)

### DIFF
--- a/editorial-plan.md
+++ b/editorial-plan.md
@@ -998,17 +998,69 @@ Six posts on how a .NET service converts one type into another, picking up the T
 
 ---
 
-## 📅 Backlog - Unscheduled Series
+## 📅 Tuesday Track - .NET Caching Solutions (August-September 2027)
 
-Nine six-post series remain unscheduled, drawn from the drafts in `docs/article-ideas/`. They continue the Tuesday cadence once the .NET Mapping Libraries series ends on 2027-07-27, and they're listed here in priority order. They're deliberately undated - that horizon is too far out to put honest dates against - so each series gets one entry rather than six speculative ones, and entries are expanded into individual dated posts when a series moves onto the calendar.
+Six posts on how a .NET service caches data, picking up the Tuesday cadence directly from the Mapping Libraries track. A comparison post anchors the track and each of the five follow-ups is a complete setup for one caching option.
 
-### .NET Caching Solutions (6 posts)
-- **Status:** `idea`
-- **Source:** `docs/article-ideas/top-5-dotnet-caching-solutions-compared.md` + 5 getting-started drafts
-- **Series:** Top 5 comparison, then IMemoryCache, Redis, Garnet, Memcached, NCache
+### The Top 5 Caching Solutions for .NET Compared: Which One Should You Choose?
+- **Status:** `draft`
+- **Scheduled:** 2027-08-03
+- **Source:** `docs/article-ideas/top-5-dotnet-caching-solutions-compared.md`
+- **File:** `src/posts/2027-08-03-top-5-dotnet-caching-solutions-compared.md`
 - **Pitch:** Caching decisions collapse into "just use Redis" one step too early. The first fork is whether you need a distributed cache at all, since `IMemoryCache` solves a real and common subset of the problem with zero infrastructure and nanosecond-scale reads.
 - **Angle:** Compares the five on scope, latency, data structures, persistence, and how .NET-native each one actually is. The core argument is that in-process and distributed caching are different problems with different right answers, and only once you're running multiple instances do the four distributed options genuinely compete with each other. Redis stays the honest default for the same reason EF Core is the default ORM, while Garnet (Microsoft Research, written in C#, RESP-compatible) and NCache are framed as options worth evaluating rather than defaulting past.
 - **Tags:** `dotnet`, `caching`, `performance`, `architecture`, `devops`
+
+### Getting Started with IMemoryCache in .NET
+- **Status:** `draft`
+- **Scheduled:** 2027-08-10
+- **Source:** `docs/article-ideas/getting-started-with-imemorycache.md`
+- **File:** `src/posts/2027-08-10-getting-started-with-imemorycache.md`
+- **Pitch:** `IMemoryCache` is the easiest caching decision in .NET to get right and, paradoxically, one of the easiest to misuse - not because the API is complicated, but because it's so simple to add that people reach for it in places a distributed cache actually belongs.
+- **Angle:** Covers size limits and per-entry `Size`, the `GetOrCreateAsync` pattern that avoids manual check-then-set bugs, and explicit invalidation on write. Makes the case for .NET 9's `HybridCache` as the better default over raw `IMemoryCache` even for single-server apps, given its cache-stampede protection and clean upgrade path to a distributed L2 tier with zero call-site changes.
+- **Tags:** `dotnet`, `caching`, `performance`, `developer-productivity`
+
+### Getting Started with Redis in .NET
+- **Status:** `draft`
+- **Scheduled:** 2027-08-17
+- **Source:** `docs/article-ideas/getting-started-with-redis-dotnet.md`
+- **File:** `src/posts/2027-08-17-getting-started-with-redis-dotnet.md`
+- **Pitch:** Most of the friction people hit adopting Redis in .NET isn't Redis's fault - it's the boilerplate that used to be necessary around `IDistributedCache`: manual serialization, hand-written cache-aside logic, no stampede protection. `HybridCache` closes that gap directly.
+- **Angle:** Covers the recommended `HybridCache`-with-Redis-as-L2 path against the classic manual `IDistributedCache` approach, sharing one `IConnectionMultiplexer` as a singleton across the whole application, and tag-based invalidation for clearing related entries at once. Flags Redis's shifting licensing terms and Valkey as the BSD-licensed fork worth knowing about rather than treating the decision as settled.
+- **Tags:** `dotnet`, `caching`, `performance`, `architecture`, `devops`
+
+### Getting Started with Garnet in .NET
+- **Status:** `draft`
+- **Scheduled:** 2027-08-24
+- **Source:** `docs/article-ideas/getting-started-with-garnet.md`
+- **File:** `src/posts/2027-08-24-getting-started-with-garnet.md`
+- **Pitch:** Garnet's pitch is unusually direct: same RESP protocol as Redis, so existing client code mostly just works, but built in C# by Microsoft Research with a modern, epoch-based GC design aimed at strong multi-core performance.
+- **Angle:** Covers connecting with the exact same `StackExchange.Redis`/`HybridCache` setup used for Redis itself, and treats "RESP-compatible" as "very likely to work" rather than "guaranteed identical" - testing an application's actual command usage (sorted sets, pub/sub, specific modules) against a real Garnet instance before trusting it as a drop-in replacement. Honest that low switching cost is a reason to actually evaluate it thoroughly, not a reason to skip evaluation.
+- **Tags:** `dotnet`, `caching`, `performance`, `tooling`
+
+### Getting Started with Memcached in .NET
+- **Status:** `draft`
+- **Scheduled:** 2027-08-31
+- **Source:** `docs/article-ideas/getting-started-with-memcached.md`
+- **File:** `src/posts/2027-08-31-getting-started-with-memcached.md`
+- **Pitch:** Memcached's setup story is the shortest in the whole series, and that's not an accident - no data structure configuration, no persistence tuning, no replication topology to choose between. A fast, multi-threaded key-value store and nothing else.
+- **Angle:** Covers the community-standard `EnyimMemcachedCore` client, client-side consistent hashing across multiple nodes (a meaningfully different model from Redis Cluster's server-side approach), and the hard key/value size limits Memcached enforces by default. Scopes it honestly to genuinely simple key-value workloads at high throughput - session stores, page fragments - and flags total lack of persistence as disqualifying the moment that matters.
+- **Tags:** `dotnet`, `caching`, `performance`, `tooling`
+
+### Getting Started with NCache in .NET
+- **Status:** `draft`
+- **Scheduled:** 2027-09-07
+- **Source:** `docs/article-ideas/getting-started-with-ncache.md`
+- **File:** `src/posts/2027-09-07-getting-started-with-ncache.md`
+- **Pitch:** NCache's whole pitch is being the distributed cache built for .NET rather than adapted to it, and that shows up most clearly in the setup itself - ASP.NET Core session state and EF Core query caching are first-class, purpose-built integrations rather than something assembled on top of a generic `IDistributedCache`.
+- **Angle:** Covers provisioning named caches ahead of time (a real difference from Redis's implicit connect-and-go model), native .NET object caching with no manual serialization step, and the purpose-built ASP.NET Core session and EF Core `FromCache()` integrations that are NCache's clearest differentiators. Flags which capabilities (advanced replication, write-behind caching) require Enterprise licensing before a design assumes them.
+- **Tags:** `dotnet`, `caching`, `architecture`, `developer-productivity`
+
+---
+
+## 📅 Backlog - Unscheduled Series
+
+Eight six-post series remain unscheduled, drawn from the drafts in `docs/article-ideas/`. They continue the Tuesday cadence once the .NET Caching Solutions series ends on 2027-09-07, and they're listed here in priority order. They're deliberately undated - that horizon is too far out to put honest dates against - so each series gets one entry rather than six speculative ones, and entries are expanded into individual dated posts when a series moves onto the calendar.
 
 ### .NET Message Brokers (6 posts)
 - **Status:** `idea`

--- a/src/posts/2027-08-03-top-5-dotnet-caching-solutions-compared.md
+++ b/src/posts/2027-08-03-top-5-dotnet-caching-solutions-compared.md
@@ -1,0 +1,167 @@
+---
+author: Steve Kaschimer
+date: 2027-08-03
+image: /images/posts/2027-08-03-hero.webp
+image_alt: "Five columns of abstract caching glyphs positioned along a horizontal axis running from single-process memory on the left to distributed network caching on the right."
+image_prompt: "A dark-mode technical editorial illustration on a near-black background with electric teal, amber, and off-white accents. Composition is five vertical columns of equal width separated by thin hairline rules, each column topped by a distinct abstract glyph rendered in flat geometry: a small solid dot fully contained inside a single box implying in-process storage, a richer layered-shapes glyph (a cube beside a small hash and a list) implying multiple data structures, a peer-to-peer mesh of three connected nodes drawn in a lighter, more angular style implying native code, a minimal single flat rectangle with no ornamentation implying pure simplicity, and a RESP-compatible glyph shown as two overlapping outlines - one solid, one dashed - implying protocol compatibility between two implementations. Beneath the glyphs, a shared horizontal axis labeled in monospaced type runs from 'single process' on the left to 'distributed network' on the right, with a small glowing teal dot positioned at a different point under each column. Mood is comparative, engineering-first, and non-partisan. Avoid: vendor logos, brand colors, circuit-board textures, gears, or generic database-cylinder clip art used as the dominant motif."
+layout: post.njk
+site_title: Tech Notes
+summary: "Caching decisions in .NET collapse into 'just use Redis' one step too early. The first fork is whether you need a distributed cache at all - IMemoryCache solves a real, common subset of caching needs with zero infrastructure. A practical breakdown of five caching options."
+tags: ["dotnet", "caching", "performance", "architecture", "devops"]
+title: "The Top 5 Caching Solutions for .NET Compared: Which One Should You Choose?"
+---
+
+Caching decisions in .NET tend to collapse into a false binary: "just use Redis." Redis is a fine default, but it's not actually the first fork in the road - the first question is whether you need a distributed cache at all, since `IMemoryCache` solves a real and common subset of caching needs with zero infrastructure and nanosecond-scale reads. Only once you're running more than one instance of your app does the distributed question even apply, and that's where Redis, NCache, Memcached, and Garnet start actually competing with each other.
+
+This guide compares the five caching options .NET developers reach for most often: `IMemoryCache` (in-process), Redis, NCache, Memcached, and Garnet (distributed). The goal isn't to crown one winner - it's to help you match the tool to whether your problem is "reduce database calls on one server" or "share cache state across a fleet," since those are genuinely different problems with different right answers. This series continues with dedicated getting-started walkthroughs for each option.
+
+## Quick Comparison
+
+| | IMemoryCache | Redis | NCache | Memcached | Garnet |
+| --- | --- | --- | --- | --- | --- |
+| **Scope** | In-process, single server | Distributed, network-accessible | Distributed, network-accessible | Distributed, network-accessible | Distributed, network-accessible |
+| **Latency** | Nanosecond-scale | Millisecond-scale | Millisecond-scale | Millisecond-scale, very low overhead | Millisecond-scale, competitive with Redis |
+| **Data structures** | Any .NET object, in memory | Rich (strings, lists, sets, hashes, streams) | Rich, .NET-native objects | Simple key-value only | Redis-compatible (RESP protocol) |
+| **Persistence** | None - lost on restart | Optional (snapshotting, AOF) | Optional | None | Optional |
+| **.NET-native** | Yes, built into ASP.NET Core | No - C++/Linux origin, mature .NET client | Yes, built specifically for .NET | No | Yes - built in C# by Microsoft Research |
+| **Best for** | Single-instance apps, hot local lookups | Most distributed caching needs; broad ecosystem | .NET-heavy enterprises wanting native tooling | Pure key-value at very high throughput | .NET shops wanting a managed, Redis-compatible option |
+
+## IMemoryCache
+
+`IMemoryCache` is the in-process cache built into ASP.NET Core - no external service, no network call, just a dictionary-like store living inside your application's own memory. It's not a distributed cache at all, and that's exactly the point: for a huge share of caching scenarios, you don't need one.
+
+**Strengths:**
+
+- Effectively free in latency terms - cache hits are nanosecond-scale since there's no network round trip involved
+- Zero infrastructure to stand up, monitor, or pay for - it's already part of the framework
+- `GetOrCreateAsync` gives you a clean pattern for "fetch from cache, or compute and cache it," which `IDistributedCache` notably lacks
+- Supports expiration policies, size limits, and priority-based eviction out of the box
+
+**Weaknesses:**
+
+- Strictly single-server - a value cached on one instance is invisible to every other instance behind a load balancer
+- Cache is lost entirely on app restart or redeploy, with no persistence option
+- Doesn't scale as a caching strategy once you're running more than one instance, which most production ASP.NET Core deployments eventually are
+
+**Choose this when:** your application runs as a single instance, or the specific data you're caching is fine being duplicated and independently computed per instance - a common pattern even in multi-instance apps, layered underneath a distributed cache.
+
+## Redis
+
+Redis is the default answer to "distributed cache" for good reason - broad ecosystem support, rich data structures beyond simple key-value, and first-party or community client libraries for essentially every language and framework, .NET included.
+
+**Strengths:**
+
+- Rich data structures - lists, sets, sorted sets, hashes, streams - support caching patterns well beyond simple key-value lookups
+- Optional persistence (snapshotting or append-only file) means Redis can survive a restart without a full cache-cold start
+- Enormous ecosystem: managed offerings from every major cloud provider, extensive tooling, and the largest base of documentation and community knowledge of any option here
+- Supports pub/sub and Redis Cluster for horizontal scaling and cross-instance messaging beyond pure caching
+
+**Weaknesses:**
+
+- Not .NET-native - it's a C++ project with Linux origins, so .NET support comes through a very mature client library rather than being built for .NET first
+- Licensing has shifted in recent years, pushing some teams toward Valkey (a BSD-licensed fork) instead of Redis directly - worth checking current licensing terms before committing
+- Every cache operation is a network round trip plus serialization, so it's meaningfully slower than `IMemoryCache` even though it's fast in absolute terms
+
+**Choose this when:** you need a distributed cache and don't have a specific reason to reach for something else - it's the right default for most .NET teams' distributed caching needs, the same way EF Core is the right default ORM.
+
+## NCache
+
+NCache is built specifically for .NET, by a vendor whose primary focus has been the .NET ecosystem since 2005. Where Redis's .NET support comes through a client library on top of a non-.NET server, NCache is native .NET end to end.
+
+**Strengths:**
+
+- Purpose-built for .NET, including deep integration with ASP.NET Core session state and EF Core query result caching through extension methods
+- Peer-to-peer distributed architecture where each cache server holds its own storage and communicates directly with peers, an alternative topology to Redis's typical primary/replica setup
+- Enterprise features - write-behind caching, data replication, event notifications - are mature and specifically tuned for .NET workloads
+- Strong fit for teams already deeply invested in the Microsoft stack who want tooling that feels native rather than adapted
+
+**Weaknesses:**
+
+- Smaller community and ecosystem than Redis - fewer public tutorials, less Stack Overflow coverage, and fewer third-party integrations
+- Commercial licensing for the full feature set, unlike Redis's more permissive open-source core
+- Less relevant outside the .NET ecosystem, so cross-team or polyglot organizations get less value from standardizing on it compared to Redis's broader language support
+
+**Choose this when:** you're a .NET-heavy enterprise that values deep, native integration with ASP.NET Core and EF Core over the broader ecosystem and community size Redis offers.
+
+## Memcached
+
+Memcached is the simplest tool in this comparison, by design. It's a pure key-value store with no data structures beyond that, no persistence, and a multi-threaded architecture tuned for raw GET/SET throughput.
+
+**Strengths:**
+
+- Genuinely simple protocol and mental model - there's very little to learn or misconfigure compared to the other options here
+- Multi-threaded design gives it excellent throughput for high-volume, simple key-value workloads like session stores or page fragment caching
+- Very low per-key overhead, since it isn't carrying the weight of richer data structures or persistence machinery it doesn't need
+
+**Weaknesses:**
+
+- No data structures beyond simple values - no lists, sets, or hashes the way Redis offers, which matters the moment your caching needs get more sophisticated than key-value
+- No persistence at all - a Memcached restart means a fully cold cache, with no snapshotting option
+- Smaller relative presence in the .NET ecosystem specifically compared to Redis, meaning less .NET-focused tooling and documentation
+
+**Choose this when:** your caching need is genuinely simple - string key-value pairs, no need for persistence or richer data structures - and you want the simplest, fastest possible tool for exactly that job rather than a more capable tool you won't use most of.
+
+## Garnet
+
+Garnet is a newer entrant: a Redis-protocol-compatible cache-store built in C# by Microsoft Research. It speaks RESP (the same protocol Redis uses), so existing Redis client libraries work against it without modification, while the implementation itself is native .NET with a modern, epoch-based garbage collection design aimed at strong multi-core performance.
+
+**Strengths:**
+
+- RESP-compatible, meaning your existing Redis client code in .NET generally works against Garnet with just a connection string change - low switching cost if you're already using a Redis client
+- Built in C#, giving it a natural fit and strong performance characteristics within the .NET/Microsoft ecosystem specifically
+- Strong benchmark numbers on multi-core machines, backed by active Microsoft Research development
+- A genuinely interesting option for teams that want Redis's protocol compatibility with a codebase and governance model closer to home for .NET shops
+
+**Weaknesses:**
+
+- Younger and less battle-tested in production at scale than Redis, NCache, or Memcached, all of which have many more years of real-world deployment behind them
+- Smaller community and far less third-party tooling, documentation, and troubleshooting content than Redis
+- Being RESP-compatible doesn't mean feature-complete parity with Redis - confirm specific commands and modules you rely on are actually supported before assuming a drop-in replacement
+
+**Choose this when:** you're in the .NET ecosystem, want Redis protocol compatibility without adopting Redis itself, and are comfortable with a newer, actively-developed project in exchange for that alignment - particularly worth evaluating rather than defaulting past.
+
+## How to Decide
+
+A few heuristics that cover most real-world decisions:
+
+**Running a single instance, or caching data that's fine being duplicated per instance?** `IMemoryCache` is not a compromise here - it's strictly faster and simpler than reaching for a distributed cache you don't yet need.
+
+**Running multiple instances and need shared cache state?** Redis is the right default unless you have a specific reason to look elsewhere - broadest ecosystem, richest feature set, most community knowledge to draw on.
+
+**Deeply invested in .NET and want native tooling over Redis's broader-but-adapted ecosystem?** NCache's ASP.NET Core session and EF Core integrations are genuinely deeper than what you'll get bolting Redis on yourself.
+
+**Caching need is purely simple key-value at very high throughput?** Memcached's simplicity is a feature, not a limitation, when you don't need anything beyond what it does.
+
+**Want Redis-protocol compatibility with a .NET-native codebase?** Garnet is worth a serious look, with the caveat that it's newer and less proven at the scale Redis has been running at for over a decade.
+
+A common, sensible pattern across all of these: use `IMemoryCache` as a fast local layer in front of whichever distributed cache you choose, for data that's read very frequently and can tolerate being slightly stale or duplicated across instances - the two aren't mutually exclusive.
+
+## Frequently Asked Questions
+
+### Do I need a distributed cache if I'm only running one server?
+
+No, and adding one anyway is pure overhead. `IMemoryCache` is faster, simpler, and free of infrastructure cost for a single-instance deployment. The moment you scale to multiple instances behind a load balancer is the moment a distributed cache actually starts solving a real problem you have.
+
+### What's the actual difference between IMemoryCache and IDistributedCache in .NET?
+
+`IMemoryCache` stores data in the running application's own process memory - fast, but invisible to any other instance of your app. `IDistributedCache` is an abstraction over a network-accessible cache (Redis, NCache, and others all have `IDistributedCache` implementations) so a value cached by one instance is immediately visible to every other instance reading from the same cache. The trade-off is latency: nanoseconds for `IMemoryCache`, milliseconds for `IDistributedCache` - still far faster than a database round trip, just not free.
+
+### Is Redis still the safe default choice given recent licensing changes?
+
+For most teams, yes, though it's worth checking current licensing terms for your specific use case before committing, since this has shifted more than once in recent years. Valkey, a BSD-licensed fork of Redis backed by the Linux Foundation and major cloud providers, is a common alternative for teams specifically concerned about licensing while wanting Redis's exact feature set and API.
+
+### Is Garnet a safe choice for production today?
+
+It depends on your risk tolerance and how central caching is to your system's reliability. Garnet shows strong performance and is backed by active Microsoft Research development, but it has meaningfully less production track record than Redis, NCache, or Memcached. Evaluate it seriously if RESP compatibility and a .NET-native codebase matter to you, but confirm the specific features and commands you depend on are supported, and weigh the smaller community against the benefits.
+
+### Why would I pick NCache over Redis for a .NET project?
+
+Primarily for the depth of native .NET integration - ASP.NET Core session state and EF Core query caching through NCache's extension methods are more purpose-built than what you'd assemble yourself around Redis. The trade-off is a smaller community, less cross-platform relevance, and commercial licensing for NCache's full feature set, against Redis's much larger ecosystem and broader applicability outside pure .NET shops.
+
+### Can I use more than one caching layer at the same time?
+
+Yes, and it's a common, effective pattern - `IMemoryCache` as a fast local layer for very hot data, backed by a distributed cache (Redis, NCache, or another) as the shared source of truth across instances. This gets you the nanosecond-scale reads of local memory for the hottest keys while still keeping cache state consistent across your fleet for everything else.
+
+### How do I decide between Redis, NCache, Memcached, and Garnet if I already know I need a distributed cache?
+
+Start with what you actually need beyond simple key-value: if it's just fast key-value at scale, Memcached's simplicity is hard to beat. If you need richer data structures, persistence, or the broadest possible ecosystem, Redis is the safe default. If deep native .NET integration matters more than ecosystem breadth, evaluate NCache. If you want Redis's protocol with a .NET-native implementation and are comfortable with a newer project, Garnet is worth a serious look rather than an afterthought.

--- a/src/posts/2027-08-10-getting-started-with-imemorycache.md
+++ b/src/posts/2027-08-10-getting-started-with-imemorycache.md
@@ -1,0 +1,180 @@
+---
+author: Steve Kaschimer
+date: 2027-08-10
+image: /images/posts/2027-08-10-hero.webp
+image_alt: "A small solid dot fully contained inside a single box with no connecting lines leaving its border, a fainter second box beside it representing a stampede-protected wrapper layer."
+image_prompt: "A dark-mode technical editorial illustration on a near-black background with electric teal, amber, and off-white accents. Composition centers on a small solid teal dot fully enclosed within a single flat rectangular box, with no lines or arrows crossing its border, emphasizing complete containment within one process. A second, fainter rectangle sits just behind and slightly offset from the first, implying a protective wrapper layer added on top. A tiny amber gauge icon near the base implies a size limit. Mood is contained, immediate, and deliberately narrow. Avoid: vendor logos, brand colors, circuit-board textures, gears, or generic database-cylinder clip art."
+layout: post.njk
+site_title: Tech Notes
+summary: "IMemoryCache is the easiest caching decision in .NET to get right and, paradoxically, one of the easiest to misuse. A setup guide for size limits, the GetOrCreateAsync pattern, explicit invalidation on write, and why HybridCache is the better default even for single-server apps."
+tags: ["dotnet", "caching", "performance", "developer-productivity"]
+title: "Getting Started with IMemoryCache in .NET"
+---
+
+`IMemoryCache` is the easiest caching decision in .NET to get right and, paradoxically, one of the easiest to misuse - not because the API is complicated, but because it's so simple to add that people reach for it in places a distributed cache actually belongs, and forget it exists in places where it would help. Understanding what it is (a single-process dictionary with expiration policies) and isn't (anything that survives a restart, or is visible to another instance) is most of what you need to use it well.
+
+This guide covers using `IMemoryCache` in .NET, bootstrapping it correctly with expiration and size limits, the core `GetOrCreate` pattern that avoids most common mistakes, and the best practices - including when .NET 9's `HybridCache` is a better starting point than `IMemoryCache` directly. By the end you'll know exactly which caching problems this tool solves, and which ones it doesn't.
+
+If you're deciding between caching options first, [a comparison of the top .NET caching solutions](/posts/2027-08-03-top-5-dotnet-caching-solutions-compared/) covers where `IMemoryCache` fits relative to Redis, NCache, Memcached, and Garnet.
+
+## What You'll Need
+
+- .NET 8 SDK or later
+- Nothing else - `IMemoryCache` is part of the framework, no external service or NuGet package required beyond what ASP.NET Core already includes
+
+## Installing IMemoryCache
+
+For most ASP.NET Core apps, it's already available. If you're in a non-web host or want the package explicitly:
+
+```bash
+dotnet add package Microsoft.Extensions.Caching.Memory
+```
+
+Register it:
+
+```csharp
+var builder = WebApplication.CreateBuilder(args);
+builder.Services.AddMemoryCache();
+```
+
+## Bootstrapping the Ideal Environment
+
+The default configuration works, but two settings matter enough to set deliberately rather than leave at defaults: a size limit, and consistent expiration policy.
+
+### Set a size limit to prevent unbounded growth
+
+Without a limit, a memory cache can grow without bound and become its own memory problem:
+
+```csharp
+builder.Services.AddMemoryCache(options =>
+{
+    options.SizeLimit = 1024; // units are arbitrary -- you define what "1" means per entry
+});
+```
+
+Every entry then needs a `Size` set explicitly when it's cached, or it won't count against the limit:
+
+```csharp
+var entryOptions = new MemoryCacheEntryOptions
+{
+    Size = 1,
+    AbsoluteExpirationRelativeToNow = TimeSpan.FromMinutes(10)
+};
+cache.Set(cacheKey, value, entryOptions);
+```
+
+### Use GetOrCreate / GetOrCreateAsync instead of manual check-then-set
+
+```csharp
+public async Task<Product> GetProductAsync(int id)
+{
+    return await cache.GetOrCreateAsync($"product:{id}", async entry =>
+    {
+        entry.AbsoluteExpirationRelativeToNow = TimeSpan.FromMinutes(10);
+        entry.Size = 1;
+        return await repository.GetByIdAsync(id);
+    });
+}
+```
+
+`GetOrCreateAsync` handles the "check the cache, and if missing, compute and store the value" pattern in one call. Writing that check-then-set logic manually is a common source of subtle bugs, particularly around concurrent requests for the same missing key.
+
+### Consider HybridCache instead, even for a single-server app
+
+.NET 9 introduced `HybridCache`, which wraps `IMemoryCache` as its fast local (L1) tier and adds cache-stampede protection - if 100 concurrent requests miss the same key at once, only one actually executes the factory function; the rest await that single result instead of each independently hitting your database:
+
+```bash
+dotnet add package Microsoft.Extensions.Caching.Hybrid
+```
+
+```csharp
+builder.Services.AddHybridCache();
+```
+
+```csharp
+public class ProductService(HybridCache cache, IProductRepository repository)
+{
+    public async Task<Product> GetProductAsync(int id) =>
+        await cache.GetOrCreateAsync(
+            $"product:{id}",
+            async cancel => await repository.GetByIdAsync(id, cancel),
+            new HybridCacheEntryOptions { Expiration = TimeSpan.FromMinutes(10) });
+}
+```
+
+This works with zero extra infrastructure - it behaves like `IMemoryCache` until you register a distributed cache backend, at which point `HybridCache` automatically picks it up as an L2 tier without any change to your call sites. Because of the stampede protection and near-identical API, `HybridCache` is worth defaulting to over raw `IMemoryCache` for new code, even if you never add a distributed backend.
+
+## Core Workflow
+
+- **Cache computed or fetched values, not the source of truth itself.** `IMemoryCache` should be a performance optimization sitting in front of a database or external call, never the only place a piece of data lives.
+- **Set expiration on every entry.** An entry with no expiration lives until evicted by memory pressure or explicitly removed - almost always the wrong default for application data that can change.
+- **Invalidate explicitly on writes.** When the underlying data changes, remove or update the cached entry rather than waiting for expiration - `cache.Remove(key)` after a successful write is the simplest correct pattern.
+
+```csharp
+public async Task UpdateProductAsync(Product product)
+{
+    await repository.UpdateAsync(product);
+    cache.Remove($"product:{product.Id}");
+}
+```
+
+## Verifying Your Setup
+
+1. **A size limit is set, and entries specify `Size`** - confirm entries without a `Size` aren't silently bypassing your limit
+2. **Every cached entry has an expiration policy** - audit for any `Set` call missing `AbsoluteExpirationRelativeToNow` or `SlidingExpiration`
+3. **Writes invalidate the cache** - confirm an update to underlying data is reflected in reads shortly after, not stuck serving stale cached data for the full expiration window
+4. **Concurrent cache misses don't cause a stampede** - if you're using raw `IMemoryCache` rather than `HybridCache`, test what happens when many requests hit a cold cache key simultaneously
+
+## Best Practices
+
+**Default to `HybridCache` over raw `IMemoryCache` for new code.** The API is nearly identical, but stampede protection and a clear upgrade path to a distributed L2 tier make it the better starting point in .NET 9+.
+
+**Always set a size limit and per-entry `Size`.** An unbounded in-memory cache is a slow memory leak waiting to happen under enough traffic.
+
+**Never treat IMemoryCache as shared state across instances.** This is the single most common mistake - a value cached on one instance is completely invisible to any other instance, which becomes a real bug, not just a missed optimization, the moment your app scales beyond one instance.
+
+**Invalidate on write, don't rely solely on expiration.** Expiration is a safety net for staleness, not a substitute for actively invalidating a cache entry when you know the underlying data just changed.
+
+**Use short, deliberate expirations for anything that changes.** A long expiration on frequently-changing data trades correctness for cache hit rate in a way that's easy to regret later - tune expiration to how often the data actually changes, not how long you can get away with.
+
+## Comparison with Redis
+
+| | IMemoryCache | Redis (via IDistributedCache) |
+| --- | --- | --- |
+| Scope | Single process | Shared across all instances |
+| Latency | Nanosecond-scale | Millisecond-scale |
+| Survives restart | No | Yes, if persistence is enabled |
+| Infrastructure | None - built in | Requires a running Redis instance |
+| Best fit | Single-instance apps, or a fast local layer in front of a distributed cache | Multi-instance apps needing shared cache state |
+
+They're not really competitors - `IMemoryCache` (or `HybridCache`'s L1 tier) and Redis solve different problems and combine naturally, with `HybridCache` specifically designed to let you use both without maintaining separate cache-aside logic for each.
+
+## Frequently Asked Questions
+
+### Does IMemoryCache work across multiple instances of my app?
+
+No. Each instance has its own completely independent `IMemoryCache` - a value cached on Instance A is invisible to Instance B. If you need cache state shared across instances, you need a distributed cache like Redis, or `HybridCache` with a distributed backend registered.
+
+### What happens to IMemoryCache data when my app restarts?
+
+It's gone entirely - `IMemoryCache` has no persistence. This is by design; if you need cached data to survive a restart, that's a signal you actually need a distributed cache with persistence enabled, not a workaround for `IMemoryCache`.
+
+### Should I use IMemoryCache or HybridCache for a new project?
+
+`HybridCache`, in almost every case where you're on .NET 9 or later. It offers the same core API, adds cache-stampede protection `IMemoryCache` doesn't have, and gives you a clean upgrade path to a distributed L2 cache later without touching your call sites. There's little reason to reach for raw `IMemoryCache` directly in new code.
+
+### How do I prevent IMemoryCache from growing unbounded?
+
+Set a `SizeLimit` when registering the cache, and specify a `Size` value on every entry you add - entries without an explicit size don't count against the limit, so both pieces are necessary. Combine this with sensible expiration policies so entries don't accumulate indefinitely even before hitting the size limit.
+
+### What's cache stampede, and why does it matter?
+
+A cache stampede happens when many concurrent requests all miss the same cache key at once - for example, right after an expiration - and all independently fall through to the expensive operation being cached (a database query, an API call), multiplying load at exactly the moment you were trying to reduce it. Raw `IMemoryCache` doesn't protect against this; `HybridCache`'s `GetOrCreateAsync` does, by coalescing concurrent requests for the same key into a single execution.
+
+### Can I use IMemoryCache for session state?
+
+Technically yes, but it's usually the wrong choice for anything beyond single-instance, throwaway scenarios - session data lost on restart or invisible to other instances behind a load balancer is a real problem for most production apps. ASP.NET Core's session middleware is generally backed by a distributed cache (Redis being the most common) specifically to avoid this.
+
+### What's the most common mistake with IMemoryCache?
+
+Treating it as if it were shared state across instances - caching something on one server and being surprised another server doesn't see it. The second most common is forgetting expiration entirely, letting entries accumulate until memory pressure forces eviction rather than actively managing entry lifetime.

--- a/src/posts/2027-08-17-getting-started-with-redis-dotnet.md
+++ b/src/posts/2027-08-17-getting-started-with-redis-dotnet.md
@@ -1,0 +1,200 @@
+---
+author: Steve Kaschimer
+date: 2027-08-17
+image: /images/posts/2027-08-17-hero.webp
+image_alt: "A richer layered-shapes glyph with a cube, a small hash symbol, and a list icon clustered together, connected to a two-tier box representing a local cache in front of a shared cache."
+image_prompt: "A dark-mode technical editorial illustration on a near-black background with electric teal, amber, and off-white accents. Composition centers on a small cluster of three distinct shapes - a cube, a hash-mark glyph, and a short stacked-line list icon - grouped tightly together on the left, implying rich data structures. A teal line connects them to a two-tier rectangle on the right: a small fast tier stacked directly above a larger shared tier, implying a local cache layered in front of a distributed one. Mood is established, broad, and richly capable. Avoid: vendor logos, brand colors, circuit-board textures, gears, or generic database-cylinder clip art as the dominant motif."
+layout: post.njk
+site_title: Tech Notes
+summary: "Most of the friction people hit adopting Redis in .NET isn't Redis's fault - it's the boilerplate that used to be necessary around IDistributedCache. A setup guide for the recommended HybridCache-with-Redis path, sharing one connection multiplexer, and tag-based invalidation."
+tags: ["dotnet", "caching", "performance", "architecture", "devops"]
+title: "Getting Started with Redis in .NET"
+---
+
+Redis is the default distributed cache for .NET, and most of the friction people hit adopting it isn't Redis's fault - it's the boilerplate that used to be necessary around `IDistributedCache`: manual serialization, hand-written cache-aside logic, and no built-in protection against a cold cache getting hammered by concurrent requests. .NET 9's `HybridCache` addresses most of that directly, and it's worth knowing about before you build your own wrapper around `IDistributedCache` the way most tutorials from before 2025 will show you.
+
+This guide covers installing and connecting to Redis from .NET, bootstrapping it through both the classic `IDistributedCache` approach and the newer, recommended `HybridCache` path, the core patterns for reads, writes, and invalidation, and the best practices that keep a Redis-backed cache fast and correct. By the end you'll have a distributed cache that's shared cleanly across every instance of your application.
+
+If you're deciding between caching options first, [a comparison of the top .NET caching solutions](/posts/2027-08-03-top-5-dotnet-caching-solutions-compared/) covers where Redis fits relative to `IMemoryCache`, NCache, Memcached, and Garnet.
+
+## What You'll Need
+
+- .NET 8 SDK or later (.NET 9+ if you want `HybridCache`)
+- A running Redis instance - locally via Docker, or a managed offering from your cloud provider
+- Awareness of Redis's current licensing terms for your use case, or a look at Valkey (a BSD-licensed, drop-in-compatible fork) if that's a concern
+
+```bash
+docker run -d -p 6379:6379 redis:latest
+```
+
+## Installing Redis Client Libraries
+
+```bash
+dotnet add package Microsoft.Extensions.Caching.StackExchangeRedis
+```
+
+This brings in `StackExchange.Redis`, the standard .NET client, along with the `IDistributedCache` implementation backed by it.
+
+## Bootstrapping the Ideal Environment
+
+### The recommended path: HybridCache with Redis as L2
+
+```bash
+dotnet add package Microsoft.Extensions.Caching.Hybrid
+```
+
+```csharp
+var builder = WebApplication.CreateBuilder(args);
+
+builder.Services.AddStackExchangeRedisCache(options =>
+{
+    options.Configuration = builder.Configuration.GetConnectionString("Redis");
+    options.InstanceName = "myapp:"; // prefixes all keys, useful for shared Redis instances
+});
+
+builder.Services.AddHybridCache(options =>
+{
+    options.DefaultEntryOptions = new HybridCacheEntryOptions
+    {
+        Expiration = TimeSpan.FromMinutes(30),        // L2 (Redis) expiration
+        LocalCacheExpiration = TimeSpan.FromMinutes(5) // L1 (in-process) expiration
+    };
+});
+```
+
+Registering `AddStackExchangeRedisCache` alongside `AddHybridCache` is all it takes - `HybridCache` detects the registered `IDistributedCache` and automatically uses Redis as its L2 tier, with its own fast in-process L1 tier layered in front. No code at the call site changes:
+
+```csharp
+public class ProductService(HybridCache cache, IProductRepository repository)
+{
+    public async Task<Product> GetProductAsync(int id) =>
+        await cache.GetOrCreateAsync(
+            $"product:{id}",
+            async cancel => await repository.GetByIdAsync(id, cancel));
+}
+```
+
+Requests hit L1 (in-process memory) first, fall through to L2 (Redis) on an L1 miss, and only reach your actual data source on a miss at both tiers - with stampede protection at every level, so concurrent requests for the same cold key coalesce into a single execution.
+
+### The classic path: IDistributedCache directly
+
+If you're not yet on .NET 9, or want lower-level control:
+
+```csharp
+builder.Services.AddStackExchangeRedisCache(options =>
+{
+    options.Configuration = builder.Configuration.GetConnectionString("Redis");
+});
+```
+
+```csharp
+public class ProductService(IDistributedCache cache, IProductRepository repository)
+{
+    public async Task<Product?> GetProductAsync(int id)
+    {
+        var cacheKey = $"product:{id}";
+        var cached = await cache.GetStringAsync(cacheKey);
+        if (cached is not null)
+            return JsonSerializer.Deserialize<Product>(cached);
+
+        var product = await repository.GetByIdAsync(id);
+        if (product is not null)
+        {
+            await cache.SetStringAsync(cacheKey, JsonSerializer.Serialize(product),
+                new DistributedCacheEntryOptions { AbsoluteExpirationRelativeToNow = TimeSpan.FromMinutes(30) });
+        }
+        return product;
+    }
+}
+```
+
+Notice everything `HybridCache` handles for you here: manual serialization, a manual check-then-set pattern, and no protection against concurrent requests all hitting `GetByIdAsync` simultaneously on a cache miss. This is exactly the boilerplate `HybridCache` exists to eliminate.
+
+### Sharing one connection multiplexer
+
+`StackExchange.Redis`'s `IConnectionMultiplexer` is expensive to create and designed to be a long-lived singleton shared across your whole application - including other features that also talk to Redis directly (a SignalR backplane, distributed locks, and so on):
+
+```csharp
+builder.Services.AddSingleton<IConnectionMultiplexer>(
+    ConnectionMultiplexer.Connect(builder.Configuration.GetConnectionString("Redis")!));
+```
+
+If multiple features each open their own connection instead of sharing one multiplexer, you end up with far more Redis connections than your application actually needs.
+
+## Core Workflow
+
+- **Cache-aside is the default pattern**, whether via `HybridCache.GetOrCreateAsync` or hand-rolled `IDistributedCache` logic: check cache, fall through to source on miss, populate cache with the result.
+- **Invalidate explicitly on writes.** `HybridCache` supports tag-based invalidation for removing groups of related entries at once, which is considerably cleaner than tracking individual keys by hand.
+- **Use Redis's richer data structures when key-value alone isn't enough.** For scenarios like leaderboards or rate limiting, `StackExchange.Redis`'s direct API (sorted sets, hashes) is more appropriate than the cache abstraction layer.
+
+```csharp
+// Tag-based invalidation with HybridCache
+await cache.GetOrCreateAsync(
+    $"product:{id}",
+    async cancel => await repository.GetByIdAsync(id, cancel),
+    tags: ["products"]);
+
+// Later, invalidate every entry tagged "products" at once
+await cache.RemoveByTagAsync("products");
+```
+
+## Verifying Your Setup
+
+1. **Connection is shared, not duplicated** - confirm `IConnectionMultiplexer` is registered as a singleton and reused across features, not reconnected per request
+2. **HybridCache is actually using Redis as L2** - stop your Redis container temporarily and confirm the app degrades to L1-only behavior rather than failing outright, or confirm your chosen failure mode matches expectations
+3. **Stampede protection works** - fire many concurrent requests at a cold cache key and confirm only one actually reaches your data source
+4. **Keys are properly namespaced** - if sharing a Redis instance across applications, confirm `InstanceName` or an equivalent prefix prevents key collisions
+
+## Best Practices
+
+**Default to `HybridCache` over hand-rolled `IDistributedCache` logic.** It eliminates serialization boilerplate, adds stampede protection, and gives you a free in-process L1 tier - there's very little reason to write the manual check-then-set pattern yourself in new code.
+
+**Share one `IConnectionMultiplexer` across your whole application.** Register it as a singleton and reuse it for caching, SignalR backplanes, distributed locks, or anything else that talks to Redis - one connection pool, not one per feature.
+
+**Set both L1 and L2 expiration deliberately with HybridCache.** `LocalCacheExpiration` (L1) should generally be shorter than `Expiration` (L2) - the local tier is meant to be a very fast, short-lived cache of what's already in the shared tier.
+
+**Use tag-based invalidation for related entries instead of tracking keys manually.** Removing "everything related to product 42" by tag is more maintainable than remembering every individual key that needs to be cleared.
+
+**Check current Redis licensing for your use case, or evaluate Valkey.** Licensing terms have shifted more than once in recent years - confirm what applies to you before standardizing on Redis specifically versus a compatible fork.
+
+## Comparison with NCache
+
+| | Redis | NCache |
+| --- | --- | --- |
+| .NET integration | Mature client library, not .NET-native | Built specifically for .NET |
+| Data structures | Rich (lists, sets, hashes, sorted sets, streams) | Rich, .NET-native object caching |
+| Ecosystem | Largest of any option in this comparison | Smaller, .NET-focused |
+| ASP.NET Core session support | Via IDistributedCache | Deep, purpose-built integration |
+| Best fit | Most distributed caching needs | .NET-heavy enterprises wanting native tooling |
+
+Both are legitimate distributed caches for .NET - Redis wins on ecosystem breadth and community size, NCache on depth of native .NET integration. For most teams without a specific reason to prefer NCache's native tooling, Redis remains the more broadly supported default.
+
+## Frequently Asked Questions
+
+### Should I use HybridCache or IDistributedCache directly with Redis?
+
+`HybridCache`, if you're on .NET 9 or later. It wraps `IDistributedCache` implementations (including Redis) and adds a fast in-process L1 tier, automatic serialization, and cache-stampede protection, all through a simpler API. There's little reason to hand-write the check-then-set pattern `IDistributedCache` requires when `HybridCache` handles it for you.
+
+### What happens if Redis goes down while my app is running?
+
+With `HybridCache`, behavior depends on configuration, but typically requests fall through to your data source directly (bypassing the L2 cache) rather than failing outright, since L1 (in-process) continues working independently. With raw `IDistributedCache`, a Redis outage will generally surface as exceptions from cache calls unless you've wrapped them in your own fallback logic - worth testing deliberately rather than assuming.
+
+### Do I need to worry about Redis licensing?
+
+It's worth checking current terms for your specific situation, since Redis's licensing has changed more than once in recent years. Valkey, a BSD-licensed fork backed by the Linux Foundation and major cloud providers, is a common alternative if licensing terms are a concern - it's largely a drop-in replacement using the same client libraries and protocol.
+
+### How do I invalidate a group of related cache entries at once?
+
+With `HybridCache`, tag entries when creating them (`tags: ["products"]`) and invalidate the whole group with `RemoveByTagAsync("products")`. With raw `IDistributedCache`, you'd need to track related keys yourself, which is more error-prone - this is one of the concrete conveniences `HybridCache` adds over the lower-level abstraction.
+
+### Why should I share one IConnectionMultiplexer instead of creating connections as needed?
+
+`ConnectionMultiplexer.Connect()` is expensive and designed to be a long-lived singleton - it manages its own internal connection pooling to Redis. Creating a new one per request or per feature multiplies connection overhead unnecessarily and can exhaust Redis's connection limits under load; registering it once as a singleton and injecting it wherever needed is the correct pattern.
+
+### Can I use Redis for things other than caching, like a SignalR backplane or session state?
+
+Yes - Redis's pub/sub and data structure support make it a common backing store for SignalR's distributed backplane, ASP.NET Core session state, distributed locks, and rate limiting, in addition to general-purpose caching. If you're already running Redis for caching, sharing the same instance (and connection multiplexer) for these other purposes is common and efficient, provided you're mindful of key namespacing to avoid collisions.
+
+### What's the most common mistake in a first Redis setup for .NET?
+
+Writing manual cache-aside logic with `IDistributedCache` instead of using `HybridCache`, and creating a new `IConnectionMultiplexer` per request or per feature instead of sharing one singleton across the application. Both are easy to avoid once you know to look for them, but both are the default outcome of following an older tutorial without noticing `HybridCache` now exists.

--- a/src/posts/2027-08-24-getting-started-with-garnet.md
+++ b/src/posts/2027-08-24-getting-started-with-garnet.md
@@ -1,0 +1,159 @@
+---
+author: Steve Kaschimer
+date: 2027-08-24
+image: /images/posts/2027-08-24-hero.webp
+image_alt: "Two overlapping outlines of the same shape - one solid, one dashed - implying protocol compatibility between two separate implementations, with a small multi-core grid glyph beneath."
+image_prompt: "A dark-mode technical editorial illustration on a near-black background with electric teal, amber, and off-white accents. Composition centers on two nearly identical rectangular outlines overlapping closely - the left one solid teal, the right one dashed in amber - implying the same wire protocol spoken by two distinct implementations. Beneath them, a small grid of four evenly spaced squares implies multi-core performance. Mood is compatible, modern, and quietly confident. Avoid: vendor logos, brand colors, circuit-board textures, gears, or generic database-cylinder clip art."
+layout: post.njk
+site_title: Tech Notes
+summary: "Same protocol as Redis, so existing client code mostly just works, but built in C# by Microsoft Research with a modern GC design aimed at multi-core performance. A setup guide for connecting with the existing StackExchange.Redis client and verifying command compatibility before trusting it as a drop-in replacement."
+tags: ["dotnet", "caching", "performance", "tooling"]
+title: "Getting Started with Garnet in .NET"
+---
+
+Garnet's pitch is unusually direct for a caching tool: same protocol as Redis, so your existing client code mostly just works, but built in C# by Microsoft Research with a modern, epoch-based garbage collection design aimed squarely at strong multi-core performance. For .NET shops, that combination - Redis-compatible on the wire, native .NET under the hood - is the whole appeal, along with the honest caveat that it's meaningfully younger than everything else in this comparison.
+
+This guide covers installing and running Garnet, bootstrapping a connection using the same `StackExchange.Redis` client you'd use for Redis itself, the core workflow (which is close to identical to Redis, by design), and the best practices for adopting something newer without getting burned by gaps between it and the tool it's compatible with. By the end you'll have a working Garnet setup and a clear sense of what to verify before trusting it with production traffic.
+
+If you're deciding between caching options first, [a comparison of the top .NET caching solutions](/posts/2027-08-03-top-5-dotnet-caching-solutions-compared/) covers where Garnet fits relative to `IMemoryCache`, Redis, NCache, and Memcached.
+
+## What You'll Need
+
+- .NET 8 SDK or later
+- Docker, or the ability to build/run Garnet's server binary directly
+- An existing familiarity with Redis is genuinely useful here, since Garnet's client-facing behavior is designed to mirror it closely
+
+```bash
+docker run -d -p 6379:6379 ghcr.io/microsoft/garnet
+```
+
+## Installing Garnet Client Libraries
+
+Because Garnet speaks RESP (the same wire protocol Redis uses), you don't need a Garnet-specific client - the standard Redis client for .NET works directly:
+
+```bash
+dotnet add package Microsoft.Extensions.Caching.StackExchangeRedis
+```
+
+This is Garnet's core practical advantage for .NET teams: if you already have Redis integration code, pointing it at a Garnet instance is frequently just a connection string change, not a rewrite.
+
+## Bootstrapping the Ideal Environment
+
+### Connecting exactly like you would to Redis
+
+```csharp
+var builder = WebApplication.CreateBuilder(args);
+
+builder.Services.AddStackExchangeRedisCache(options =>
+{
+    options.Configuration = builder.Configuration.GetConnectionString("Garnet");
+});
+
+builder.Services.AddHybridCache();
+```
+
+Because `HybridCache` works against any registered `IDistributedCache`, and Garnet's RESP compatibility means `AddStackExchangeRedisCache` connects to it without modification, the entire `HybridCache` setup from the Redis guide applies here unchanged - same API, same stampede protection, same L1/L2 tiering, just pointed at a different backend.
+
+```csharp
+public class ProductService(HybridCache cache, IProductRepository repository)
+{
+    public async Task<Product> GetProductAsync(int id) =>
+        await cache.GetOrCreateAsync(
+            $"product:{id}",
+            async cancel => await repository.GetByIdAsync(id, cancel));
+}
+```
+
+### Verify command compatibility before assuming full parity
+
+RESP-compatible doesn't automatically mean every Redis command or module you rely on is implemented identically. Before migrating a production workload:
+
+```csharp
+var multiplexer = ConnectionMultiplexer.Connect(connectionString);
+var db = multiplexer.GetDatabase();
+
+// Test the specific commands/patterns your app actually uses
+await db.StringSetAsync("test-key", "test-value");
+var result = await db.StringGetAsync("test-key");
+```
+
+Run through your application's actual Redis usage patterns - not just basic get/set, but any sorted sets, pub/sub, Lua scripting, or specific modules (RediSearch, RedisJSON) you depend on - and confirm each is supported before treating Garnet as a drop-in replacement rather than a protocol-compatible alternative.
+
+## Core Workflow
+
+The workflow is intentionally identical to Redis, since that's the entire design goal:
+
+- **Cache-aside via `HybridCache`**, same as the Redis guide - `GetOrCreateAsync` with tag-based invalidation where useful
+- **Share one connection across your application**, the same discipline that applies to `StackExchange.Redis` against real Redis
+- **Monitor Garnet-specific operational behavior separately from what you know about Redis operations.** Even with wire compatibility, operational characteristics (memory behavior, GC pauses, failure modes) come from a genuinely different implementation and shouldn't be assumed identical just because the protocol is.
+
+```csharp
+await cache.GetOrCreateAsync(
+    $"product:{id}",
+    async cancel => await repository.GetByIdAsync(id, cancel),
+    tags: ["products"]);
+
+await cache.RemoveByTagAsync("products");
+```
+
+## Verifying Your Setup
+
+1. **Existing Redis client code connects without modification** - confirm `StackExchange.Redis` (directly or via `HybridCache`) works against Garnet with just a connection string change
+2. **Your specific command usage is supported** - test the actual Redis features your application depends on, not just basic get/set, against a real Garnet instance
+3. **Performance matches expectations under your actual workload** - Garnet's benchmark strength is on multi-core machines specifically; validate against your real traffic pattern rather than trusting generic benchmarks
+4. **You have a rollback plan** - given Garnet's relative youth compared to Redis, confirm you can revert to Redis (or another option) without a major rework if something doesn't hold up in production
+
+## Best Practices
+
+**Treat "RESP-compatible" as "very likely to work," not "guaranteed identical."** Test your application's actual Redis usage patterns against Garnet directly rather than assuming full command and module parity.
+
+**Take advantage of the low switching cost to actually evaluate it, not just read about it.** Because adopting Garnet often requires nothing more than a connection string change on top of existing Redis integration code, there's little reason not to run a real evaluation against your actual workload rather than deciding from benchmarks alone.
+
+**Weigh production maturity honestly against your risk tolerance.** Garnet has strong backing and active development, but meaningfully less time in production at scale than Redis, NCache, or Memcached - factor that into how central you make it to critical-path infrastructure, at least initially.
+
+**Use `HybridCache` the same way you would with Redis.** There's no reason to write Garnet-specific caching code - the whole point of RESP compatibility is that your existing `IDistributedCache`-based patterns carry over directly.
+
+**Keep an eye on the project's release cadence and community activity before committing long-term.** As a newer, actively developed project, checking that development momentum continues is more relevant due diligence here than it would be for an established tool like Redis.
+
+## Comparison with Redis
+
+| | Garnet | Redis |
+| --- | --- | --- |
+| Protocol | RESP-compatible | RESP (native) |
+| Implementation language | C#, built by Microsoft Research | C++ |
+| .NET client | Same `StackExchange.Redis` client works directly | `StackExchange.Redis` (the native, original target) |
+| Production maturity | Newer, less battle-tested at scale | Over a decade of production use across huge deployments |
+| Ecosystem | Smaller, growing | Largest of any option in this comparison |
+| Best fit | .NET shops wanting Redis compatibility with a .NET-native codebase, willing to accept newer-project risk | Most distributed caching needs, especially where maturity matters most |
+
+The practical migration cost between the two is genuinely low given the shared protocol - which makes Garnet worth directly evaluating rather than dismissing, but doesn't erase the real gap in how long each has been proven at scale.
+
+## Frequently Asked Questions
+
+### Do I need a different client library to use Garnet instead of Redis?
+
+No - because Garnet speaks RESP, the same protocol Redis uses, the standard `StackExchange.Redis` client (and by extension, `Microsoft.Extensions.Caching.StackExchangeRedis` and `HybridCache`) connects to Garnet without any client-side changes, typically just a different connection string.
+
+### Is Garnet a full drop-in replacement for Redis?
+
+Mostly, for common usage patterns, but not guaranteed for everything. RESP compatibility covers the core protocol and most commands, but specific Redis modules (RediSearch, RedisJSON) or less common commands may not have identical support. Test your application's actual usage against Garnet directly before treating it as a verified drop-in replacement.
+
+### Is Garnet ready for production use?
+
+It depends on your risk tolerance and how central caching is to your system's reliability. Garnet has strong performance characteristics and active Microsoft Research backing, but it has meaningfully less production track record at scale than Redis. Many teams are well-served evaluating it for non-critical-path caching first before trusting it with core infrastructure.
+
+### Why would a .NET team choose Garnet over just using Redis?
+
+The main draw is a codebase and governance model closer to home for .NET shops - Garnet is built in C#, which some teams value for contribution and debugging familiarity, combined with strong reported performance on multi-core hardware. It's a deliberate trade of Redis's much longer track record for a .NET-native implementation and active Microsoft Research development.
+
+### What performance benefits does Garnet actually offer over Redis?
+
+Garnet's design, including its epoch-based garbage collection approach, shows strong benchmark results specifically on multi-core machines. Whether that translates into a meaningful difference for your specific workload depends heavily on your actual traffic patterns and hardware - validate against your own workload rather than relying on generic benchmark claims.
+
+### Can I run Garnet and Redis side by side during a migration?
+
+Yes, and it's a reasonable approach given the shared protocol - you could route some traffic to Garnet for evaluation while keeping Redis as the primary, or migrate incrementally by service or feature. Because the client code is identical either way, the migration itself is mostly a configuration change rather than a code change.
+
+### What's the most common mistake evaluating Garnet?
+
+Assuming full command and module parity with Redis based on RESP compatibility alone, without testing the application's actual specific usage patterns first. The second is skipping a real evaluation against production-like traffic because the switching cost seems low - low switching cost is a reason to actually test thoroughly, not a reason to skip testing.

--- a/src/posts/2027-08-31-getting-started-with-memcached.md
+++ b/src/posts/2027-08-31-getting-started-with-memcached.md
@@ -1,0 +1,160 @@
+---
+author: Steve Kaschimer
+date: 2027-08-31
+image: /images/posts/2027-08-31-hero.webp
+image_alt: "A minimal flat rectangle with no ornamentation, connected by a plain straight line to a single small value dot, deliberately stripped of any extra glyph or layer."
+image_prompt: "A dark-mode technical editorial illustration on a near-black background with electric teal, amber, and off-white accents. Composition centers on a single flat, unornamented rectangle connected by one plain straight teal line to a small solid dot, representing pure key-value simplicity with nothing else attached. A faint secondary rectangle sits beside it at a slight offset, sharing no connecting lines, implying a second independent node with no cross-communication. Mood is stripped-down, fast, and deliberately narrow. Avoid: vendor logos, brand colors, circuit-board textures, gears, or generic database-cylinder clip art as the dominant motif."
+layout: post.njk
+site_title: Tech Notes
+summary: "Memcached's setup story is the shortest in this entire series, and that's not an accident - no data structure configuration, no persistence tuning, no replication topology to choose between. A setup guide for the EnyimMemcachedCore client, client-side sharding, and knowing exactly when reaching for it over Redis is the right call."
+tags: ["dotnet", "caching", "performance", "tooling"]
+title: "Getting Started with Memcached in .NET"
+---
+
+Memcached's setup story is the shortest in this entire series, and that's not an accident - it's the entire design philosophy in one fact. There's no data structure configuration to reason about, no persistence tuning, no replication topology to choose between. You get a fast, multi-threaded key-value store and nothing else, which is exactly right when nothing else is what you need.
+
+This guide covers installing Memcached and connecting to it from .NET, bootstrapping a client with sensible connection pooling, the core get/set workflow (which is most of what there is), and the best practices that keep you from accidentally fighting Memcached's intentional simplicity. By the end you'll know exactly when reaching for this over Redis is the right call, not just the familiar one.
+
+If you're deciding between caching options first, [a comparison of the top .NET caching solutions](/posts/2027-08-03-top-5-dotnet-caching-solutions-compared/) covers where Memcached fits relative to `IMemoryCache`, Redis, NCache, and Garnet.
+
+## What You'll Need
+
+- .NET 8 SDK or later
+- A running Memcached instance - locally via Docker, or a managed offering from your cloud provider
+
+```bash
+docker run -d -p 11211:11211 memcached:latest
+```
+
+## Installing a Memcached Client
+
+.NET doesn't have a first-party Memcached client the way it does for Redis (`StackExchange.Redis` is community-standard but extremely mature). `EnyimMemcached` is the most widely used community client:
+
+```bash
+dotnet add package EnyimMemcachedCore
+```
+
+## Bootstrapping the Ideal Environment
+
+### Registering the client
+
+```csharp
+var builder = WebApplication.CreateBuilder(args);
+
+builder.Services.AddEnyimMemcached(options =>
+{
+    options.AddServer("localhost", 11211);
+});
+```
+
+For multiple Memcached nodes (Memcached itself has no clustering - the client distributes keys across nodes via consistent hashing):
+
+```csharp
+builder.Services.AddEnyimMemcached(options =>
+{
+    options.AddServer("memcached-1", 11211);
+    options.AddServer("memcached-2", 11211);
+});
+```
+
+This client-side distribution is a meaningfully different model from Redis Cluster or NCache's server-side clustering - Memcached nodes don't know about each other at all; the client decides which node a given key belongs to.
+
+### Basic get/set
+
+```csharp
+public class ProductService(IMemcachedClient cache, IProductRepository repository)
+{
+    public async Task<Product?> GetProductAsync(int id)
+    {
+        var cacheKey = $"product:{id}";
+        var cached = await cache.GetAsync<Product>(cacheKey);
+        if (cached is not null)
+            return cached;
+
+        var product = await repository.GetByIdAsync(id);
+        if (product is not null)
+        {
+            await cache.SetAsync(cacheKey, product, TimeSpan.FromMinutes(30));
+        }
+        return product;
+    }
+}
+```
+
+That's close to the entirety of Memcached's API surface - `Get`, `Set`, `Remove`, and a handful of atomic increment/decrement operations for counters. There's no equivalent to Redis's sorted sets, hashes, or pub/sub, because Memcached deliberately doesn't try to be more than a fast key-value store.
+
+## Core Workflow
+
+- **Cache-aside is the only pattern Memcached really supports.** There's no server-side scripting, no pub/sub for invalidation notifications - your application code is fully responsible for cache-aside logic.
+- **Key size and value size both have hard limits** (typically 250 bytes for keys, 1MB for values by default) - Memcached will silently reject or fail on values that exceed configured limits, so keep this in mind for large cached objects.
+- **Invalidate explicitly on writes**, the same as any cache-aside pattern - Memcached has no built-in mechanism for reacting to changes elsewhere.
+
+```csharp
+public async Task UpdateProductAsync(Product product)
+{
+    await repository.UpdateAsync(product);
+    await cache.RemoveAsync($"product:{product.Id}");
+}
+```
+
+## Verifying Your Setup
+
+1. **Multiple nodes distribute keys as expected** - if running more than one Memcached instance, confirm the client's consistent hashing is spreading keys across nodes rather than concentrating them
+2. **Values under the size limit are cached correctly** - confirm large objects aren't silently failing to cache due to exceeding Memcached's default value size limit
+3. **A node going down degrades gracefully** - since nodes don't replicate to each other, confirm your client and application handle a node becoming unavailable without hard failures
+4. **Expiration is set on every entry** - Memcached does support a "never expire" option, but that's rarely the right default for application data
+
+## Best Practices
+
+**Only reach for Memcached when your caching need is genuinely simple key-value.** The moment you want data structures beyond strings, or need persistence, Redis is the better fit - Memcached's simplicity is a strength specifically for the use cases it's designed for, not a general-purpose caching upgrade path.
+
+**Understand that Memcached has no persistence at all.** A restart means a fully cold cache - if that's a problem for your use case (versus just a minor and expected performance dip), Memcached is the wrong tool regardless of how simple your data shape is.
+
+**Be deliberate about key and value size limits.** Memcached's defaults (roughly 250-byte keys, 1MB values) are lower than what Redis typically accommodates - check these before caching larger objects, and consider whether they actually need to be cached whole or split.
+
+**Understand client-side sharding if you're running multiple nodes.** Because Memcached nodes don't communicate with each other, your client library's consistent hashing determines key distribution - and if that consistent hashing scheme changes (e.g., adding or removing a node), cache keys can redistribute and cause a temporary wave of cache misses.
+
+**Use Memcached specifically for session stores, page fragments, or simple lookups at high throughput.** These are the scenarios where its multi-threaded simplicity genuinely outperforms a more feature-rich cache carrying overhead it doesn't need.
+
+## Comparison with Redis
+
+| | Memcached | Redis |
+| --- | --- | --- |
+| Data structures | Simple key-value only | Rich (lists, sets, hashes, sorted sets, streams) |
+| Persistence | None | Optional (snapshotting, AOF) |
+| Clustering | Client-side sharding, nodes don't communicate | Server-side clustering (Redis Cluster) |
+| Threading | Multi-threaded by design | Historically single-threaded per instance, though this has evolved |
+| .NET client maturity | Solid community client, less mature than StackExchange.Redis | Very mature, first-party Microsoft package support |
+| Best fit | Pure key-value at very high throughput | Anything needing more than simple key-value, or persistence |
+
+Memcached wins specifically on raw simplicity and multi-threaded throughput for pure key-value workloads. Redis wins on everything else - richer functionality, persistence, and a substantially more mature .NET ecosystem around it.
+
+## Frequently Asked Questions
+
+### Does .NET have a first-party Memcached client like it does for Redis?
+
+No - there's no Microsoft-maintained equivalent to `Microsoft.Extensions.Caching.StackExchangeRedis` for Memcached. `EnyimMemcachedCore` is the most widely used community client and is a mature, production-viable choice, but it doesn't have the same institutional backing as the Redis tooling.
+
+### Can Memcached persist data to disk?
+
+No, never - this is a deliberate design choice, not a missing feature. A Memcached restart or crash means a completely cold cache. If persistence matters for your use case, Memcached is the wrong tool regardless of how well its simple key-value model otherwise fits.
+
+### How does Memcached handle multiple server nodes?
+
+Through client-side consistent hashing - the client library decides which node a given key belongs to, and Memcached nodes have no awareness of or communication with each other. This is different from Redis Cluster, where the cluster itself manages data distribution and replication server-side.
+
+### What happens if a Memcached node goes down?
+
+Every key that hashed to that node becomes unavailable - there's no replication to fall back on, since nodes don't communicate. Your application needs to treat this as an expected cache miss (falling through to the real data source) rather than a hard failure, and be aware that losing a node effectively means losing that portion of your cached data until it's repopulated.
+
+### Is there a size limit on what I can store in Memcached?
+
+Yes - by default, keys are limited to around 250 bytes and values to about 1MB, both configurable but worth knowing as defaults. This is generally smaller than what you'd hit caching similar data in Redis, so it's worth checking before assuming a large object will cache without issue.
+
+### Should I use Memcached or Redis for session state?
+
+Redis is the far more common choice for session state in .NET, mainly because Memcached's total lack of persistence means a Memcached restart logs every active user out. If session loss on a cache restart is unacceptable, which it usually is, Redis's optional persistence makes it the safer default.
+
+### What's the most common mistake when adopting Memcached?
+
+Choosing it out of familiarity or simplicity when the actual caching need has already outgrown simple key-value - needing to cache a list, a set, or anything with more structure than a flat value is a clear signal Memcached isn't the right fit, and reaching for Redis or another richer cache would save a workaround later.

--- a/src/posts/2027-09-07-getting-started-with-ncache.md
+++ b/src/posts/2027-09-07-getting-started-with-ncache.md
@@ -1,0 +1,181 @@
+---
+author: Steve Kaschimer
+date: 2027-09-07
+image: /images/posts/2027-09-07-hero.webp
+image_alt: "A peer-to-peer mesh of three connected nodes drawn in an angular native style, each node holding its own storage rather than routing through a single central hub."
+image_prompt: "A dark-mode technical editorial illustration on a near-black background with electric teal, amber, and off-white accents. Composition centers on three angular node shapes arranged in a triangle, each connected directly to the other two by thin teal lines with no central hub, implying peer-to-peer distribution rather than primary/replica hierarchy. A small amber badge on one node represents native .NET object storage, distinct from a generic serialized-blob icon. Mood is purpose-built, enterprise, and precise. Avoid: vendor logos, brand colors, circuit-board textures, gears, or generic database-cylinder clip art as the dominant motif."
+layout: post.njk
+site_title: Tech Notes
+summary: "NCache's whole pitch is being the distributed cache built for .NET rather than adapted to it - ASP.NET Core session state and EF Core query caching are first-class integrations, not something assembled on top of a generic IDistributedCache. A setup guide for named caches, native object caching, and the purpose-built session and EF Core integrations."
+tags: ["dotnet", "caching", "architecture", "developer-productivity"]
+title: "Getting Started with NCache in .NET"
+---
+
+NCache's whole pitch is being the distributed cache built for .NET rather than adapted to it, and that shows up most clearly in the setup itself - ASP.NET Core session state and EF Core query caching are first-class, purpose-built integrations rather than something you assemble yourself on top of a generic `IDistributedCache` implementation. The trade-off is a smaller ecosystem and, for the full feature set, a commercial license - worth knowing upfront rather than discovering halfway through evaluation.
+
+This guide covers installing and connecting to NCache from .NET, bootstrapping a cache and its ASP.NET Core integrations, the core read/write/session workflow, and the best practices that make the most of its .NET-native design. By the end you'll have a working NCache setup and a clear sense of which of its enterprise features are worth turning on for your specific workload.
+
+If you're deciding between caching options first, [a comparison of the top .NET caching solutions](/posts/2027-08-03-top-5-dotnet-caching-solutions-compared/) covers where NCache fits relative to `IMemoryCache`, Redis, Memcached, and Garnet.
+
+## What You'll Need
+
+- .NET 8 SDK or later
+- An NCache installation - Open Source edition is available for evaluation and smaller deployments; Enterprise unlocks the full feature set (write-behind caching, advanced replication, peer-to-peer clustering)
+- A running NCache cache server, either locally or in your target environment
+
+## Installing NCache
+
+Install the NCache server following Alachisoft's setup instructions for your platform, then add the client SDK to your .NET project:
+
+```bash
+dotnet add package Alachisoft.NCache.SDK
+```
+
+Create a named cache through NCache's management tools (the NCache Web Manager, or `createcache` from the command line) before connecting to it from your application - unlike Redis, where a database exists implicitly the moment you connect, NCache caches are provisioned as named, configured entities.
+
+## Bootstrapping the Ideal Environment
+
+### Connecting to a cache
+
+```csharp
+using Alachisoft.NCache.Client;
+
+var builder = WebApplication.CreateBuilder(args);
+
+var cache = CacheManager.GetCache("myAppCache");
+builder.Services.AddSingleton(cache);
+```
+
+`CacheManager.GetCache` returns a connection to a named cache cluster - like Redis's connection multiplexer, this should be created once and shared, not reconnected per request.
+
+### Basic get/set
+
+```csharp
+public class ProductService(ICache cache, IProductRepository repository)
+{
+    public async Task<Product?> GetProductAsync(int id)
+    {
+        var cacheKey = $"product:{id}";
+        if (cache.Contains(cacheKey))
+            return cache.Get<Product>(cacheKey);
+
+        var product = await repository.GetByIdAsync(id);
+        if (product is not null)
+        {
+            cache.Insert(cacheKey, product, new CacheItemExpiration(TimeSpan.FromMinutes(30)));
+        }
+        return product;
+    }
+}
+```
+
+NCache caches native .NET objects directly - no manual JSON serialization step the way raw `IDistributedCache` requires, since NCache's client handles object serialization internally.
+
+### ASP.NET Core session state, the purpose-built way
+
+This is one of NCache's strongest differentiators over a generic `IDistributedCache`-based session provider:
+
+```csharp
+builder.Services.AddNCacheSession(options =>
+{
+    options.CacheName = "myAppCache";
+});
+
+builder.Services.AddSession();
+```
+
+```csharp
+app.UseSession();
+```
+
+Sessions stored this way are replicated according to your cache cluster's topology, so a session isn't lost if a specific cache node goes down - a concern that's handled at the infrastructure level rather than something you build yourself.
+
+### EF Core integration
+
+NCache offers extension methods specifically for caching EF Core query results:
+
+```csharp
+var activeOrders = await db.Orders
+    .Where(o => o.Status == OrderStatus.Processing)
+    .FromCache(TimeSpan.FromMinutes(10)) // NCache extension method
+    .ToListAsync();
+```
+
+This caches query results transparently at the EF Core query level, which is a meaningfully different (and more automatic) approach than manually wrapping repository methods in cache-aside logic yourself.
+
+## Core Workflow
+
+- **Use named caches deliberately, provisioned ahead of time.** Unlike Redis's implicit key namespace, NCache caches are explicit, configured entities - decide your cache topology (replicated, partitioned, client cache) as part of setup, not as an afterthought.
+- **Lean on native object caching rather than manual serialization.** This is one of the concrete conveniences of NCache's .NET-native design - don't reintroduce JSON serialization boilerplate that the client already handles.
+- **Use write-behind caching for write-heavy workloads where eventual database consistency is acceptable.** NCache can batch writes to your database asynchronously rather than requiring every cache write to also block on a synchronous database write.
+
+```csharp
+// Explicit invalidation on write
+public async Task UpdateProductAsync(Product product)
+{
+    await repository.UpdateAsync(product);
+    cache.Remove($"product:{product.Id}");
+}
+```
+
+## Verifying Your Setup
+
+1. **Cache connection is a shared singleton** - confirm `CacheManager.GetCache` is called once and the resulting connection is reused, not recreated per request
+2. **Session state survives a node failure** - if using replicated topology, test that a session remains available after taking one cache node offline
+3. **EF Core query caching is actually hitting the cache** - confirm a repeated query within the cache window doesn't re-execute against the database
+4. **Expiration and eviction policies match your data's actual change frequency** - audit cache entries for appropriate expiration rather than defaults copied from a tutorial
+
+## Best Practices
+
+**Provision named caches with a deliberate topology, not a default.** NCache's peer-to-peer, replicated, and partitioned topologies each suit different workloads - pick based on your actual availability and scale requirements rather than accepting whatever a quickstart guide used.
+
+**Use the ASP.NET Core session and EF Core integrations instead of building your own.** These are exactly the areas where NCache's .NET-native design pays off over a generic distributed cache - using them is the whole reason to choose NCache in the first place.
+
+**Reserve write-behind caching for workloads that can tolerate eventual database consistency.** It's a powerful feature for write-heavy scenarios, but it changes your consistency guarantees - understand the trade-off before enabling it broadly.
+
+**Share one cache connection across your application**, the same discipline `IConnectionMultiplexer` requires with Redis - `CacheManager.GetCache` shouldn't be called repeatedly per request.
+
+**Confirm which features require Enterprise licensing before architecting around them.** Some of NCache's more advanced capabilities (certain replication and clustering options) require the commercial edition - verify what your evaluation or open-source setup actually supports before committing to a design that assumes them.
+
+## Comparison with Redis
+
+| | NCache | Redis |
+| --- | --- | --- |
+| .NET integration | Native, purpose-built | Mature client library, not .NET-native |
+| Object caching | Native .NET objects, automatic serialization | Requires manual serialization, or HybridCache's built-in handling |
+| ASP.NET Core session | Deep, purpose-built provider | Via generic IDistributedCache session provider |
+| EF Core integration | Purpose-built extension methods | Requires custom cache-aside logic |
+| Ecosystem | Smaller, .NET-focused | Largest of any option in this comparison |
+| Licensing | Commercial for full feature set | Open-source core, licensing has shifted over time |
+
+NCache's advantage is depth of integration specifically within the .NET and Microsoft ecosystem; Redis's advantage is breadth - more tooling, more community knowledge, and applicability beyond .NET if your organization is polyglot.
+
+## Frequently Asked Questions
+
+### Do I need to create a cache before connecting to it, unlike Redis?
+
+Yes - NCache caches are named, explicitly provisioned entities configured through NCache's management tools before your application connects to them. This is different from Redis, where you connect to a server and start using keys immediately without a separate provisioning step.
+
+### Does NCache require manual object serialization like raw IDistributedCache does with Redis?
+
+No - NCache's client caches native .NET objects directly, handling serialization internally. This is one of its concrete .NET-native conveniences compared to working with raw `IDistributedCache`, where you'd typically serialize to JSON yourself, unless you're using `HybridCache`, which handles this for you regardless of backend.
+
+### Is NCache free to use?
+
+NCache offers an Open Source edition suitable for evaluation and smaller deployments, with an Enterprise edition unlocking the full feature set - advanced replication topologies, write-behind caching, and other enterprise capabilities. Confirm which edition covers the specific features your design depends on before committing.
+
+### How does NCache's session state provider compare to using Redis for sessions?
+
+NCache's session provider is purpose-built with replication awareness specific to NCache's cache topology, generally requiring less manual configuration than assembling equivalent behavior around Redis's `IDistributedCache`-based session provider. Both are viable in production; NCache's is more turnkey specifically because it's built for exactly this use case.
+
+### What's write-behind caching, and when should I use it?
+
+Write-behind caching lets NCache batch and asynchronously flush writes to your actual database rather than requiring every cache write to synchronously also write through to the database. It improves write throughput at the cost of eventual, not immediate, database consistency - appropriate for write-heavy workloads that can tolerate a short window where the cache is ahead of the database, not appropriate where every write needs to be immediately durable.
+
+### Can I use NCache and Redis together, or should I pick one?
+
+Technically you could run both for different purposes, but that's unusual and adds operational complexity without a clear benefit for most teams - pick one as your primary distributed cache based on whether native .NET integration (NCache) or ecosystem breadth (Redis) matters more for your situation, rather than running both.
+
+### What's the most common mistake in a first NCache setup?
+
+Treating it like a drop-in Redis replacement and missing its purpose-built ASP.NET Core session and EF Core integrations - which is where NCache's .NET-native design actually pays off. The second common mistake is not confirming upfront which features require Enterprise licensing, leading to a design that assumes capabilities the deployed edition doesn't actually include.


### PR DESCRIPTION
## Summary

- Schedules and drafts the .NET Caching Solutions Tuesday track: a comparison anchor post plus five getting-started guides, running weekly Tuesdays 2027-08-03 through 2027-09-07, picking up the cadence directly after the .NET Mapping Libraries track
- Moves the series from `editorial-plan.md`'s Backlog into a dated `## 📅 Tuesday Track - .NET Caching Solutions (August-September 2027)` section, all entries `Status: draft` with `File:` paths, and updates the Backlog intro count from nine to eight remaining series

### Posts added

- **Anchor:** The Top 5 Caching Solutions for .NET Compared: Which One Should You Choose? (2027-08-03) - IMemoryCache, Redis, NCache, Memcached, and Garnet compared, framing the real first fork as in-process vs. distributed rather than "just use Redis"
- Getting Started with IMemoryCache in .NET (2027-08-10)
- Getting Started with Redis in .NET (2027-08-17)
- Getting Started with Garnet in .NET (2027-08-24)
- Getting Started with Memcached in .NET (2027-08-31)
- Getting Started with NCache in .NET (2027-09-07)

Each setup guide cross-links back to the anchor post, mirroring the structure of the prior .NET ORMs/API Styles/Validation Approaches/Mapping Libraries/Testing/Logging/Architecture tracks.

## Test plan

- [x] `npm run deploy` builds cleanly, all 6 posts render
- [x] `node scripts/a11y-check.js` (axe-core + Playwright) - zero violations across home/post/about/privacy/terms/404 in light and dark mode
- [x] Verified all 5 setup-guide cross-links resolve to the anchor post's output URL


---
_Generated by [Claude Code](https://claude.ai/code/session_01WKyNF7L5qzrfct8cec6A32)_