### PR TITLE
Add .NET Message Brokers Tuesday track (6 posts)

### DIFF
--- a/editorial-plan.md
+++ b/editorial-plan.md
@@ -1058,17 +1058,69 @@ Six posts on how a .NET service caches data, picking up the Tuesday cadence dire
 
 ---
 
-## 📅 Backlog - Unscheduled Series
+## 📅 Tuesday Track - .NET Message Brokers (September-October 2027)
 
-Eight six-post series remain unscheduled, drawn from the drafts in `docs/article-ideas/`. They continue the Tuesday cadence once the .NET Caching Solutions series ends on 2027-09-07, and they're listed here in priority order. They're deliberately undated - that horizon is too far out to put honest dates against - so each series gets one entry rather than six speculative ones, and entries are expanded into individual dated posts when a series moves onto the calendar.
+Six posts on how a .NET service moves messages between other services, picking up the Tuesday cadence directly from the Caching Solutions track. A comparison post anchors the track and each of the five follow-ups is a complete setup for one broker.
 
-### .NET Message Brokers (6 posts)
-- **Status:** `idea`
-- **Source:** `docs/article-ideas/top-5-dotnet-message-brokers-compared.md` + 5 getting-started drafts
-- **Series:** Top 5 comparison, then RabbitMQ, Kafka, Azure Service Bus, Amazon SQS, NATS
+### The Top 5 Message Brokers for .NET Compared: Which One Should You Choose?
+- **Status:** `draft`
+- **Scheduled:** 2027-09-14
+- **Source:** `docs/article-ideas/top-5-dotnet-message-brokers-compared.md`
+- **File:** `src/posts/2027-09-14-top-5-dotnet-message-brokers-compared.md`
 - **Pitch:** Broker comparisons get framed as "which one is fastest" when the actual differentiator is shape - routing discrete messages between services, streaming an ordered replayable log, or just decoupling two parts of a system without standing up new infrastructure.
 - **Angle:** Compares the five on model, message replay, hosting, and .NET client experience, then argues that picking on throughput benchmarks alone reliably produces the wrong answer. Makes a practical point most comparisons skip entirely: .NET teams rarely talk to these brokers directly, so the abstraction sitting in between - MassTransit, NServiceBus, or Rebus - often matters as much as the broker choice itself. The managed options (Service Bus, SQS) are evaluated on cloud coupling rather than feature count.
 - **Tags:** `dotnet`, `messaging`, `architecture`, `microservices`, `devops`
+
+### Getting Started with RabbitMQ in .NET
+- **Status:** `draft`
+- **Scheduled:** 2027-09-21
+- **Source:** `docs/article-ideas/getting-started-with-rabbitmq.md`
+- **File:** `src/posts/2027-09-21-getting-started-with-rabbitmq.md`
+- **Pitch:** Working directly against RabbitMQ's raw AMQP client in .NET means hand-managing connections, channels, serialization, retry, and error queues yourself - all boilerplate the overwhelming majority of real .NET RabbitMQ integrations avoid by going through MassTransit instead.
+- **Angle:** Covers MassTransit's `IConsumer<T>` and `ConfigureEndpoints` auto-topology as the default rather than a nice-to-have, `Publish` vs. `Send` as a coupling decision rather than an API preference, and tuning `PrefetchCount`/`ConcurrentMessageLimit` per consumer workload. Frames MassTransit as the practical argument for RabbitMQ over a raw-client comparison, since it's also what makes switching brokers later a configuration change.
+- **Tags:** `dotnet`, `messaging`, `architecture`, `developer-productivity`
+
+### Getting Started with Kafka in .NET
+- **Status:** `draft`
+- **Scheduled:** 2027-09-28
+- **Source:** `docs/article-ideas/getting-started-with-kafka.md`
+- **File:** `src/posts/2027-09-28-getting-started-with-kafka.md`
+- **Pitch:** Kafka's .NET story is deliberately more hands-on than RabbitMQ's - Confluent.Kafka is a thinner wrapper around partitions, consumer groups, and offsets than MassTransit gives you over RabbitMQ, because Kafka is a fundamentally different thing than a traditional broker.
+- **Angle:** Covers `Acks.All` plus `EnableIdempotence` as the default worth defaulting to, partition-key selection as the actual lever for ordering and parallelism, and manual offset commits after successful processing rather than risky auto-commit. Treats Kafka's log-based retention (independent of consumption) as the core conceptual shift from every queue-based broker in the series, and is explicit about when Kafka is overkill for a workload that's really just a queue.
+- **Tags:** `dotnet`, `messaging`, `architecture`, `performance`, `microservices`
+
+### Getting Started with Azure Service Bus in .NET
+- **Status:** `draft`
+- **Scheduled:** 2027-10-05
+- **Source:** `docs/article-ideas/getting-started-with-azure-service-bus.md`
+- **File:** `src/posts/2027-10-05-getting-started-with-azure-service-bus.md`
+- **Pitch:** Azure Service Bus's reputation as the best .NET developer experience among message brokers isn't marketing - the `Azure.Messaging.ServiceBus` SDK feels designed by people who write ASP.NET Core applications, not adapted from a cross-language client.
+- **Angle:** Covers queues (point-to-point) versus topics/subscriptions (pub/sub) as a deliberate architectural choice, `MessageId`-based duplicate detection as low-effort idempotency protection, and explicit message completion instead of relying on `AutoCompleteMessages`. Draws the abandon-vs-dead-letter distinction clearly, and flags real Azure lock-in and usage-based cost scaling as the honest trade-offs against the smoothest SDK in the comparison.
+- **Tags:** `dotnet`, `messaging`, `cloud`, `architecture`, `devops`
+
+### Getting Started with Amazon SQS in .NET
+- **Status:** `draft`
+- **Scheduled:** 2027-10-12
+- **Source:** `docs/article-ideas/getting-started-with-amazon-sqs.md`
+- **File:** `src/posts/2027-10-12-getting-started-with-amazon-sqs.md`
+- **Pitch:** SQS's simplicity is genuinely refreshing after RabbitMQ's exchange model or Kafka's partition mechanics - a queue, messages go in, messages come out, AWS handles the rest - but it still asks for a few binary decisions made explicitly rather than by default.
+- **Angle:** Covers standard versus FIFO queues, long polling as the default with essentially no downside, and deletion (not "acknowledgment") as SQS's genuinely different completion model governed by visibility timeout. Positions FIFO's `MessageGroupId` as the SQS analog to a Kafka partition key, and is direct that pairing with SNS is what fills the pub/sub gap SQS alone doesn't cover.
+- **Tags:** `dotnet`, `messaging`, `cloud`, `architecture`, `devops`
+
+### Getting Started with NATS in .NET
+- **Status:** `draft`
+- **Scheduled:** 2027-10-19
+- **Source:** `docs/article-ideas/getting-started-with-nats.md`
+- **File:** `src/posts/2027-10-19-getting-started-with-nats.md`
+- **Pitch:** NATS's core pitch is that most messaging doesn't need to be as heavy as it usually is - subject-based pub/sub, a tiny operational footprint, and genuinely low latency, without RabbitMQ's exchange configuration or Kafka's partition mechanics.
+- **Angle:** Covers core NATS's fire-and-forget model (and the real, deliberate trade-off that a message is simply gone if nobody's subscribed) against JetStream's durability and explicit acknowledgment once persistence actually matters. Treats subject hierarchies and wildcards as NATS's answer to RabbitMQ's topic routing, and is upfront that the smaller .NET ecosystem is a real factor to weigh, not just a footnote.
+- **Tags:** `dotnet`, `messaging`, `architecture`, `performance`, `microservices`
+
+---
+
+## 📅 Backlog - Unscheduled Series
+
+Seven six-post series remain unscheduled, drawn from the drafts in `docs/article-ideas/`. They continue the Tuesday cadence once the .NET Message Brokers series ends on 2027-10-19, and they're listed here in priority order. They're deliberately undated - that horizon is too far out to put honest dates against - so each series gets one entry rather than six speculative ones, and entries are expanded into individual dated posts when a series moves onto the calendar.
 
 ### .NET Background Job Libraries (6 posts)
 - **Status:** `idea`

--- a/src/posts/2027-09-14-top-5-dotnet-message-brokers-compared.md
+++ b/src/posts/2027-09-14-top-5-dotnet-message-brokers-compared.md
@@ -1,0 +1,167 @@
+---
+author: Steve Kaschimer
+date: 2027-09-14
+image: /images/posts/2027-09-14-hero.webp
+image_alt: "Five columns of abstract message-broker glyphs positioned along a horizontal axis running from flexible discrete routing on the left to a replayable ordered log on the right."
+image_prompt: "A dark-mode technical editorial illustration on a near-black background with electric teal, amber, and off-white accents. Composition is five vertical columns of equal width separated by thin hairline rules, each column topped by a distinct abstract glyph rendered in flat geometry: a branching exchange-routing glyph with several thin arrows fanning to different destinations, a partitioned append-only log shown as a row of small sequential rectangles with a small circular replay arrow above it, a cloud-bounded topic/subscription glyph with two identical output lines, a minimal single-lane queue glyph with a clean start and end, and a lightweight subject-hierarchy glyph shown as a dot branching into three thin dotted-line paths. Beneath the glyphs, a shared horizontal axis labeled in monospaced type runs from 'flexible routing' on the left to 'replayable log' on the right, with a small glowing teal dot positioned at a different point under each column. Mood is comparative, engineering-first, and non-partisan. Avoid: vendor logos, brand colors, circuit-board textures, gears, or generic arrow clip art used as the dominant motif."
+layout: post.njk
+site_title: Tech Notes
+summary: "Message broker decisions in .NET tend to get framed as 'which one is fastest,' when the actual differentiator is shape - routing discrete messages, streaming a replayable log, or decoupling two parts of a system. A practical breakdown of five brokers and the abstraction layer that often matters more than the choice itself."
+tags: ["dotnet", "messaging", "architecture", "microservices", "devops"]
+title: "The Top 5 Message Brokers for .NET Compared: Which One Should You Choose?"
+---
+
+Message broker decisions in .NET tend to get framed as "which one is fastest," when the actual differentiator is almost always shape: are you routing discrete messages between services, streaming an ordered, replayable log of events, or just trying to decouple two parts of a system without standing up new infrastructure. RabbitMQ, Kafka, Azure Service Bus, Amazon SQS, and NATS all move messages from one place to another, but they were built to solve meaningfully different problems, and picking based on throughput benchmarks alone tends to produce the wrong answer.
+
+This guide compares the five message brokers .NET developers reach for most often, what each one actually optimizes for, and which system shape fits best. One practical note before diving in: most .NET teams don't talk to these brokers directly - an abstraction library like MassTransit, NServiceBus, or Rebus typically sits in between, giving you a consistent programming model regardless of which broker is underneath. That's worth knowing before you evaluate raw client libraries, since the abstraction layer often matters as much as the broker choice itself. This series continues with dedicated getting-started walkthroughs for each broker.
+
+## Quick Comparison
+
+| | RabbitMQ | Kafka | Azure Service Bus | Amazon SQS | NATS |
+| --- | --- | --- | --- | --- | --- |
+| **Category** | General-purpose message broker | Distributed event streaming log | Managed cloud message broker | Managed cloud queue | Lightweight cloud-native messaging |
+| **Model** | Queues, exchanges, flexible routing | Partitioned, append-only, replayable log | Queues and topics/subscriptions | Queues (standard and FIFO) | Subject-based pub/sub, queues via JetStream |
+| **Message replay** | No (messages consumed and removed) | Yes - core feature | No | No | Yes, via JetStream |
+| **Hosting** | Self-hosted or managed (CloudAMQP, etc.) | Self-hosted or managed (Confluent, MSK) | Fully managed, Azure only | Fully managed, AWS only | Self-hosted or managed |
+| **.NET developer experience** | Strong, especially via MassTransit | Capable but more low-level (Confluent.Kafka) | Excellent - idiomatic, async-first SDK | Good, straightforward SDK | Good, lightweight client |
+| **Best for** | Complex routing, request-reply, general EDA | High-volume event streaming, replay, analytics | Azure-native enterprise apps wanting managed simplicity | AWS-native apps wanting cheap, zero-ops queueing | Low-latency, lightweight cloud-native microservices |
+
+## RabbitMQ
+
+RabbitMQ is the most widely used open-source message broker in the world, and in recent evaluations it consistently ranks at or near the top for general-purpose messaging specifically because of its routing flexibility - exchanges (direct, topic, fanout, headers) let you express complex delivery rules without extra infrastructure.
+
+**Strengths:**
+
+- Exceptional routing flexibility via its exchange model, supporting patterns from simple point-to-point queues to sophisticated topic-based fan-out, without needing separate infrastructure for each
+- Excellent request-reply support, which matters for orchestration-heavy architectures that need synchronous-feeling communication over an async transport
+- Mature dead-letter queue support with configurable retry policies and message TTL, handled natively rather than bolted on
+- RabbitMQ 4.x's quorum queue and stream throughput improvements have narrowed the performance gap with Kafka for many internal microservice workloads that previously considered migrating purely for throughput reasons
+
+**Weaknesses:**
+
+- No message replay in the way Kafka offers - once a message is consumed and acknowledged, it's gone, which matters if your architecture relies on reprocessing historical events
+- Self-hosting requires real operational investment (clustering, monitoring, upgrades) unless you use a managed offering, which adds cost and vendor dependency back in
+- Throughput at extreme scale still generally favors Kafka for pure high-volume event streaming, even with RabbitMQ 4.x's improvements
+
+**Choose this when:** you need flexible routing, request-reply patterns, and general-purpose event-driven communication between services, and you don't have a specific need for long-term event replay or extreme streaming throughput.
+
+## Kafka
+
+Kafka is fundamentally a distributed, append-only log rather than a traditional queue - messages aren't removed on consumption, they're retained (for a configurable period or indefinitely) and can be replayed by any consumer at any offset. This makes it the right tool for a different class of problem than RabbitMQ solves.
+
+**Strengths:**
+
+- Message replay and long-term retention are core, first-class features - consumers can reprocess history, and new consumers can be added later and read from the beginning without any special accommodation
+- Built for high-throughput, partitioned scalability, remaining the reference choice for genuinely high-volume event streaming and real-time analytics pipelines
+- Strong ecosystem for stream processing (Kafka Streams, ksqlDB) if your architecture needs to transform data in flight, not just move it
+
+**Weaknesses:**
+
+- The .NET client experience (Confluent.Kafka) is capable but meaningfully more low-level than Azure Service Bus's SDK or RabbitMQ-via-MassTransit - more configuration and error-handling awareness required
+- Operational complexity is real, whether self-hosted or via a managed offering (Confluent Cloud, Amazon MSK) - partitioning, consumer group rebalancing, and retention policy all need deliberate design
+- Overkill for simple point-to-point or request-reply messaging needs, where its log-based model adds complexity without a corresponding benefit
+
+**Choose this when:** your workload is genuinely log-based - event sourcing, high-volume event streaming, analytics pipelines, or any scenario where replayability and long-term retention are core requirements, not just a queue that happens to move messages.
+
+## Azure Service Bus
+
+Azure Service Bus is Microsoft's managed message broker, and it's widely regarded as having the best .NET developer experience of any option here - unsurprising, given it's built by the same organization as the .NET SDKs it integrates with, with an idiomatic, async-first client that plugs cleanly into dependency injection.
+
+**Strengths:**
+
+- Arguably the best .NET developer experience in this comparison - the `Azure.Messaging.ServiceBus` SDK feels native to .NET rather than adapted to it
+- Fully managed - no cluster to operate, patch, or scale yourself, which is a real operational simplification for teams already on Azure
+- Built-in dead-letter queues, transactions, and topics/subscriptions for pub/sub scenarios, all without additional infrastructure to stand up
+- Strong security and enterprise integration story, fitting naturally into an existing Azure-centric architecture
+
+**Weaknesses:**
+
+- Real Azure lock-in - migrating away later is a genuine project, not a configuration change, the same trade-off that applies to any fully managed cloud-specific service
+- Costs scale with usage in a way that can become expensive at very high volume compared to self-hosted RabbitMQ or Kafka
+- No message replay in the Kafka sense - it's a queue/topic model, not a log, so it doesn't fit event-sourcing-style architectures needing historical reprocessing
+
+**Choose this when:** you're building on Azure and want a managed broker with minimal operational overhead and the best possible .NET developer ergonomics, without a specific need for Kafka-style replay or RabbitMQ-level routing customization.
+
+## Amazon SQS
+
+Amazon SQS is AWS's fully managed queue service - simpler in model than Service Bus or RabbitMQ, cheap, and effectively zero-operations, which is exactly why it's the default choice for AWS-native .NET teams that don't need sophisticated routing.
+
+**Strengths:**
+
+- Genuinely zero operational overhead - no cluster, no patching, no capacity planning beyond what AWS handles automatically
+- Very cost-effective, particularly for standard (non-FIFO) queues at scale, making it attractive for high-volume, simple queueing needs
+- FIFO queues are available when strict ordering and exactly-once processing semantics matter, at some throughput cost compared to standard queues
+- Straightforward .NET SDK, and a natural fit if the rest of your infrastructure (Lambda, other AWS services) is already on AWS
+
+**Weaknesses:**
+
+- Simpler messaging model than RabbitMQ or Service Bus - no built-in topic/subscription pub-sub the way Service Bus offers (SNS is typically paired with SQS for that), and no routing flexibility comparable to RabbitMQ's exchanges
+- Real AWS lock-in, the same category of trade-off Azure Service Bus carries for Azure
+- Standard queues are only eventually consistent in delivery ordering - if strict ordering matters, you need FIFO queues specifically, with their own throughput trade-offs
+
+**Choose this when:** you're building on AWS and want the cheapest, lowest-operational-overhead queueing option, and your messaging needs are more straightforward point-to-point than complex routing or event streaming.
+
+## NATS
+
+NATS is the lightweight option in this comparison - a simple, fast, subject-based publish-subscribe system originally designed for low-latency cloud-native communication, with JetStream added on top for persistence and replay when you need it.
+
+**Strengths:**
+
+- Genuinely lightweight and fast - low latency and a simple operational footprint make it attractive for real-time microservice communication where heavier brokers feel like overkill
+- Subject-based pub/sub is simple to reason about and a natural fit for cloud-native, Kubernetes-heavy environments
+- JetStream adds persistence, replay, and at-least-once delivery guarantees on top of NATS's core messaging when you need durability beyond fire-and-forget pub/sub
+- Simple to self-host, with a much lighter operational footprint than running a Kafka cluster
+
+**Weaknesses:**
+
+- Smaller ecosystem and community than RabbitMQ or Kafka specifically within the .NET world, meaning fewer examples, less abstraction-library support, and fewer people already familiar with it
+- Without JetStream, core NATS is fire-and-forget with no persistence - appropriate for some use cases, a real gap for others that assumed durability by default
+- Less commonly the default choice discussed in .NET messaging comparisons relative to the other four, which affects both hiring and available guidance
+
+**Choose this when:** you want lightweight, low-latency messaging for cloud-native microservices and don't need RabbitMQ's routing sophistication or Kafka's log-based replay as a primary requirement - particularly appealing in Kubernetes-heavy environments already comfortable with lightweight, cloud-native tooling.
+
+## How to Decide
+
+A few heuristics that cover most real-world decisions:
+
+**Need complex routing, request-reply patterns, and general-purpose event-driven communication?** RabbitMQ (typically via MassTransit in .NET) remains the strongest general-purpose choice, and 4.x's throughput improvements have closed much of the gap that used to push people toward Kafka by default.
+
+**Workload is genuinely log-based - event sourcing, streaming analytics, or needs replay?** Kafka is built for exactly this; don't reach for it if you just need a queue, since its operational complexity isn't worth paying for a use case that doesn't need replay.
+
+**Building on Azure and want the best .NET developer experience with minimal ops?** Azure Service Bus is hard to beat specifically for teams already in the Azure ecosystem.
+
+**Building on AWS and want the cheapest, simplest, zero-ops queueing?** Amazon SQS is the default answer, with FIFO queues available if strict ordering matters.
+
+**Want lightweight, low-latency messaging without heavier infrastructure, especially in Kubernetes?** NATS (with JetStream if you need persistence) fits cloud-native architectures that don't need RabbitMQ's or Kafka's full feature set.
+
+A meaningful chunk of real .NET systems don't pick a broker in isolation - they pick MassTransit, NServiceBus, or Rebus as the programming model first, which then supports multiple broker backends (RabbitMQ, Azure Service Bus, Amazon SQS, and others) interchangeably. That decouples "how do I write message-driven code" from "which broker are we running," which is worth considering if you're not yet locked into a specific cloud platform.
+
+## Frequently Asked Questions
+
+### Should I choose a broker directly, or use an abstraction library like MassTransit?
+
+For most application-level messaging (not high-throughput event streaming), an abstraction library is usually the better starting point - MassTransit, NServiceBus, or Rebus give you a consistent programming model and let you swap the underlying broker (RabbitMQ, Azure Service Bus, Amazon SQS) with configuration changes rather than a rewrite. Kafka is somewhat of an exception, since its log-based model doesn't map as cleanly onto these general-purpose abstraction layers.
+
+### What's the fundamental difference between RabbitMQ and Kafka?
+
+RabbitMQ is a traditional message broker - messages are routed to queues and removed once consumed. Kafka is a distributed, append-only log - messages are retained for a configurable period (or indefinitely) and can be replayed by any consumer at any point. This isn't a matter of one being "better" - they're built for different problems: RabbitMQ for flexible routing and general messaging, Kafka for high-volume event streaming and replay.
+
+### Is Azure Service Bus or Amazon SQS the better choice if I'm not tied to a specific cloud yet?
+
+Neither is inherently better - the decision should follow your broader cloud platform choice, since both carry real lock-in and are priced and integrated around their respective ecosystems. If you're genuinely undecided on cloud platform, a self-hosted or cloud-agnostic option (RabbitMQ, NATS, or Kafka via a managed service like Confluent Cloud) avoids coupling your messaging infrastructure to that decision.
+
+### Does RabbitMQ 4.x change the calculus against Kafka for throughput-sensitive workloads?
+
+Somewhat - RabbitMQ 4.x's quorum queue and native stream improvements have narrowed the performance gap for many internal microservice workloads that previously might have considered migrating to Kafka purely for throughput. If replay and long-term log retention aren't actual requirements, this reduces the case for taking on Kafka's added operational complexity just for raw speed.
+
+### Which broker has the best .NET developer experience?
+
+Azure Service Bus is widely regarded as the strongest, since its SDK is built idiomatically for .NET with async-first APIs and clean dependency injection integration. RabbitMQ via MassTransit is a close second, since MassTransit's abstractions significantly reduce the boilerplate you'd otherwise write against RabbitMQ's raw client directly.
+
+### Can I switch message brokers later without a full rewrite?
+
+If you're using an abstraction library like MassTransit, switching between RabbitMQ, Azure Service Bus, and Amazon SQS is largely a configuration change, since your message and handler code targets the abstraction, not the broker directly. Kafka is the exception - its log-based model and replay semantics are different enough that migrating to or from Kafka usually involves more than a configuration swap, regardless of abstraction layer.
+
+### Is NATS mature enough for production use in a .NET application?
+
+Yes, it's used in production, particularly in Kubernetes-heavy, cloud-native environments, though with a smaller .NET-specific community and ecosystem than RabbitMQ or Kafka. Evaluate it seriously for lightweight, low-latency messaging needs, but weigh the smaller community and less abstraction-library support against your team's risk tolerance and support needs.

--- a/src/posts/2027-09-21-getting-started-with-rabbitmq.md
+++ b/src/posts/2027-09-21-getting-started-with-rabbitmq.md
@@ -1,0 +1,207 @@
+---
+author: Steve Kaschimer
+date: 2027-09-21
+image: /images/posts/2027-09-21-hero.webp
+image_alt: "A branching exchange-routing glyph with several thin arrows fanning out to different destination queues, each terminating in a small automatically-generated endpoint marker."
+image_prompt: "A dark-mode technical editorial illustration on a near-black background with electric teal, amber, and off-white accents. Composition centers on a small solid diamond-shaped exchange glyph on the left, with several thin teal arrows branching outward to distinct rectangular endpoint shapes on the right, each endpoint marked with a tiny automatic-generation dot implying it was created without manual configuration. A faint retry-loop icon sits beneath one endpoint. Mood is flexible, mature, and well-abstracted. Avoid: vendor logos, brand colors, circuit-board textures, gears, or generic arrow clip art as the dominant motif."
+layout: post.njk
+site_title: Tech Notes
+summary: "Working directly against RabbitMQ's raw AMQP client in .NET means hand-managing connections, serialization, retry, and error queues yourself - boilerplate the overwhelming majority of real integrations avoid via MassTransit. A setup guide for consumers, publishers, and configuring retry and dead-lettering without hand-rolling it."
+tags: ["dotnet", "messaging", "architecture", "developer-productivity"]
+title: "Getting Started with RabbitMQ in .NET"
+---
+
+Working directly against RabbitMQ's raw AMQP client in .NET means hand-managing connections, channels, serialization, retry policy, and error queues yourself - all solvable, all boilerplate you'd rather not maintain per project. This is why the overwhelming majority of real .NET RabbitMQ integrations go through MassTransit rather than the raw client: it gives you strongly-typed messages and consumers instead of AMQP primitives, and it's the setup this guide focuses on, since it's genuinely how most teams should approach RabbitMQ in .NET.
+
+This guide covers installing RabbitMQ and MassTransit, bootstrapping publishers and consumers with sensible endpoint configuration, the core publish/consume/request-reply workflow, and the best practices that keep a RabbitMQ-backed system resilient rather than fragile. By the end you'll have a working pub/sub setup with retry and dead-lettering handled for you, not hand-rolled.
+
+If you're deciding between message brokers first, [a comparison of the top .NET message brokers](/posts/2027-09-14-top-5-dotnet-message-brokers-compared/) covers where RabbitMQ fits relative to Kafka, Azure Service Bus, Amazon SQS, and NATS.
+
+## What You'll Need
+
+- .NET 8 SDK or later
+- Docker, for running RabbitMQ locally
+
+```bash
+docker run -d --name rabbitmq -p 5672:5672 -p 15672:15672 rabbitmq:3-management
+```
+
+The management plugin (included in the `-management` image tag) gives you a web UI at `http://localhost:15672` (default credentials `guest`/`guest`) for inspecting queues, exchanges, and message flow - genuinely useful during setup and debugging.
+
+## Installing MassTransit and RabbitMQ Support
+
+```bash
+dotnet add package MassTransit
+dotnet add package MassTransit.RabbitMQ
+```
+
+## Bootstrapping the Ideal Environment
+
+### Define a message contract
+
+```csharp
+public record OrderSubmitted(int OrderId, int CustomerId, decimal Total);
+```
+
+Plain records work well as message contracts - MassTransit serializes and routes based on the message type, so keeping contracts as simple, immutable data shapes, not entities, not classes with behavior, is worth doing from the start.
+
+### Register MassTransit with RabbitMQ
+
+```csharp
+var builder = WebApplication.CreateBuilder(args);
+
+builder.Services.AddMassTransit(x =>
+{
+    x.AddConsumer<OrderSubmittedConsumer>();
+
+    x.UsingRabbitMq((context, cfg) =>
+    {
+        cfg.Host(builder.Configuration.GetConnectionString("RabbitMq"), h =>
+        {
+            h.Username(builder.Configuration["RabbitMq:Username"]!);
+            h.Password(builder.Configuration["RabbitMq:Password"]!);
+        });
+
+        cfg.ConfigureEndpoints(context);
+    });
+});
+
+var app = builder.Build();
+app.Run();
+```
+
+`cfg.ConfigureEndpoints(context)` is what automatically creates a receive endpoint per registered consumer, using MassTransit's default naming convention - you don't need to manually declare queues and bindings the way you would against the raw RabbitMQ client.
+
+### Define a consumer
+
+```csharp
+public class OrderSubmittedConsumer(IOrderService orderService) : IConsumer<OrderSubmitted>
+{
+    public async Task Consume(ConsumeContext<OrderSubmitted> context)
+    {
+        await orderService.ProcessAsync(context.Message.OrderId);
+    }
+}
+```
+
+Consumers implement `IConsumer<T>`, resolved through DI the same as any other service - constructor injection works normally.
+
+### Publishing and sending
+
+```csharp
+public class OrderController(IPublishEndpoint publishEndpoint) : ControllerBase
+{
+    [HttpPost]
+    public async Task<IActionResult> SubmitOrder(SubmitOrderRequest request)
+    {
+        var order = await CreateOrderAsync(request);
+
+        await publishEndpoint.Publish(new OrderSubmitted(order.Id, order.CustomerId, order.Total));
+
+        return Accepted();
+    }
+}
+```
+
+`IPublishEndpoint.Publish` broadcasts to every consumer subscribed to that message type - the pub/sub pattern. For point-to-point delivery to a specific queue, `ISendEndpointProvider.Send` targets a named destination directly instead.
+
+### Configure retry and endpoint-specific settings
+
+```csharp
+x.AddConsumer<OrderSubmittedConsumer>(configure =>
+{
+    configure.UseMessageRetry(r => r.Interval(3, TimeSpan.FromSeconds(5)));
+});
+
+x.UsingRabbitMq((context, cfg) =>
+{
+    cfg.Host("localhost", "/", h => { /* ... */ });
+
+    cfg.ReceiveEndpoint("order-processing", e =>
+    {
+        e.PrefetchCount = 16;
+        e.ConcurrentMessageLimit = 8;
+        e.ConfigureConsumer<OrderSubmittedConsumer>(context);
+    });
+});
+```
+
+`PrefetchCount` and `ConcurrentMessageLimit` control how many messages a consumer pulls and processes concurrently - worth tuning deliberately rather than leaving at defaults, especially for consumers doing meaningfully expensive work per message.
+
+## Core Workflow
+
+- **Use `Publish` for pub/sub (broadcast to any interested consumer), `Send` for point-to-point (a specific destination).** Choosing the right one is a design decision, not just an API preference - it determines your system's coupling.
+- **Let MassTransit's default retry and dead-letter behavior handle transient failures**, tuning `UseMessageRetry` per consumer where the default doesn't fit.
+- **Use request-response for genuinely synchronous-feeling interactions over an async transport**, where a caller needs a specific reply rather than fire-and-forget.
+
+```csharp
+public class TransferDataRequestConsumer : IConsumer<TransferData>
+{
+    public async Task Consume(ConsumeContext<TransferData> context)
+    {
+        var balance = await GetCurrentBalanceAsync(context.Message.AccountId);
+        await context.RespondAsync(new CurrentBalance(balance));
+    }
+}
+```
+
+## Verifying Your Setup
+
+1. **Queues and exchanges appear as expected** - check the RabbitMQ management UI and confirm MassTransit created the expected topology for your registered consumers
+2. **Messages route correctly** - publish a test message and confirm only consumers subscribed to that message type receive it
+3. **Retry and dead-lettering work** - deliberately throw an exception in a consumer and confirm the configured retry policy runs, then that the message ends up in a dead-letter/error queue after retries are exhausted
+4. **Concurrency settings match your workload** - confirm `PrefetchCount` and `ConcurrentMessageLimit` are tuned appropriately for how expensive your consumer's work actually is
+
+## Best Practices
+
+**Use MassTransit rather than the raw RabbitMQ client for application-level messaging.** The boilerplate it eliminates (serialization, retry, dead-lettering, connection management) isn't worth reimplementing yourself for typical use cases.
+
+**Design message contracts as immutable, versioned data shapes.** Treat them like a public API contract - adding fields is generally safe; removing or renaming them can break consumers still expecting the old shape.
+
+**Tune `PrefetchCount` and `ConcurrentMessageLimit` deliberately per consumer**, based on how expensive that consumer's actual work is - a high prefetch count on a slow consumer just means a large backlog of in-flight, unprocessed messages.
+
+**Configure message retry per consumer, not globally by default.** Different consumers have different failure characteristics - a transient network call might warrant several quick retries, while a deterministic business rule failure won't be fixed by retrying at all.
+
+**Use the RabbitMQ management UI during development, but plan real production observability separately.** It's genuinely useful for debugging locally; production needs proper logging, metrics, and alerting around consumer health and dead-letter queue growth.
+
+## Comparison with Azure Service Bus
+
+| | RabbitMQ (via MassTransit) | Azure Service Bus |
+| --- | --- | --- |
+| Hosting | Self-hosted or managed | Fully managed, Azure only |
+| Routing | Flexible exchange-based routing | Topics/subscriptions |
+| .NET abstraction | MassTransit (recommended) | Native SDK, also supported by MassTransit |
+| Operational overhead | Real, unless using a managed offering | Minimal - fully managed |
+| Best fit | Complex routing, self-hosted control, general EDA | Azure-native teams wanting managed simplicity |
+
+Both are well-supported MassTransit transports, which is one of the more practical reasons to adopt MassTransit in the first place - your message and consumer code stays largely the same if you switch from RabbitMQ to Azure Service Bus later, since the transport is a configuration detail rather than baked into your application code.
+
+## Frequently Asked Questions
+
+### Should I use MassTransit or RabbitMQ's raw .NET client directly?
+
+MassTransit, for the large majority of application-level messaging scenarios. The raw client requires you to hand-manage connections, channels, serialization, retries, and dead-lettering yourself - all things MassTransit provides out of the box with a strongly-typed, DI-friendly API on top.
+
+### What's the difference between Publish and Send in MassTransit?
+
+`Publish` broadcasts a message to every consumer subscribed to that message type - the pub/sub pattern, appropriate when you don't know or care who's listening. `Send` delivers to a specific, named destination - point-to-point, appropriate when you're targeting a particular queue or service directly.
+
+### How does MassTransit handle retries and failed messages?
+
+`UseMessageRetry` configures a retry policy per consumer (immediate retries, exponential backoff, or a fixed interval), and after retries are exhausted, MassTransit moves the message to an error queue for RabbitMQ, following the transport's native dead-letter conventions. This is largely automatic once configured, rather than something you build yourself.
+
+### Do I need to manually declare RabbitMQ queues and exchanges?
+
+No, not when using MassTransit - `cfg.ConfigureEndpoints(context)` automatically creates the queue and exchange topology needed for your registered consumers, following MassTransit's naming conventions. You can override this if you need specific naming or topology, but it's not required for typical usage.
+
+### How do I do request-response messaging with RabbitMQ and MassTransit?
+
+Use `IRequestClient<T>` on the calling side and `context.RespondAsync(...)` in the consumer handling the request. This gives you a synchronous-feeling call-and-await pattern built on top of RabbitMQ's async transport, useful for orchestration-heavy scenarios where you genuinely need a reply, not just fire-and-forget.
+
+### Can I switch from RabbitMQ to another broker later without rewriting my messaging code?
+
+If you're using MassTransit, largely yes - your message contracts and consumer classes stay the same; only the transport configuration (`UsingRabbitMq` vs. `UsingAzureServiceBus` vs. `UsingAmazonSqs`) changes. This is one of the strongest practical arguments for adopting MassTransit rather than coding directly against a specific broker's client.
+
+### What's the most common mistake in a first RabbitMQ setup?
+
+Working directly against the raw RabbitMQ client instead of MassTransit, reimplementing retry logic, dead-lettering, and serialization that MassTransit already provides. The second common mistake is leaving `PrefetchCount` and `ConcurrentMessageLimit` at defaults without considering whether they actually match a given consumer's workload.

--- a/src/posts/2027-09-28-getting-started-with-kafka.md
+++ b/src/posts/2027-09-28-getting-started-with-kafka.md
@@ -1,0 +1,177 @@
+---
+author: Steve Kaschimer
+date: 2027-09-28
+image: /images/posts/2027-09-28-hero.webp
+image_alt: "A partitioned append-only log shown as a row of sequential rectangles with a small circular replay arrow above it, and a distinct key-colored marker pinning one entry to a specific partition."
+image_prompt: "A dark-mode technical editorial illustration on a near-black background with electric teal, amber, and off-white accents. Composition centers on a horizontal row of small sequential rectangles representing an append-only log, with a thin circular replay arrow curving above the row implying messages can be re-read from any point. One rectangle carries a small amber key-shaped marker, implying a partition key pinning it to a specific lane. Beneath, a faint second row runs parallel, implying a separate partition. Mood is structured, high-throughput, and deliberate. Avoid: vendor logos, brand colors, circuit-board textures, gears, or generic database-cylinder clip art."
+layout: post.njk
+site_title: Tech Notes
+summary: "Kafka's .NET story is deliberately more hands-on than RabbitMQ's - Confluent.Kafka is a thinner wrapper around partitions, consumer groups, and offsets, because Kafka is a fundamentally different thing than a traditional broker. A setup guide for producers, consumer groups, and manual offset commits."
+tags: ["dotnet", "messaging", "architecture", "performance", "microservices"]
+title: "Getting Started with Kafka in .NET"
+---
+
+Kafka's .NET story is deliberately more hands-on than RabbitMQ's - Confluent.Kafka is a capable, well-maintained client, but it's a thinner wrapper around Kafka's actual concepts (partitions, consumer groups, offsets, delivery semantics) than MassTransit gives you over RabbitMQ. That's not a gap in the tooling; it's a reflection of Kafka being a fundamentally different thing than a traditional message broker. Getting comfortable with partitions and consumer groups before writing much code will save you from a class of subtle bugs that only show up under real concurrent consumption.
+
+This guide covers installing the Kafka .NET client, bootstrapping producers and consumers with the configuration that actually matters, the core patterns for partitioning and consumer groups, and the best practices for using Kafka's log-based model correctly rather than treating it like a queue with extra steps. By the end you'll understand not just how to produce and consume messages, but why Kafka's guarantees work the way they do.
+
+If you're deciding between message brokers first, [a comparison of the top .NET message brokers](/posts/2027-09-14-top-5-dotnet-message-brokers-compared/) covers where Kafka fits relative to RabbitMQ, Azure Service Bus, Amazon SQS, and NATS.
+
+## What You'll Need
+
+- .NET 8 SDK or later
+- Docker, for running Kafka locally
+
+```bash
+docker run -d --name kafka -p 9092:9092 apache/kafka:latest
+```
+
+## Installing the Kafka Client
+
+```bash
+dotnet add package Confluent.Kafka
+```
+
+This is the official, actively maintained .NET client, built on `librdkafka` (a native C library) for performance - worth knowing since it means platform-specific native dependencies are involved, generally handled transparently by the NuGet package.
+
+## Bootstrapping the Ideal Environment
+
+### Producing messages
+
+```csharp
+public class OrderEventProducer : IDisposable
+{
+    private readonly IProducer<string, string> _producer;
+
+    public OrderEventProducer(IConfiguration config)
+    {
+        var producerConfig = new ProducerConfig
+        {
+            BootstrapServers = config["Kafka:BootstrapServers"],
+            Acks = Acks.All,          // wait for all in-sync replicas to acknowledge
+            EnableIdempotence = true  // prevents duplicate messages on retry
+        };
+        _producer = new ProducerBuilder<string, string>(producerConfig).Build();
+    }
+
+    public async Task PublishOrderSubmittedAsync(int orderId, OrderSubmitted evt)
+    {
+        var json = JsonSerializer.Serialize(evt);
+        await _producer.ProduceAsync("order-events", new Message<string, string>
+        {
+            Key = orderId.ToString(), // determines partition assignment
+            Value = json
+        });
+    }
+
+    public void Dispose() => _producer.Dispose();
+}
+```
+
+`Acks.All` combined with `EnableIdempotence = true` is the combination worth defaulting to for anything where message loss or duplication matters - it trades a small amount of latency for meaningfully stronger delivery guarantees. The `Key` matters more than it might look: Kafka uses it to determine which partition a message lands in, and messages with the same key are guaranteed to stay in order within that partition.
+
+### Consuming messages
+
+```csharp
+public class OrderEventConsumer(IConfiguration config, ILogger<OrderEventConsumer> logger) : BackgroundService
+{
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        var consumerConfig = new ConsumerConfig
+        {
+            BootstrapServers = config["Kafka:BootstrapServers"],
+            GroupId = "order-processing-service",
+            AutoOffsetReset = AutoOffsetReset.Earliest,
+            EnableAutoCommit = false // commit manually after successful processing
+        };
+
+        using var consumer = new ConsumerBuilder<string, string>(consumerConfig).Build();
+        consumer.Subscribe("order-events");
+
+        while (!stoppingToken.IsCancellationRequested)
+        {
+            var result = consumer.Consume(stoppingToken);
+            try
+            {
+                var evt = JsonSerializer.Deserialize<OrderSubmitted>(result.Message.Value);
+                await ProcessOrderEventAsync(evt!);
+                consumer.Commit(result); // only commit after successful processing
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(ex, "Failed to process message at offset {Offset}", result.Offset);
+                // Decide: retry, dead-letter, or skip -- Kafka won't decide this for you
+            }
+        }
+    }
+}
+```
+
+`EnableAutoCommit = false` paired with manual `Commit` after successful processing is the safer default - auto-commit can mark a message as processed before your handler actually finishes with it, which risks silently losing work if the process crashes mid-handling.
+
+## Core Workflow
+
+- **Choose partition keys deliberately.** Messages with the same key land in the same partition and preserve order relative to each other - this is your main lever for both ordering guarantees and parallelism, since consumers within a group each own a subset of partitions.
+- **Use consumer groups to scale horizontally.** Multiple consumer instances sharing a `GroupId` each get assigned a subset of the topic's partitions automatically - adding instances increases parallel consumption up to the partition count.
+- **Understand that Kafka doesn't remove messages on consumption.** Retention (time-based or size-based) determines how long messages stick around regardless of whether anyone's consumed them - this is fundamentally different from a queue, where consumption implies removal.
+
+## Verifying Your Setup
+
+1. **Messages produce and land in the expected partition** - confirm messages with the same key consistently land in the same partition
+2. **Consumer groups scale as expected** - run multiple consumer instances with the same `GroupId` and confirm partitions distribute across them, not all processed by one instance
+3. **Manual commit behavior is correct** - deliberately throw an exception mid-processing and confirm the offset isn't committed, so the message is redelivered on restart
+4. **Idempotent production is working** - confirm `EnableIdempotence` prevents duplicate messages even under retry conditions
+
+## Best Practices
+
+**Default to `Acks.All` and `EnableIdempotence = true` for anything where correctness matters.** The latency cost is small relative to the guarantee it buys you - avoid weaker settings without a specific, understood reason.
+
+**Commit offsets manually after successful processing, not automatically.** Auto-commit risks marking work as done before it's actually finished, which becomes a real data-loss risk if your process crashes mid-handling.
+
+**Choose partition keys based on what needs ordering relative to what.** A poor key choice (or none at all, resulting in round-robin distribution) loses ordering guarantees you might actually need - think about this deliberately rather than defaulting.
+
+**Design consumers to handle redelivery, since Kafka's guarantees are at-least-once by default.** A message can be redelivered after a crash between processing and committing - consumer logic needs to be idempotent, the same defensive principle that applies to retriable work in any messaging system.
+
+**Don't reach for Kafka if you don't actually need replay or high-volume streaming.** Its operational complexity (partitioning, consumer group rebalancing, retention tuning) isn't worth taking on for a workload a simpler queue would serve just as well.
+
+## Comparison with RabbitMQ
+
+| | Kafka | RabbitMQ |
+| --- | --- | --- |
+| Model | Distributed, partitioned, append-only log | Traditional queue-based broker |
+| Message retention | Configurable, independent of consumption | Removed on consumption/acknowledgment |
+| Replay | Native, core feature | Not supported |
+| .NET client experience | More low-level (Confluent.Kafka) | Higher-level via MassTransit |
+| Best fit | High-volume event streaming, replay, analytics | Flexible routing, general-purpose messaging |
+
+They solve fundamentally different problems - reaching for Kafka because it's associated with "high performance" when your actual need is a general-purpose queue with flexible routing usually means taking on unnecessary operational complexity that RabbitMQ (via MassTransit) would handle more simply.
+
+## Frequently Asked Questions
+
+### Does Kafka guarantee messages are processed exactly once?
+
+By default, Kafka's consumer model is at-least-once - a message can be redelivered if a crash happens between processing and committing the offset. Exactly-once semantics are achievable with Kafka's transactional APIs, but they add real complexity; for most applications, designing idempotent consumers to safely handle at-least-once delivery is the more practical approach.
+
+### How do I choose a good partition key?
+
+Base it on what needs to stay ordered relative to what else - for example, using an order ID as the key ensures all events for a given order land in the same partition and process in order relative to each other, while different orders can be processed in parallel across partitions. A poor or missing key choice loses ordering guarantees you might actually need.
+
+### What happens if I add more consumer instances than partitions?
+
+Extra instances beyond the partition count sit idle for that topic - Kafka can't assign more than one consumer per partition within the same consumer group, since ordering and exclusive processing within a partition depend on that constraint. Partition count is effectively your parallelism ceiling for a given topic and consumer group.
+
+### Should I use auto-commit or manual commit for consumer offsets?
+
+Manual commit, for anything where correctness matters. Auto-commit risks marking a message as processed before your handler has actually finished with it - if the process crashes in that window, you can silently lose the in-flight message's processing without Kafka being able to tell you anything went wrong.
+
+### How long does Kafka retain messages?
+
+Configurable per topic, based on time (e.g., seven days) or size, independent of whether any consumer has actually read a given message. This is fundamentally different from a traditional queue, where a message is typically removed once consumed - Kafka's retention is what makes replay possible.
+
+### Is Kafka overkill for a typical microservices application?
+
+Often, yes, if your actual need is general-purpose messaging between services rather than high-volume event streaming or replay. RabbitMQ (via MassTransit) or a managed queue like Azure Service Bus or Amazon SQS typically fits typical microservice communication with meaningfully less operational overhead than running or managing a Kafka cluster.
+
+### What's the most common mistake in a first Kafka setup?
+
+Using Kafka for a workload that's really just a queue, taking on partitioning and consumer group complexity without needing replay or high throughput. The second most common is leaving auto-commit enabled without understanding the data-loss risk it introduces if a consumer crashes mid-processing.

--- a/src/posts/2027-10-05-getting-started-with-azure-service-bus.md
+++ b/src/posts/2027-10-05-getting-started-with-azure-service-bus.md
@@ -1,0 +1,214 @@
+---
+author: Steve Kaschimer
+date: 2027-10-05
+image: /images/posts/2027-10-05-hero.webp
+image_alt: "A cloud-bounded topic/subscription glyph with two identical output lines fanning to separate independent boxes, each stamped with a small completion checkmark."
+image_prompt: "A dark-mode technical editorial illustration on a near-black background with electric teal, amber, and off-white accents. Composition centers on a small cloud-bounded topic shape at the center, with two identical thin teal lines fanning outward to two independent rectangular boxes, each stamped with a small amber completion checkmark, implying each subscriber gets its own copy and its own explicit acknowledgment. A faint lock-shaped icon sits beside one box, implying session-based ordering. Mood is polished, native, and dependable. Avoid: vendor logos, brand colors, circuit-board textures, gears, or generic cloud clip art as the dominant motif."
+layout: post.njk
+site_title: Tech Notes
+summary: "The Azure.Messaging.ServiceBus SDK feels designed by people who write ASP.NET Core applications, not adapted from a cross-language client. A setup guide for queues vs. topics/subscriptions, MessageId-based duplicate detection, and explicit message completion instead of relying on AutoCompleteMessages."
+tags: ["dotnet", "messaging", "cloud", "architecture", "devops"]
+title: "Getting Started with Azure Service Bus in .NET"
+---
+
+Azure Service Bus's reputation as the best .NET developer experience among message brokers isn't marketing - the `Azure.Messaging.ServiceBus` SDK genuinely feels like it was designed by people who write ASP.NET Core applications, not adapted from a cross-language client. That smoothness can hide a couple of decisions worth making deliberately rather than by default: whether you need queues or topics, and how you handle message locking for longer-running processing.
+
+This guide covers installing and connecting to Azure Service Bus from .NET, bootstrapping queues and topic/subscription pub-sub, the core send/receive workflow including message locking, and the best practices that keep a Service Bus-backed system reliable under real failure conditions. By the end you'll have a working setup using either pattern, and a clear sense of which one fits a given scenario.
+
+If you're deciding between message brokers first, [a comparison of the top .NET message brokers](/posts/2027-09-14-top-5-dotnet-message-brokers-compared/) covers where Azure Service Bus fits relative to RabbitMQ, Kafka, Amazon SQS, and NATS.
+
+## What You'll Need
+
+- .NET 8 SDK or later
+- An Azure subscription and a Service Bus namespace (Standard tier supports topics; Basic tier is queues-only)
+
+```bash
+az servicebus namespace create --name my-app-servicebus --resource-group my-rg --sku Standard
+az servicebus queue create --name orders --namespace-name my-app-servicebus --resource-group my-rg
+```
+
+## Installing the Azure Service Bus SDK
+
+```bash
+dotnet add package Azure.Messaging.ServiceBus
+```
+
+## Bootstrapping the Ideal Environment
+
+### Queues: point-to-point delivery
+
+```csharp
+var builder = WebApplication.CreateBuilder(args);
+
+builder.Services.AddSingleton(_ =>
+    new ServiceBusClient(builder.Configuration.GetConnectionString("ServiceBus")));
+
+var app = builder.Build();
+```
+
+`ServiceBusClient` is designed to be a long-lived singleton, the same discipline that applies to Redis's connection multiplexer - create it once, share it across your application.
+
+### Sending a message
+
+```csharp
+public class OrderService(ServiceBusClient client)
+{
+    public async Task SubmitOrderAsync(Order order)
+    {
+        await using var sender = client.CreateSender("orders");
+
+        var message = new ServiceBusMessage(JsonSerializer.Serialize(order))
+        {
+            ContentType = "application/json",
+            MessageId = order.Id.ToString() // enables duplicate detection if configured on the queue
+        };
+
+        await sender.SendMessageAsync(message);
+    }
+}
+```
+
+`MessageId` combined with duplicate detection (configured on the queue itself) gives you a straightforward way to guard against accidental re-sends without building your own idempotency key tracking.
+
+### Receiving messages with a background processor
+
+```csharp
+public class OrderQueueProcessor(ServiceBusClient client, IOrderService orderService, ILogger<OrderQueueProcessor> logger)
+    : BackgroundService
+{
+    private ServiceBusProcessor? _processor;
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        _processor = client.CreateProcessor("orders", new ServiceBusProcessorOptions
+        {
+            MaxConcurrentCalls = 8,
+            AutoCompleteMessages = false // complete manually after successful processing
+        });
+
+        _processor.ProcessMessageAsync += async args =>
+        {
+            var order = JsonSerializer.Deserialize<Order>(args.Message.Body.ToString());
+            try
+            {
+                await orderService.ProcessAsync(order!.Id);
+                await args.CompleteMessageAsync(args.Message);
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(ex, "Failed to process order {OrderId}", order?.Id);
+                await args.AbandonMessageAsync(args.Message); // returns to queue for redelivery
+            }
+        };
+
+        _processor.ProcessErrorAsync += args =>
+        {
+            logger.LogError(args.Exception, "Service Bus processor error");
+            return Task.CompletedTask;
+        };
+
+        await _processor.StartProcessingAsync(stoppingToken);
+    }
+
+    public override async Task StopAsync(CancellationToken cancellationToken)
+    {
+        if (_processor is not null)
+            await _processor.StopProcessingAsync(cancellationToken);
+        await base.StopAsync(cancellationToken);
+    }
+}
+```
+
+`AutoCompleteMessages = false` paired with explicit `CompleteMessageAsync` after successful processing is the safer pattern - the same principle that applies to manual offset commits in Kafka, ensuring a message isn't marked done until your handler actually finishes with it.
+
+### Topics and subscriptions, for pub/sub
+
+```bash
+az servicebus topic create --name order-events --namespace-name my-app-servicebus --resource-group my-rg
+az servicebus topic subscription create --name notifications --topic-name order-events --namespace-name my-app-servicebus --resource-group my-rg
+```
+
+```csharp
+await using var sender = client.CreateSender("order-events");
+await sender.SendMessageAsync(new ServiceBusMessage(JsonSerializer.Serialize(orderPlacedEvent)));
+```
+
+Each subscription on a topic receives its own copy of every message published to that topic - this is Service Bus's equivalent of RabbitMQ's fanout exchange, letting multiple independent consumers react to the same event without competing for the same messages.
+
+## Core Workflow
+
+- **Use queues for point-to-point work distribution, topics for pub/sub.** This mirrors the same architectural decision you'd make with RabbitMQ's queues vs. exchanges - pick based on whether one consumer or many independent consumers should see each message.
+- **Complete messages manually after successful processing**, abandoning (for retry) or dead-lettering (for messages that will never succeed) explicitly rather than relying on auto-complete.
+- **Use message sessions for scenarios requiring strict ordering per logical group.** Sessions let you process related messages (like all events for one order) in order, similar in spirit to Kafka's partition-key ordering guarantee.
+
+```csharp
+if (retryCount >= maxRetries)
+{
+    await args.DeadLetterMessageAsync(args.Message, "MaxRetriesExceeded");
+}
+else
+{
+    await args.AbandonMessageAsync(args.Message);
+}
+```
+
+## Verifying Your Setup
+
+1. **Messages send and receive correctly** - confirm a message sent to a queue is received and completed by your processor
+2. **Duplicate detection works, if configured** - send the same `MessageId` twice within the detection window and confirm only one is delivered
+3. **Failed messages end up in the dead-letter queue after exhausting retries**, not looping indefinitely - confirm your abandon/dead-letter logic actually terminates
+4. **Topic subscriptions each receive their own copy** - confirm multiple subscriptions on the same topic each independently receive every published message
+
+## Best Practices
+
+**Register `ServiceBusClient` as a singleton and share it.** It manages its own connection pooling internally - creating new clients per operation is unnecessary overhead.
+
+**Set `AutoCompleteMessages = false` and complete messages explicitly after successful processing.** This avoids the same class of "marked done before actually done" risk that applies to Kafka's auto-commit.
+
+**Use `MessageId` and duplicate detection for anything where accidental re-sends are a real risk.** It's a low-effort way to get idempotency protection without building your own deduplication logic.
+
+**Choose queues vs. topics deliberately based on consumer cardinality**, not habit - a queue where you actually need pub/sub means you're missing fan-out to other interested consumers; a topic for pure point-to-point work adds unnecessary structure.
+
+**Move messages to the dead-letter queue explicitly once retries are exhausted, rather than abandoning indefinitely.** An abandon loop with no termination condition just means a message cycling forever without ever being resolved or flagged for attention.
+
+## Comparison with Amazon SQS
+
+| | Azure Service Bus | Amazon SQS |
+| --- | --- | --- |
+| Model | Queues and topics/subscriptions | Queues (standard and FIFO); pub/sub via SNS+SQS |
+| .NET SDK experience | Excellent, idiomatic and async-first | Good, straightforward |
+| Duplicate detection | Built in via `MessageId` | Built in for FIFO queues |
+| Ordering | Via message sessions | Via FIFO queues |
+| Best fit | Azure-native teams wanting managed pub/sub built in | AWS-native teams wanting the cheapest, simplest queueing |
+
+Both are fully managed and both integrate cleanly with .NET, but the choice is really about which cloud platform you're already committed to - Service Bus's built-in topic/subscription model is a genuine convenience over pairing SNS with SQS for the equivalent pub/sub pattern on AWS.
+
+## Frequently Asked Questions
+
+### Should I use a queue or a topic for a given scenario?
+
+Use a queue when exactly one consumer should process each message (work distribution). Use a topic with subscriptions when multiple independent consumers each need their own copy of every message (pub/sub) - the same distinction that applies to point-to-point vs. broadcast messaging in any broker.
+
+### How do I prevent duplicate messages from being processed twice?
+
+Set a `MessageId` on outgoing messages and enable duplicate detection on the queue or topic (with a configured detection time window). Service Bus will recognize and discard duplicate `MessageId`s sent within that window, giving you idempotency protection without building your own deduplication tracking.
+
+### What's the difference between abandoning and dead-lettering a message?
+
+Abandoning returns a message to the queue for redelivery, appropriate for transient failures you expect to succeed on retry. Dead-lettering moves a message to a separate dead-letter queue permanently, appropriate once you've determined a message will never successfully process (after exhausting retries, or on a clearly invalid message) - it stops the message from cycling indefinitely while preserving it for inspection.
+
+### How do I guarantee message ordering in Azure Service Bus?
+
+Use message sessions, which group related messages (via a session ID you assign) and guarantee they're processed in order by a single consumer at a time. This is Service Bus's equivalent of Kafka's partition-key ordering guarantee, scoped to a logical group rather than the entire queue or topic.
+
+### Is Azure Service Bus expensive at high volume?
+
+It can become costly relative to self-hosted RabbitMQ or Kafka at very high message volumes, since Service Bus pricing scales with usage (operations and, on Premium tier, throughput units). For moderate volumes, especially weighed against the operational cost of self-hosting an alternative, it's often still cost-competitive - model your actual expected volume against current pricing rather than assuming either direction by default.
+
+### Can I use Azure Service Bus with MassTransit instead of the native SDK directly?
+
+Yes - MassTransit supports Azure Service Bus as a transport, giving you the same consumer/publish abstraction you'd use with RabbitMQ, at the cost of an additional abstraction layer over Service Bus's already strong native SDK. Many teams use the native SDK directly specifically because Service Bus's own client is already idiomatic enough that MassTransit's abstraction adds less relative value than it does over RabbitMQ's lower-level client.
+
+### What's the most common mistake in a first Azure Service Bus setup?
+
+Leaving `AutoCompleteMessages` at its default and not explicitly completing messages after successful processing, risking the same "marked done before actually done" class of bug that applies to auto-commit in Kafka. The second common mistake is choosing a queue for a scenario that actually needs a topic's fan-out to multiple independent consumers.

--- a/src/posts/2027-10-12-getting-started-with-amazon-sqs.md
+++ b/src/posts/2027-10-12-getting-started-with-amazon-sqs.md
@@ -1,0 +1,201 @@
+---
+author: Steve Kaschimer
+date: 2027-10-12
+image: /images/posts/2027-10-12-hero.webp
+image_alt: "A minimal single-lane queue glyph with a clean start and end, a small visibility-timeout clock hovering above the midpoint instead of any explicit acknowledgment marker."
+image_prompt: "A dark-mode technical editorial illustration on a near-black background with electric teal, amber, and off-white accents. Composition centers on a single flat horizontal lane with a clear entry point on the left and exit point on the right, representing a plain queue with no branching or exchange logic. A small amber clock icon hovers above the lane's midpoint, implying a visibility timeout governs redelivery rather than an explicit acknowledgment step. Mood is simple, direct, and zero-ops. Avoid: vendor logos, brand colors, circuit-board textures, gears, or generic cloud clip art as the dominant motif."
+layout: post.njk
+site_title: Tech Notes
+summary: "SQS's simplicity is genuinely refreshing after RabbitMQ's exchange model or Kafka's partition mechanics - a queue, messages go in, messages come out, AWS handles the rest. A setup guide for standard vs. FIFO queues, long polling, and deletion as SQS's genuinely different completion model."
+tags: ["dotnet", "messaging", "cloud", "architecture", "devops"]
+title: "Getting Started with Amazon SQS in .NET"
+---
+
+Amazon SQS's simplicity is its whole pitch, and that simplicity is genuinely refreshing after RabbitMQ's exchange model or Kafka's partition mechanics - a queue, messages go in, messages come out, AWS handles the rest. The part worth understanding upfront isn't complexity so much as a set of binary decisions SQS asks you to make explicitly: standard or FIFO, short or long polling, and how deletion (not "completion" - SQS's model is genuinely different here) fits into your processing logic.
+
+This guide covers installing and connecting to SQS from .NET, bootstrapping standard and FIFO queues, the core send/receive/delete workflow, and the best practices that keep an SQS-backed system correct under real failure and retry conditions. By the end you'll have a working setup and a clear sense of when FIFO's added guarantees are actually worth their throughput cost.
+
+If you're deciding between message brokers first, [a comparison of the top .NET message brokers](/posts/2027-09-14-top-5-dotnet-message-brokers-compared/) covers where Amazon SQS fits relative to RabbitMQ, Kafka, Azure Service Bus, and NATS.
+
+## What You'll Need
+
+- .NET 8 SDK or later
+- An AWS account and credentials configured (via the AWS CLI, environment variables, or an IAM role if running on AWS infrastructure)
+
+```bash
+aws sqs create-queue --queue-name orders
+```
+
+## Installing the AWS SDK for SQS
+
+```bash
+dotnet add package AWSSDK.SQS
+dotnet add package AWSSDK.Extensions.NETCore.Setup
+```
+
+## Bootstrapping the Ideal Environment
+
+### Registering the SQS client
+
+```csharp
+var builder = WebApplication.CreateBuilder(args);
+
+builder.Services.AddAWSService<IAmazonSQS>();
+builder.Services.AddDefaultAWSOptions(builder.Configuration.GetAWSOptions());
+
+var app = builder.Build();
+```
+
+`AddAWSService<T>` handles registering a properly configured client using your application's AWS configuration (credentials, region) - no manual client construction needed in most cases.
+
+### Sending a message
+
+```csharp
+public class OrderService(IAmazonSQS sqs, IConfiguration config)
+{
+    public async Task SubmitOrderAsync(Order order)
+    {
+        var queueUrl = config["Sqs:OrdersQueueUrl"];
+
+        await sqs.SendMessageAsync(new SendMessageRequest
+        {
+            QueueUrl = queueUrl,
+            MessageBody = JsonSerializer.Serialize(order),
+            MessageAttributes = new Dictionary<string, MessageAttributeValue>
+            {
+                ["OrderId"] = new() { DataType = "String", StringValue = order.Id.ToString() }
+            }
+        });
+    }
+}
+```
+
+SQS identifies queues by URL, not just name - fetch and cache the queue URL (via `GetQueueUrlAsync`, or store it directly in configuration) rather than re-resolving it on every send.
+
+### Receiving and deleting messages
+
+```csharp
+public class OrderQueueProcessor(IAmazonSQS sqs, IOrderService orderService, IConfiguration config, ILogger<OrderQueueProcessor> logger)
+    : BackgroundService
+{
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        var queueUrl = config["Sqs:OrdersQueueUrl"];
+
+        while (!stoppingToken.IsCancellationRequested)
+        {
+            var response = await sqs.ReceiveMessageAsync(new ReceiveMessageRequest
+            {
+                QueueUrl = queueUrl,
+                MaxNumberOfMessages = 10,
+                WaitTimeSeconds = 20, // long polling
+                VisibilityTimeout = 30
+            }, stoppingToken);
+
+            foreach (var message in response.Messages)
+            {
+                try
+                {
+                    var order = JsonSerializer.Deserialize<Order>(message.Body);
+                    await orderService.ProcessAsync(order!.Id);
+
+                    // Deletion is the SQS equivalent of "acknowledgment" -- without it, the message reappears
+                    await sqs.DeleteMessageAsync(queueUrl, message.ReceiptHandle, stoppingToken);
+                }
+                catch (Exception ex)
+                {
+                    logger.LogError(ex, "Failed to process message {MessageId}", message.MessageId);
+                    // Don't delete -- the message becomes visible again after VisibilityTimeout expires
+                }
+            }
+        }
+    }
+}
+```
+
+`WaitTimeSeconds = 20` enables long polling - SQS holds the request open waiting for a message to arrive, rather than returning immediately with an empty result. This meaningfully reduces both latency and the number of (billed) empty API calls compared to short polling.
+
+### FIFO queues, when strict ordering matters
+
+```bash
+aws sqs create-queue --queue-name orders.fifo --attributes FifoQueue=true,ContentBasedDeduplication=true
+```
+
+```csharp
+await sqs.SendMessageAsync(new SendMessageRequest
+{
+    QueueUrl = fifoQueueUrl,
+    MessageBody = JsonSerializer.Serialize(order),
+    MessageGroupId = order.CustomerId.ToString(), // ordering scope, similar to a Kafka partition key
+    MessageDeduplicationId = order.Id.ToString()   // required unless ContentBasedDeduplication is enabled
+});
+```
+
+`MessageGroupId` scopes ordering the same way a Kafka partition key does - messages within the same group are delivered in order, while different groups can be processed independently and in parallel.
+
+## Core Workflow
+
+- **Delete messages only after successful processing.** SQS's visibility timeout, not an explicit acknowledgment call, is what governs redelivery - an undeleted message simply becomes visible again once the timeout expires, whether that's intentional (a crash) or accidental (forgetting to delete).
+- **Use long polling (`WaitTimeSeconds`) by default.** It reduces both latency and the number of billed empty receive calls compared to short polling.
+- **Choose standard queues by default, FIFO only when you specifically need strict ordering or exactly-once processing.** FIFO's guarantees come with a real throughput ceiling compared to standard queues.
+
+## Verifying Your Setup
+
+1. **Messages send and are received correctly** - confirm a sent message appears in a subsequent receive call
+2. **Deletion behaves as expected** - confirm an undeleted message becomes visible again after the visibility timeout, and a deleted one doesn't reappear
+3. **Long polling is actually reducing empty calls** - confirm `WaitTimeSeconds` is set and observe reduced polling frequency compared to short polling
+4. **FIFO ordering holds, if used** - for a FIFO queue, confirm messages within the same `MessageGroupId` are consistently delivered in send order
+
+## Best Practices
+
+**Only delete a message after your handler has fully and successfully processed it.** This is the SQS equivalent of manual offset commits in Kafka or explicit message completion in Service Bus - deleting too early risks losing work if a crash happens between deletion and actual completion.
+
+**Set `VisibilityTimeout` based on your actual processing time, with margin.** Too short, and a message becomes visible again (and gets redelivered to another consumer) while still being processed; too long, and a genuinely failed message takes longer than necessary to become available for retry.
+
+**Use long polling by default.** There's little reason to use short polling (`WaitTimeSeconds = 0`) for typical application workloads - long polling reduces cost and latency with no meaningful downside for most use cases.
+
+**Reach for FIFO queues only when you specifically need strict ordering or exactly-once processing.** Standard queues have meaningfully higher throughput and are the right default unless your use case genuinely requires FIFO's guarantees.
+
+**Design consumers to be idempotent regardless of queue type.** Standard queues are explicitly at-least-once delivery, and even FIFO's "exactly-once processing" has edge cases worth defending against with idempotent handler logic.
+
+## Comparison with Azure Service Bus
+
+| | Amazon SQS | Azure Service Bus |
+| --- | --- | --- |
+| Model | Queues (standard and FIFO) | Queues and topics/subscriptions |
+| Pub/sub | Requires pairing with SNS | Built in via topics |
+| Acknowledgment model | Explicit delete; visibility timeout governs redelivery | Explicit complete; lock duration governs redelivery |
+| Ordering | FIFO queues with MessageGroupId | Message sessions |
+| Best fit | AWS-native teams wanting the cheapest, simplest queueing | Azure-native teams wanting managed pub/sub built in |
+
+The core mental models are similar (visibility timeout vs. lock duration, message group vs. session for ordering), but SQS's simpler model doesn't include topic-based pub/sub natively - that's SNS's job, paired with SQS as the delivery mechanism, whereas Service Bus bundles both under one service.
+
+## Frequently Asked Questions
+
+### What happens if I forget to delete a message after processing it?
+
+It becomes visible again once the visibility timeout expires and gets redelivered to another (or the same) consumer - SQS has no separate "acknowledgment" call distinct from deletion. This is exactly why deleting only after successful processing matters: forgetting to delete an already-processed message just means unnecessary reprocessing, but deleting before processing completes risks losing work entirely if a crash happens in between.
+
+### Should I use standard or FIFO queues?
+
+Standard queues by default - they have meaningfully higher throughput and are sufficient for the majority of use cases, since most applications can tolerate the (rare, but possible) out-of-order or duplicate delivery standard queues allow. Reach for FIFO specifically when strict ordering or exactly-once processing within a message group is a real requirement, not a nice-to-have.
+
+### How does SQS handle pub/sub, since there's no topic concept like Service Bus?
+
+Pair SQS with Amazon SNS - SNS handles the pub/sub fan-out, publishing to multiple SQS queues (or other subscribers) from a single topic, with each queue then consumed independently. This is architecturally similar to Service Bus's topic/subscription model, just split across two AWS services rather than bundled into one.
+
+### What's the difference between short polling and long polling?
+
+Short polling returns immediately, even if no messages are available, which wastes API calls (and their associated cost) when the queue is often empty. Long polling (`WaitTimeSeconds` greater than zero) holds the request open until a message arrives or the wait time elapses, reducing both latency to receive new messages and the number of empty, billed calls - there's little reason not to default to it.
+
+### How do I prevent duplicate message processing?
+
+For FIFO queues, enable `ContentBasedDeduplication` or provide an explicit `MessageDeduplicationId` to prevent the same logical message from being enqueued twice within the deduplication window. For standard queues, which don't offer this, design your consumer logic to be idempotent instead, since at-least-once delivery means occasional duplicates are expected by design.
+
+### What does MessageGroupId do in a FIFO queue?
+
+It scopes ordering - messages with the same `MessageGroupId` are delivered strictly in send order, while different groups can be processed independently and in parallel. This is conceptually the same role a partition key plays in Kafka: the mechanism that lets you get both ordering where you need it and parallelism where you don't.
+
+### What's the most common mistake in a first SQS setup?
+
+Deleting a message immediately upon receipt rather than after successful processing, which risks losing work if a crash happens in between. The second common mistake is defaulting to FIFO queues out of an abundance of caution about ordering, without actually needing the ordering guarantee - unnecessarily giving up standard queues' higher throughput for a requirement that wasn't real.

--- a/src/posts/2027-10-19-getting-started-with-nats.md
+++ b/src/posts/2027-10-19-getting-started-with-nats.md
@@ -1,0 +1,193 @@
+---
+author: Steve Kaschimer
+date: 2027-10-19
+image: /images/posts/2027-10-19-hero.webp
+image_alt: "A lightweight subject-hierarchy glyph shown as a small dot branching into three thin dotted paths, with one path terminating in a persisted-stream marker distinct from the other two ephemeral ones."
+image_prompt: "A dark-mode technical editorial illustration on a near-black background with electric teal, amber, and off-white accents. Composition centers on a small solid teal dot branching into three thin dotted lines fanning outward at slightly different angles, representing a subject hierarchy. Two of the lines terminate in plain open endpoints implying ephemeral, fire-and-forget delivery, while the third terminates in a small solid amber cylinder-free stream marker implying persistence layered on top. Mood is light, fast, and deliberately minimal. Avoid: vendor logos, brand colors, circuit-board textures, gears, or generic database-cylinder clip art as the dominant motif."
+layout: post.njk
+site_title: Tech Notes
+summary: "NATS's core pitch is that most messaging doesn't need to be as heavy as it usually is - subject-based pub/sub, a tiny operational footprint, and genuinely low latency. A setup guide for core NATS's fire-and-forget model and JetStream's durability once persistence actually matters."
+tags: ["dotnet", "messaging", "architecture", "performance", "microservices"]
+title: "Getting Started with NATS in .NET"
+---
+
+NATS's core pitch is that most messaging doesn't need to be as heavy as it usually is - subject-based publish-subscribe, a tiny operational footprint, and genuinely low latency, without RabbitMQ's exchange configuration or Kafka's partition mechanics. The trade-off is equally direct: core NATS is fire-and-forget with no persistence at all, and understanding exactly when that's fine (and when you need JetStream layered on top) is the single most important decision in adopting it.
+
+This guide covers installing and connecting to NATS from .NET, bootstrapping both core NATS pub/sub and JetStream for durable messaging, the core patterns for publish/subscribe and request-reply, and the best practices for knowing which of the two modes a given piece of your system actually needs. By the end you'll have a lightweight messaging setup and a clear mental model for when "lightweight" stops being enough.
+
+If you're deciding between message brokers first, [a comparison of the top .NET message brokers](/posts/2027-09-14-top-5-dotnet-message-brokers-compared/) covers where NATS fits relative to RabbitMQ, Kafka, Azure Service Bus, and Amazon SQS.
+
+## What You'll Need
+
+- .NET 8 SDK or later
+- Docker, for running NATS locally
+
+```bash
+docker run -d --name nats -p 4222:4222 -p 8222:8222 nats:latest -js
+```
+
+The `-js` flag enables JetStream on the server - worth including from the start even if you begin with core NATS, so you can add durability later without reprovisioning.
+
+## Installing the NATS Client
+
+```bash
+dotnet add package NATS.Client.Core
+dotnet add package NATS.Client.JetStream
+```
+
+## Bootstrapping the Ideal Environment
+
+### Connecting
+
+```csharp
+var builder = WebApplication.CreateBuilder(args);
+
+builder.Services.AddSingleton(_ =>
+    new NatsConnection(new NatsOpts { Url = builder.Configuration["Nats:Url"] ?? "nats://localhost:4222" }));
+
+var app = builder.Build();
+```
+
+`NatsConnection` is designed to be a long-lived singleton, the same pattern as Redis's connection multiplexer or Service Bus's client - create once, share across the application.
+
+### Core NATS: fire-and-forget publish/subscribe
+
+```csharp
+public class OrderEventPublisher(NatsConnection nats)
+{
+    public async Task PublishOrderSubmittedAsync(OrderSubmitted evt)
+    {
+        await nats.PublishAsync("orders.submitted", evt);
+    }
+}
+```
+
+```csharp
+public class OrderEventSubscriber(NatsConnection nats, IOrderService orderService) : BackgroundService
+{
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        await foreach (var msg in nats.SubscribeAsync<OrderSubmitted>("orders.submitted", cancellationToken: stoppingToken))
+        {
+            await orderService.ProcessAsync(msg.Data!.OrderId);
+        }
+    }
+}
+```
+
+This is genuinely all there is to core NATS pub/sub - no queue declaration, no exchange configuration. But note what's missing compared to every other broker in this series: if no subscriber is connected when a message publishes, it's simply gone. There's no queue holding it for later.
+
+### Subject hierarchies and wildcards
+
+```csharp
+// Publish to a specific, hierarchical subject
+await nats.PublishAsync("orders.submitted.us-west", evt);
+
+// Subscribe with a wildcard to receive from all regions
+await foreach (var msg in nats.SubscribeAsync<OrderSubmitted>("orders.submitted.*", cancellationToken: stoppingToken))
+{
+    // handles orders.submitted.us-west, orders.submitted.eu-central, etc.
+}
+```
+
+Subjects are dot-separated hierarchies, and `*` (single token) and `>` (multiple trailing tokens) wildcards let subscribers express interest in a range of related subjects without needing separate subscriptions for each - this is NATS's answer to RabbitMQ's topic exchange routing.
+
+### JetStream: durability and replay, when you need them
+
+```csharp
+var js = new NatsJSContext(nats);
+
+await js.CreateStreamAsync(new StreamConfig("ORDERS", ["orders.>"])
+{
+    Retention = StreamConfigRetention.Limits,
+    MaxAge = TimeSpan.FromDays(7)
+});
+```
+
+```csharp
+// Publish through JetStream for persistence
+var ack = await js.PublishAsync("orders.submitted", evt);
+```
+
+```csharp
+// A durable consumer that survives restarts and tracks its own position
+var consumer = await js.CreateOrUpdateConsumerAsync("ORDERS", new ConsumerConfig("order-processor")
+{
+    AckPolicy = ConsumerConfigAckPolicy.Explicit
+});
+
+await foreach (var msg in consumer.ConsumeAsync<OrderSubmitted>())
+{
+    await orderService.ProcessAsync(msg.Data!.OrderId);
+    await msg.AckAsync();
+}
+```
+
+This is a meaningfully different mode from core NATS - messages persist in a stream, consumers track their own position durably, and explicit acknowledgment (similar to Kafka's manual offset commit, or Service Bus's message completion) governs redelivery. Reach for this the moment "the message must not be lost if nobody's listening right now" becomes a real requirement.
+
+## Core Workflow
+
+- **Use core NATS for genuinely ephemeral, low-latency signaling** where losing a message when no one's listening is acceptable - real-time status updates, cache invalidation broadcasts, anything where a missed message just means slightly stale state rather than lost work.
+- **Use JetStream the moment durability matters**, treating the decision the same way you'd decide between Kafka's log-based durability and a plain queue's simpler at-least-once model.
+- **Use subject hierarchies deliberately**, designing your subject naming (`orders.submitted.region`) to support the wildcard subscriptions you'll actually need, the same care you'd put into RabbitMQ routing keys.
+
+## Verifying Your Setup
+
+1. **Core NATS pub/sub delivers to active subscribers** - confirm a message published while a subscriber is connected is received
+2. **Core NATS messages are genuinely lost with no subscriber connected** - confirm this explicitly so it's a known, intentional trade-off rather than a surprise in production
+3. **JetStream persists and redelivers correctly** - confirm a JetStream-published message is still delivered to a consumer that connects after the publish, unlike core NATS
+4. **Explicit acknowledgment in JetStream governs redelivery correctly** - confirm an unacknowledged message is redelivered, and an acknowledged one isn't
+
+## Best Practices
+
+**Be explicit with yourself about which mode (core or JetStream) each part of your system needs.** This is the single most consequential decision in a NATS-based design - treating core NATS's fire-and-forget behavior as an oversight rather than a deliberate choice leads to real, silent message loss.
+
+**Design subject hierarchies thoughtfully from the start.** Wildcards make hierarchical subjects powerful, but only if the hierarchy itself reflects how you'll actually want to subscribe later - retrofitting a subject naming scheme is more disruptive than planning one upfront.
+
+**Use JetStream's explicit acknowledgment for anything where processing correctness matters**, the same defensive default that applies to manual offset commits in Kafka or explicit completion in Service Bus.
+
+**Keep NATS's operational footprint light by not over-provisioning for scale you don't have.** Its appeal is partly that it doesn't need Kafka-scale operational investment - don't recreate that complexity unnecessarily if your actual throughput doesn't call for it.
+
+**Evaluate the smaller .NET ecosystem honestly before committing.** Fewer examples and less abstraction-library support, compared to RabbitMQ or Kafka, mean more of the integration work falls on your team directly - factor that into the adoption decision, not just NATS's technical merits.
+
+## Comparison with RabbitMQ
+
+| | NATS | RabbitMQ |
+| --- | --- | --- |
+| Model | Subject-based pub/sub; JetStream for persistence | Queue/exchange-based broker |
+| Default durability | None (core NATS) | Durable by default with persistent queues |
+| Operational footprint | Very light | Moderate, more mature tooling |
+| .NET ecosystem | Smaller | Larger, especially via MassTransit |
+| Best fit | Lightweight, low-latency cloud-native messaging | General-purpose messaging with flexible routing |
+
+NATS is the leaner choice when your priority is minimal operational overhead and low latency; RabbitMQ (especially via MassTransit) offers a more mature .NET ecosystem and durable-by-default behavior without needing a second mode (JetStream) layered on to get there.
+
+## Frequently Asked Questions
+
+### Does NATS guarantee message delivery like RabbitMQ or Kafka?
+
+Not by default - core NATS is fire-and-forget: if no subscriber is connected when a message publishes, it's lost with no persistence to fall back on. JetStream, layered on top of core NATS, adds the durability, persistence, and redelivery guarantees comparable to what RabbitMQ or Kafka provide by default.
+
+### When should I use JetStream instead of core NATS?
+
+The moment message loss due to no active subscriber becomes unacceptable for that specific use case. Core NATS is appropriate for ephemeral signaling where a missed message just means slightly stale state; JetStream is appropriate wherever a message represents work that must eventually happen, not just a notification that can be safely missed.
+
+### How do NATS subject wildcards work?
+
+`*` matches exactly one token in a dot-separated subject hierarchy (`orders.submitted.*` matches `orders.submitted.us-west` but not `orders.submitted.us-west.priority`), while `>` matches one or more trailing tokens (`orders.>` matches everything under `orders.`). Designing your subject hierarchy with these patterns in mind from the start makes future wildcard subscriptions much more natural.
+
+### Is NATS suitable for high-throughput streaming like Kafka?
+
+JetStream can handle substantial throughput and does support persistence and replay conceptually similar to Kafka, but Kafka remains the more mature, battle-tested choice specifically for very high-volume event streaming and analytics pipelines. NATS's strength is closer to lightweight, low-latency messaging than Kafka-scale log processing, even with JetStream enabled.
+
+### Can I do request-reply messaging with NATS?
+
+Yes - it's a first-class, well-supported pattern in core NATS, arguably more natural than in RabbitMQ or Kafka, since NATS's request-reply is built directly into its core pub/sub model rather than requiring an additional pattern layered on top.
+
+### How mature is the .NET client for NATS?
+
+Solid and actively maintained, but with a meaningfully smaller community and fewer examples than Confluent.Kafka, RabbitMQ's client, or Azure Service Bus's SDK. Evaluate this honestly against your team's risk tolerance and need for community support, separate from NATS's technical capabilities.
+
+### What's the most common mistake when adopting NATS?
+
+Using core NATS for a scenario that actually needed JetStream's durability, and discovering message loss in production rather than as a deliberate, understood design decision made upfront. The second common mistake is underestimating the smaller ecosystem's impact on day-to-day development compared to more established brokers.


### PR DESCRIPTION
## Summary

- Schedules and drafts the .NET Message Brokers Tuesday track: a comparison anchor post plus five getting-started guides, running weekly Tuesdays 2027-09-14 through 2027-10-19, picking up the cadence directly after the .NET Caching Solutions track
- Moves the series from `editorial-plan.md`'s Backlog into a dated `## 📅 Tuesday Track - .NET Message Brokers (September-October 2027)` section, all entries `Status: draft` with `File:` paths, and updates the Backlog intro count from eight to seven remaining series

### Posts added

- **Anchor:** The Top 5 Message Brokers for .NET Compared: Which One Should You Choose? (2027-09-14) - RabbitMQ, Kafka, Azure Service Bus, Amazon SQS, and NATS compared on shape (flexible routing vs. replayable log vs. managed queue) rather than raw throughput, with a note on MassTransit/NServiceBus/Rebus as the abstraction layer most .NET teams actually build against
- Getting Started with RabbitMQ in .NET (2027-09-21)
- Getting Started with Kafka in .NET (2027-09-28)
- Getting Started with Azure Service Bus in .NET (2027-10-05)
- Getting Started with Amazon SQS in .NET (2027-10-12)
- Getting Started with NATS in .NET (2027-10-19)

Each setup guide cross-links back to the anchor post, mirroring the structure of the prior .NET ORMs/API Styles/Validation Approaches/Mapping Libraries/Caching Solutions/Testing/Logging/Architecture tracks.

## Test plan

- [x] `npm run deploy` builds cleanly, all 6 posts render
- [x] `node scripts/a11y-check.js` (axe-core + Playwright) - zero violations across home/post/about/privacy/terms/404 in light and dark mode
- [x] Verified all 5 setup-guide cross-links resolve to the anchor post's output URL


---
_Generated by [Claude Code](https://claude.ai/code/session_01WKyNF7L5qzrfct8cec6A32)_