### PR TITLE
Add .NET Background Job Libraries Tuesday track (6 posts)

### DIFF
--- a/editorial-plan.md
+++ b/editorial-plan.md
@@ -1118,17 +1118,69 @@ Six posts on how a .NET service moves messages between other services, picking u
 
 ---
 
-## 📅 Backlog - Unscheduled Series
+## 📅 Tuesday Track - .NET Background Job Libraries (October-November 2027)
 
-Seven six-post series remain unscheduled, drawn from the drafts in `docs/article-ideas/`. They continue the Tuesday cadence once the .NET Message Brokers series ends on 2027-10-19, and they're listed here in priority order. They're deliberately undated - that horizon is too far out to put honest dates against - so each series gets one entry rather than six speculative ones, and entries are expanded into individual dated posts when a series moves onto the calendar.
+Six posts on how a .NET service runs work outside the request/response cycle, picking up the Tuesday cadence directly from the Message Brokers track. A comparison post anchors the track and each of the five follow-ups is a complete setup for one background job tool.
 
-### .NET Background Job Libraries (6 posts)
-- **Status:** `idea`
-- **Source:** `docs/article-ideas/top-5-dotnet-background-job-libraries-compared.md` + 5 getting-started drafts
-- **Series:** Top 5 comparison, then Hangfire, Quartz.NET, Coravel, Wolverine, Azure Functions timer triggers
+### The Top 5 Background Job Libraries for .NET Compared: Which One Should You Choose?
+- **Status:** `draft`
+- **Scheduled:** 2027-10-26
+- **Source:** `docs/article-ideas/top-5-dotnet-background-job-libraries-compared.md`
+- **File:** `src/posts/2027-10-26-top-5-dotnet-background-job-libraries-compared.md`
 - **Pitch:** A `BackgroundService` with a `PeriodicTimer` is genuinely enough for one job. It stops scaling around the third - no persistence, no retry policy, no job history, no cron expressions, no coordination across instances, and an unhandled exception silently kills the loop for the rest of the process's lifetime.
 - **Angle:** Compares the five on persistence, dashboard, clustering, and setup effort, starting from what .NET already gives you for free so the comparison begins at the point a library is actually justified. These aren't all solving the same problem - two are schedulers, Wolverine is a messaging framework that happens to include scheduling, and Azure Functions is a managed runtime rather than a library - so matching the tool to the system matters more than ranking them. Hangfire is the default for most teams; Quartz.NET earns its extra configuration only when the scheduling rules are genuinely complex.
 - **Tags:** `dotnet`, `tooling`, `architecture`, `devops`, `developer-productivity`
+
+### Getting Started with Hangfire in .NET
+- **Status:** `draft`
+- **Scheduled:** 2027-11-02
+- **Source:** `docs/article-ideas/getting-started-with-hangfire.md`
+- **File:** `src/posts/2027-11-02-getting-started-with-hangfire.md`
+- **Pitch:** Hangfire's install-to-first-job time is genuinely a few minutes, and that speed is exactly why it's easy to skip the two decisions that determine whether it stays cheap to run: which storage backend, and how much you rely on the polling interval defaults.
+- **Angle:** Covers `AddHangfireServer()` as the easy-to-forget half of setup (jobs enqueue but never run without it), securing the dashboard before any non-local deployment, and `RecurringJob.AddOrUpdate` with a stable ID as the idempotent registration pattern that survives redeploys. Flags that storage load scales with polling frequency, not job volume - a real cost consideration for a small number of infrequent jobs.
+- **Tags:** `dotnet`, `tooling`, `architecture`, `developer-productivity`
+
+### Getting Started with Quartz.NET in .NET
+- **Status:** `draft`
+- **Scheduled:** 2027-11-09
+- **Source:** `docs/article-ideas/getting-started-with-quartznet.md`
+- **File:** `src/posts/2027-11-09-getting-started-with-quartznet.md`
+- **Pitch:** Quartz.NET's reputation for complexity is earned, but it's complexity in service of a specific thing: scheduling rules that are genuinely hard to express correctly, like a job that must run at 9am in the customer's local time zone, skip holidays, and never overlap.
+- **Angle:** Covers the job/trigger/scheduler separation as the core vocabulary that makes everything else click, `UseClustering()` for coordinating execution across instances without duplicate runs, and calendar exclusions for rules Hangfire's simpler model can't express. Direct that its configuration overhead is only worth paying when the scheduling need is genuinely hard, not for "run this every night."
+- **Tags:** `dotnet`, `tooling`, `architecture`, `developer-productivity`
+
+### Getting Started with Coravel in .NET
+- **Status:** `draft`
+- **Scheduled:** 2027-11-16
+- **Source:** `docs/article-ideas/getting-started-with-coravel.md`
+- **File:** `src/posts/2027-11-16-getting-started-with-coravel.md`
+- **Pitch:** Coravel's whole value proposition is that it doesn't ask you for anything - no database, no storage configuration, no dashboard to secure. Add a package, write a fluent scheduling expression, and you're done.
+- **Angle:** Covers the fluent `.Schedule().DailyAtHour()` API, `PreventOverlapping` as cheap insurance for any job whose duration is uncertain relative to its interval, and the explicit trade-off of zero persistence and zero multi-instance coordination. Frames Coravel as a deliberately different tool from Hangfire rather than a smaller version of it, with clear signals for when to graduate away from it.
+- **Tags:** `dotnet`, `tooling`, `developer-productivity`
+
+### Getting Started with Wolverine in .NET
+- **Status:** `draft`
+- **Scheduled:** 2027-11-23
+- **Source:** `docs/article-ideas/getting-started-with-wolverine.md`
+- **File:** `src/posts/2027-11-23-getting-started-with-wolverine.md`
+- **Pitch:** Wolverine is the one entry in this series where "getting started with background jobs" and "getting started with the whole library" are almost the same document - scheduling is one feature of a much broader messaging framework, not the framework's reason for existing.
+- **Angle:** Covers convention-based handlers with no interfaces required (source-generated dispatch instead of MediatR-style reflection), the durable outbox that atomically coordinates database writes with message publishing, and `Schedule.CronJob` versus `bus.ScheduleAsync` as the recurring-versus-one-time scheduling split. Upfront that adopting Wolverine purely for scheduling means taking on a full messaging framework's scope for one feature - the wrong trade unless the rest of its capabilities are also wanted.
+- **Tags:** `dotnet`, `messaging`, `architecture`, `performance`
+
+### Getting Started with Azure Functions Timer Triggers in .NET
+- **Status:** `draft`
+- **Scheduled:** 2027-11-30
+- **Source:** `docs/article-ideas/getting-started-with-azure-functions-timer-triggers.md`
+- **File:** `src/posts/2027-11-30-getting-started-with-azure-functions-timer-triggers.md`
+- **Pitch:** Azure Functions timer triggers solve a problem the other four tools in this series structurally can't: what happens when your job needs to run even if your main application isn't. An in-process scheduler is only as reliable as the app hosting it.
+- **Angle:** Covers scaffolding on the isolated worker model (the only path worth building on, since in-process support ends November 2026), Azure's 6-field NCronTab format that trips people up expecting standard 5-field cron, and designing for idempotency since serverless retries mean more-than-once execution is a real possibility, not an edge case. Honest that real Azure lock-in is the trade for structural independence from any single app's uptime.
+- **Tags:** `dotnet`, `cloud`, `architecture`, `devops`
+
+---
+
+## 📅 Backlog - Unscheduled Series
+
+Six six-post series remain unscheduled, drawn from the drafts in `docs/article-ideas/`. They continue the Tuesday cadence once the .NET Background Job Libraries series ends on 2027-11-30, and they're listed here in priority order. They're deliberately undated - that horizon is too far out to put honest dates against - so each series gets one entry rather than six speculative ones, and entries are expanded into individual dated posts when a series moves onto the calendar.
 
 ### .NET Mocking Libraries (6 posts)
 - **Status:** `idea`

--- a/src/posts/2027-10-26-top-5-dotnet-background-job-libraries-compared.md
+++ b/src/posts/2027-10-26-top-5-dotnet-background-job-libraries-compared.md
@@ -1,0 +1,165 @@
+---
+author: Steve Kaschimer
+date: 2027-10-26
+image: /images/posts/2027-10-26-hero.webp
+image_alt: "Five columns of abstract background-job glyphs positioned along a horizontal axis running from lightweight in-process scheduling on the left to fully decoupled managed execution on the right."
+image_prompt: "A dark-mode technical editorial illustration on a near-black background with electric teal, amber, and off-white accents. Composition is five vertical columns of equal width separated by thin hairline rules, each column topped by a distinct abstract glyph rendered in flat geometry: a small dashboard-panel glyph with a job-list icon inside it, a layered job/trigger/scheduler stack of three thin rectangles, a minimal single fluent-arrow glyph with no supporting infrastructure beneath it, a cloud-bounded clock icon fully detached from any host shape, and a message-envelope glyph with a small embedded clock corner implying scheduling folded into a broader messaging concept. Beneath the glyphs, a shared horizontal axis labeled in monospaced type runs from 'in-process' on the left to 'fully decoupled' on the right, with a small glowing teal dot positioned at a different point under each column. Mood is comparative, engineering-first, and non-partisan. Avoid: vendor logos, brand colors, circuit-board textures, gears, or generic clock clip art used as the dominant motif."
+layout: post.njk
+site_title: Tech Notes
+summary: "A BackgroundService with a PeriodicTimer is genuinely enough for one job. It stops scaling around the third - no persistence, no retry policy, no job history, no coordination across instances. A practical breakdown of five tools .NET developers reach for once they've outgrown it."
+tags: ["dotnet", "tooling", "architecture", "devops", "developer-productivity"]
+title: "The Top 5 Background Job Libraries for .NET Compared: Which One Should You Choose?"
+---
+
+Every .NET app eventually needs to run something outside the request/response cycle - sending an email, processing an upload, running a nightly report. The honest starting point before comparing libraries at all: .NET already ships with enough for the simplest case, a `BackgroundService` with a `PeriodicTimer`. What you give up with that approach is real, though - no persistence, no retry policy, no job history, no cron expressions, no coordination across instances, and an unhandled exception silently kills the loop for the rest of the process's lifetime. It's fine for one job in one app. It stops scaling around the third job.
+
+This guide compares the five tools .NET developers reach for once they've outgrown a hand-rolled `BackgroundService`: Hangfire, Quartz.NET, Coravel, Azure Functions (timer triggers), and Wolverine. They're not all solving the same problem - some are schedulers, one is a full messaging framework that happens to include scheduling, and one is a managed cloud runtime rather than a library at all - so "which is best" matters less here than "which actually matches what you're building." This series continues with dedicated getting-started walkthroughs for each option.
+
+## Quick Comparison
+
+| | Hangfire | Quartz.NET | Coravel | Azure Functions (Timer) | Wolverine |
+| --- | --- | --- | --- | --- | --- |
+| **Category** | In-process job processor | In-process enterprise scheduler | In-process lightweight scheduler | Managed serverless runtime | Messaging framework with scheduling |
+| **Persistence** | Yes - SQL Server, Redis, and others | Yes - ADO.NET job store, or in-memory | None - in-memory only | Managed by Azure | Yes - via durable outbox (SQL Server, PostgreSQL/Marten) |
+| **Dashboard** | Yes, built in and polished | No - pair with external logging/monitoring | No | Application Insights integration | No dedicated dashboard |
+| **Clustering** | Yes, via shared storage | Yes, purpose-built for it | No - single instance assumed | Native, managed by the platform | Yes, as part of distributed messaging |
+| **Setup effort** | Low | Moderate - more configuration | Lowest | Low, but ties you to Azure | Moderate - broader scope than "just scheduling" |
+| **Best for** | Most teams wanting fire-and-forget/recurring jobs with visibility | Complex scheduling rules, clustering, enterprise precision | Small apps, zero-infrastructure scheduling | Cloud-native, event-driven, elastic workloads | Teams already doing message-driven architecture who want scheduling unified with it |
+
+## Hangfire
+
+Hangfire is the most widely adopted background job library in .NET, and for most teams it's the right first stop - fire-and-forget, delayed, and recurring jobs, backed by persistent storage, with a genuinely excellent built-in dashboard for visibility into job state.
+
+**Strengths:**
+
+- Rapid setup - a NuGet package, a storage connection string, and you're running jobs within your existing ASP.NET Core host, no separate process needed
+- The dashboard is a real differentiator: job history, retry status, and failure details are visible out of the box, without wiring up separate monitoring
+- Built-in retry logic handles transient failures without you writing retry loops yourself
+- Mature and extremely widely used, so documentation, examples, and Stack Overflow coverage are abundant
+
+**Weaknesses:**
+
+- Storage load is proportional to polling, not job volume - for a handful of nightly jobs, you're still running database queries every few seconds indefinitely to check what's due
+- In-process by nature: if your app isn't running (deploying, crashed, an idle app pool), nothing gets scheduled, and there's no external process watching for that
+- Some advanced features are gated behind Hangfire Pro, a commercial add-on, worth knowing before assuming everything is free
+
+**Choose this when:** you want fast setup, built-in visibility, and reliable retry handling for typical background work - email sending, report generation, order processing - without adopting a broader messaging architecture just to get scheduling.
+
+## Quartz.NET
+
+Quartz.NET is the enterprise-grade scheduler in this list - a .NET port of Java's Quartz, built for scheduling rules that are genuinely complex: time zone-aware triggers, jobs that must never overlap, clustered deployments coordinating who runs what.
+
+**Strengths:**
+
+- Sophisticated scheduling semantics that Hangfire's simpler model doesn't attempt to match - cron expressions, calendar exclusions (skip holidays), misfire handling policies
+- Purpose-built clustering support for coordinating job execution across multiple instances without duplicate runs
+- Extremely mature and stable, with over a decade of production use across large enterprise .NET systems
+
+**Weaknesses:**
+
+- More configuration and conceptual overhead than Hangfire for equivalent basic scheduling - Quartz.NET's power comes with real setup complexity
+- No built-in dashboard - monitoring and visibility need to be assembled from logging and external tooling rather than coming for free
+- Community discussion consistently describes it as more complex than it needs to be for teams whose scheduling needs are actually simple
+
+**Choose this when:** your scheduling rules are genuinely hard - specific time zones, calendar-aware exclusions, strict non-overlap guarantees, or clustered coordination - not just "run this every night."
+
+## Coravel
+
+Coravel is the simplest tool in this comparison, deliberately - fluent, in-process scheduling with zero external infrastructure. No database, no dashboard, no separate service to stand up.
+
+**Strengths:**
+
+- Genuinely minimal setup - a NuGet package and a fluent scheduling API, nothing else to provision or configure
+- Readable, chainable syntax (`.Schedule(...).EveryFiveMinutes()`) that's easy to understand at a glance without learning cron syntax if you don't want to
+- Also bundles lightweight queuing and caching helpers beyond just scheduling, useful for small apps that want a few conveniences without several separate libraries
+
+**Weaknesses:**
+
+- No persistence at all - a restart loses all schedule state, and Coravel assumes a single instance; there's no coordination mechanism for multiple instances
+- No dashboard or built-in job history, so visibility into what ran and what failed is entirely on you to build
+- Doesn't scale conceptually past a small number of straightforward jobs in a single-instance app - it's not trying to be Hangfire or Quartz.NET at a larger scale
+
+**Choose this when:** you have a small number of simple recurring tasks in a single-instance application and want the absolute lowest setup friction, with no infrastructure to provision.
+
+## Azure Functions (Timer Triggers)
+
+Azure Functions with a timer trigger is a fundamentally different category from the other four - it's not a library you add to an existing app, it's a managed, serverless execution model where your background work runs as its own deployable unit, independent of any web app's lifecycle.
+
+**Strengths:**
+
+- Genuinely decoupled from your application's lifecycle - a timer-triggered function runs on Azure's schedule regardless of whether your main web app is up, deploying, or scaled to zero
+- Elastic, consumption-based scaling fits bursty or unpredictable background workloads without you managing infrastructure capacity
+- Deep integration with Application Insights gives strong observability without assembling it yourself
+- Fits naturally into a broader event-driven architecture if you're already using other Azure trigger types (queues, blobs, Service Bus)
+
+**Weaknesses:**
+
+- Real dependency on Azure specifically - portability to another cloud or on-premises becomes a genuine migration project, not a configuration change
+- Cold-start behavior and cost governance need deliberate design attention, especially on consumption-based plans
+- Requires disciplined trigger, retry, and idempotency design on your part - the platform handles execution, not correctness of your job logic under retries or duplicate triggers
+
+**Choose this when:** cloud-native scale and event-driven automation are core to your platform strategy, especially if you're already invested in the Azure ecosystem and want background work decoupled from any single app's process lifecycle.
+
+## Wolverine
+
+Wolverine is the outlier here - not a scheduler first, but a messaging and command-processing framework (built by Jeremy Miller, the same author behind Lamar and Marten) that happens to include scheduled and delayed message delivery as one part of a much broader scope: in-process mediation, distributed messaging over RabbitMQ or Azure Service Bus, a durable transactional outbox, and saga orchestration, all under one handler convention.
+
+**Strengths:**
+
+- If you're already doing (or planning) message-driven architecture, Wolverine unifies in-process command handling, distributed messaging, and scheduled jobs under one consistent model instead of stitching together separate libraries for each
+- Built with compile-time source generation rather than runtime reflection, giving it a real performance edge over reflection-based alternatives like MediatR
+- The built-in durable outbox (with SQL Server or PostgreSQL/Marten) gives scheduled and published messages genuine delivery guarantees, not just best-effort execution
+
+**Weaknesses:**
+
+- Meaningfully broader in scope than "I just need a background job scheduler" - adopting Wolverine for scheduling alone means taking on a full messaging framework's conceptual surface area
+- Smaller community and less "background jobs" brand recognition than Hangfire or Quartz.NET, since it's not primarily marketed or known as a scheduler
+- No dedicated visibility dashboard the way Hangfire offers - monitoring is more DIY, consistent with its broader messaging-framework identity
+
+**Choose this when:** you're already building (or planning to build) a message-driven system - CQRS, event-driven communication between services - and want scheduled/delayed jobs to share the same handler model and delivery guarantees as the rest of your messaging, rather than bolting on a separate scheduler.
+
+## How to Decide
+
+A few heuristics that cover most real-world decisions:
+
+**Want fast setup, solid retry handling, and built-in visibility for typical background work?** Hangfire is the right default - it's the most widely adopted for good reason, and the dashboard alone saves real time compared to assembling monitoring yourself.
+
+**Have genuinely complex scheduling rules or need clustered coordination?** Quartz.NET's purpose-built support for calendar exclusions, time zones, and clustering handles cases Hangfire's simpler model wasn't designed for.
+
+**Building something small with a handful of jobs and want zero infrastructure?** Coravel gets you there fastest, with the explicit trade-off of no persistence and no multi-instance support.
+
+**Cloud-native, event-driven, and already invested in Azure?** Timer-triggered Azure Functions decouple background work from your app's process lifecycle entirely, at the cost of real platform lock-in.
+
+**Already building (or planning) a message-driven system?** Wolverine's unified handler model across in-process mediation, distributed messaging, and scheduling avoids maintaining separate conventions for each - but it's the wrong tool if scheduling is genuinely your only need.
+
+One point worth remembering across all of the in-process options (Hangfire, Quartz.NET, Coravel): they only run while your app is running. If the host is down when a job is due, it silently doesn't happen - there's no external process watching for that failure. Azure Functions (or any externally-triggered scheduler) sidesteps this specific risk by design, which is worth weighing for anything where a missed run has real consequences.
+
+## Frequently Asked Questions
+
+### Do I need a library at all, or can I just use a plain BackgroundService?
+
+For a single, simple recurring task in a single-instance app, a plain `BackgroundService` with a `PeriodicTimer` is genuinely sufficient and adds zero dependencies. It stops being sufficient once you need persistence, retries, cron-style scheduling, visibility into job history, or coordination across multiple instances - that's the point where reaching for one of these five starts paying off.
+
+### What's the biggest practical difference between Hangfire and Quartz.NET?
+
+Hangfire optimizes for fast setup and out-of-the-box visibility via its dashboard; Quartz.NET optimizes for scheduling sophistication (time zones, calendar exclusions, strict clustering) at the cost of more configuration and no built-in dashboard. Most teams without genuinely complex scheduling requirements find Hangfire the lower-friction choice.
+
+### Is Coravel a real alternative to Hangfire, or just a toy?
+
+It's a real, production-viable tool for its intended scope - small applications with simple recurring jobs on a single instance. It's not a smaller Hangfire; it's a deliberately different trade-off that skips persistence and multi-instance coordination entirely in exchange for near-zero setup. It stops being the right choice the moment you need either of those things.
+
+### Why would I choose Wolverine over Hangfire if I just need scheduled jobs?
+
+Generally, you wouldn't, if scheduling is genuinely your only need - Wolverine's scope is much broader, and adopting it purely for scheduling means taking on a full messaging framework's conceptual overhead. Wolverine makes sense when you're already building message-driven architecture and want scheduling to share the same handler conventions and delivery guarantees as the rest of your messaging, not as a standalone scheduler choice.
+
+### What happens if my app isn't running when an in-process scheduled job is due?
+
+For Hangfire, Quartz.NET, and Coravel, nothing happens - the job simply doesn't run, silently, and there's no external process watching for that. This is a fundamental architectural trade-off of in-process scheduling, not a bug in any specific library. If a missed run needs to be detected and alerted on, you need either external monitoring watching for the job's expected side effects, or a scheduler that lives outside your app's process (like Azure Functions or a platform-level cron).
+
+### Does Azure Functions lock me into Azure specifically?
+
+Yes, in a meaningful way - migrating timer-triggered Azure Functions to another cloud or on-premises hosting is a real project, not a configuration change, since you're relying on Azure's specific trigger and hosting model. This is a reasonable trade-off if you're already committed to Azure, but worth weighing deliberately if platform portability matters to your organization.
+
+### Can I use more than one of these in the same application?
+
+Yes, and it's not unusual - for example, Hangfire for typical fire-and-forget application jobs, alongside Azure Functions for genuinely decoupled, event-driven work that shouldn't depend on your web app's process lifecycle. Just be deliberate about which jobs belong where rather than splitting similar work across tools without a clear reason.

--- a/src/posts/2027-11-02-getting-started-with-hangfire.md
+++ b/src/posts/2027-11-02-getting-started-with-hangfire.md
@@ -1,0 +1,180 @@
+---
+author: Steve Kaschimer
+date: 2027-11-02
+image: /images/posts/2027-11-02-hero.webp
+image_alt: "A small dashboard-panel glyph with a job-list icon inside it, connected to a locked badge implying the panel requires authorization before it can be viewed."
+image_prompt: "A dark-mode technical editorial illustration on a near-black background with electric teal, amber, and off-white accents. Composition centers on a flat rectangular dashboard panel containing three thin horizontal job-row lines, each with a small status dot. A solid amber lock badge sits in the panel's corner, implying authorization required before access. A faint polling-clock icon pulses beneath the panel, implying a recurring background check. Mood is polished, visible, and appropriately guarded. Avoid: vendor logos, brand colors, circuit-board textures, gears, or generic checkmark clip art."
+layout: post.njk
+site_title: Tech Notes
+summary: "Hangfire's install-to-first-job time is genuinely a few minutes, and that speed is exactly why it's easy to skip the two decisions that determine whether it stays cheap to run. A setup guide for storage, securing the dashboard, and fire-and-forget, delayed, and recurring jobs."
+tags: ["dotnet", "tooling", "architecture", "developer-productivity"]
+title: "Getting Started with Hangfire in .NET"
+---
+
+Hangfire's install-to-first-job time is genuinely a few minutes, and that speed is exactly why it's easy to skip the two decisions that determine whether it stays cheap to run: what storage backend you point it at, and how much you rely on the polling interval defaults. Neither is complicated, but both are easy to leave on autopilot in a way that quietly costs you either database load or missed reliability guarantees.
+
+This guide covers installing Hangfire, bootstrapping storage and the dashboard correctly, the core patterns for fire-and-forget, delayed, and recurring jobs, and the best practices that keep Hangfire's polling model from becoming its own performance problem. By the end you'll have a background job setup with real visibility into what's running and what's failed.
+
+If you're deciding between background job libraries first, [a comparison of the top .NET background job libraries](/posts/2027-10-26-top-5-dotnet-background-job-libraries-compared/) covers where Hangfire fits relative to Quartz.NET, Coravel, Azure Functions, and Wolverine.
+
+## What You'll Need
+
+- .NET 8 SDK or later
+- A storage backend - SQL Server is the most common, though Redis, PostgreSQL, and others are supported via separate storage packages
+
+## Installing Hangfire
+
+```bash
+dotnet add package Hangfire.AspNetCore
+dotnet add package Hangfire.SqlServer
+```
+
+## Bootstrapping the Ideal Environment
+
+### Registering Hangfire and its storage
+
+```csharp
+var builder = WebApplication.CreateBuilder(args);
+
+builder.Services.AddHangfire(config => config
+    .SetDataCompatibilityLevel(CompatibilityLevel.Version_180)
+    .UseSimpleAssemblyNameTypeSerializer()
+    .UseRecommendedSerializerSettings()
+    .UseSqlServerStorage(builder.Configuration.GetConnectionString("Hangfire")));
+
+builder.Services.AddHangfireServer();
+
+var app = builder.Build();
+app.UseHangfireDashboard();
+app.Run();
+```
+
+`AddHangfireServer()` is what actually processes jobs - without it, jobs get enqueued into storage but nothing picks them up. This is a common first mistake: registering Hangfire's client-side services and forgetting the server component entirely.
+
+### Secure the dashboard before it goes anywhere near production
+
+By default, `UseHangfireDashboard()` is accessible to anyone who can reach the URL. Restrict it:
+
+```csharp
+app.UseHangfireDashboard("/jobs", new DashboardOptions
+{
+    Authorization = [new HangfireDashboardAuthorizationFilter()]
+});
+```
+
+```csharp
+public class HangfireDashboardAuthorizationFilter : IDashboardAuthorizationFilter
+{
+    public bool Authorize(DashboardContext context)
+    {
+        var httpContext = context.GetHttpContext();
+        return httpContext.User.Identity?.IsAuthenticated == true
+            && httpContext.User.IsInRole("Admin");
+    }
+}
+```
+
+An unsecured Hangfire dashboard exposed publicly is a real, well-known security risk - it shows job details and, depending on configuration, can let visitors trigger job execution.
+
+## Core Workflow
+
+### Fire-and-forget jobs
+
+```csharp
+public class OrderController(IBackgroundJobClient backgroundJobs) : ControllerBase
+{
+    [HttpPost("{id}/notify")]
+    public IActionResult NotifyCustomer(int id)
+    {
+        backgroundJobs.Enqueue<INotificationService>(svc => svc.SendOrderConfirmationAsync(id));
+        return Accepted();
+    }
+}
+```
+
+### Delayed jobs
+
+```csharp
+backgroundJobs.Schedule<IOrderService>(
+    svc => svc.CancelIfUnpaidAsync(orderId),
+    TimeSpan.FromHours(24));
+```
+
+### Recurring jobs
+
+```csharp
+RecurringJob.AddOrUpdate<IReportService>(
+    "daily-sales-report",
+    svc => svc.GenerateDailySalesReportAsync(),
+    Cron.Daily);
+```
+
+`AddOrUpdate` is idempotent by design - calling it again with the same ID and a changed cron expression updates the existing recurring job rather than creating a duplicate, which matters for how you register recurring jobs at startup without accumulating stale entries across deployments.
+
+### Continuations for job chains
+
+```csharp
+var jobId = backgroundJobs.Enqueue<IOrderService>(svc => svc.ProcessAsync(orderId));
+backgroundJobs.ContinueJobWith<INotificationService>(jobId, svc => svc.SendProcessedNotificationAsync(orderId));
+```
+
+## Verifying Your Setup
+
+1. **`AddHangfireServer()` is registered, not just `AddHangfire()`** - confirm enqueued jobs actually execute, not just sit in storage
+2. **The dashboard requires authentication** - confirm an unauthenticated request to your dashboard path is rejected
+3. **Recurring jobs survive a redeploy** - confirm `RecurringJob.AddOrUpdate` calls at startup don't create duplicates on each deploy
+4. **Storage load is reasonable for your job volume** - for a small number of infrequent jobs, confirm the polling interval isn't generating excessive database load relative to actual job frequency
+
+## Best Practices
+
+**Always register `AddHangfireServer()` alongside `AddHangfire()`.** Forgetting it is the most common "my jobs aren't running" issue, and it's silent - no error, just jobs that never execute.
+
+**Secure the dashboard before any non-local deployment.** This isn't optional hardening - an open Hangfire dashboard is a known, actively scanned-for exposure.
+
+**Use `AddOrUpdate` with a stable, explicit job ID for recurring jobs, registered at startup.** This keeps recurring job registration idempotent across deployments instead of accumulating duplicates or orphaned entries.
+
+**Keep job methods idempotent where possible.** Retries (automatic on failure) and rare double-execution scenarios mean a job that isn't safe to run twice can cause real problems - design job logic defensively.
+
+**Be aware storage load scales with polling, not job volume.** For very infrequent jobs, Hangfire's default polling still queries your database regularly - factor this into database load planning, especially on a shared or cost-sensitive instance.
+
+## Comparison with Quartz.NET
+
+| | Hangfire | Quartz.NET |
+| --- | --- | --- |
+| Setup effort | Low | Moderate - more configuration |
+| Dashboard | Yes, built in | No - external tooling needed |
+| Scheduling sophistication | Good for common cases | Purpose-built for complex rules (time zones, calendars, non-overlap) |
+| Clustering | Yes, via shared storage | Yes, purpose-built |
+| Best fit | Most teams wanting jobs with visibility | Genuinely complex scheduling requirements |
+
+Hangfire wins on setup speed and out-of-the-box visibility; Quartz.NET wins when your scheduling rules are complex enough that Hangfire's simpler model doesn't cleanly express them.
+
+## Frequently Asked Questions
+
+### Why aren't my Hangfire jobs running even though they're enqueued?
+
+The most common cause is forgetting `builder.Services.AddHangfireServer()` - without it, jobs are stored but nothing processes them. Confirm both `AddHangfire` (client-side registration) and `AddHangfireServer` (the worker that processes jobs) are both registered.
+
+### Is the Hangfire dashboard safe to expose publicly?
+
+Not without authorization configured. By default it's accessible to anyone who reaches the URL, which is a real security exposure - always configure an `IDashboardAuthorizationFilter` restricting access before deploying anywhere beyond local development.
+
+### How do I avoid duplicate recurring jobs across deployments?
+
+Use `RecurringJob.AddOrUpdate` with a stable, explicit job ID string, called at application startup. Because it's idempotent by ID, redeploying doesn't create duplicates - it updates the existing job if its schedule or method reference changed.
+
+### Does Hangfire guarantee a job runs exactly once?
+
+Not strictly - Hangfire targets at-least-once execution, meaning retries after a failure (or rare edge cases around worker crashes) can result in a job running more than once. Design job logic to be idempotent (safe to run twice) rather than assuming exactly-once semantics.
+
+### What database load should I expect from Hangfire?
+
+Load is driven primarily by polling frequency, not actual job volume - Hangfire's server periodically checks storage for due jobs regardless of how many jobs you actually have. For a small number of infrequent jobs, this constant polling can be disproportionate to your actual workload; factor it into your database capacity planning.
+
+### Can I use Hangfire without SQL Server?
+
+Yes - Redis, PostgreSQL, and other storage backends are supported via their own Hangfire storage packages (`Hangfire.Redis.StackExchange`, `Hangfire.PostgreSql`, and others). SQL Server is simply the most common and best-documented choice.
+
+### What's the most common mistake in a first Hangfire setup?
+
+Forgetting `AddHangfireServer()`, and deploying the dashboard without authorization configured. Both are easy to fix once known, but both fail silently or dangerously (respectively) if missed - worth checking explicitly rather than assuming the defaults are production-safe.

--- a/src/posts/2027-11-09-getting-started-with-quartznet.md
+++ b/src/posts/2027-11-09-getting-started-with-quartznet.md
@@ -1,0 +1,183 @@
+---
+author: Steve Kaschimer
+date: 2027-11-09
+image: /images/posts/2027-11-09-hero.webp
+image_alt: "A layered job/trigger/scheduler stack of three thin rectangles, with a small calendar-exclusion marker crossing out one date on a connected timeline."
+image_prompt: "A dark-mode technical editorial illustration on a near-black background with electric teal, amber, and off-white accents. Composition centers on three thin horizontal rectangles stacked with visible gaps between them, each labeled by position rather than text (bottom = job, middle = trigger, top = scheduler), connected by short vertical teal lines showing the layered relationship. Beside the stack, a short timeline with several evenly spaced dots has one dot crossed out in amber, implying a calendar exclusion. Mood is precise, enterprise, and deliberately layered. Avoid: vendor logos, brand colors, circuit-board textures, gears, or generic calendar clip art as the dominant motif."
+layout: post.njk
+site_title: Tech Notes
+summary: "Quartz.NET's reputation for complexity is earned, but it's complexity in service of a specific thing: scheduling rules that are genuinely hard to express correctly. A setup guide for the job/trigger/scheduler model, clustering, and calendar exclusions."
+tags: ["dotnet", "tooling", "architecture", "developer-productivity"]
+title: "Getting Started with Quartz.NET in .NET"
+---
+
+Quartz.NET's reputation for complexity is earned, but it's complexity in service of a specific thing: scheduling rules that are genuinely hard to express correctly. "Every weekday at 9am in the customer's local time zone, except public holidays, and never let two runs overlap" is a real requirement some systems have, and it's exactly the kind of rule Hangfire's simpler cron-based model wasn't built to express cleanly. Understanding Quartz.NET's core vocabulary - jobs, triggers, and schedulers as distinct concepts - is most of what makes the rest of it click.
+
+This guide covers installing Quartz.NET, bootstrapping it with ASP.NET Core's hosting model and persistent job storage, the core job/trigger/scheduler workflow, and the best practices that make the most of its scheduling sophistication without drowning in configuration. By the end you'll have a scheduler capable of handling rules that would be awkward or impossible to express in a simpler tool.
+
+If you're deciding between background job libraries first, [a comparison of the top .NET background job libraries](/posts/2027-10-26-top-5-dotnet-background-job-libraries-compared/) covers where Quartz.NET fits relative to Hangfire, Coravel, Azure Functions, and Wolverine.
+
+## What You'll Need
+
+- .NET 8 SDK or later
+- A database if you want persistent job storage (`AdoJobStore`) - in-memory storage is available for simpler scenarios but doesn't survive a restart
+
+## Installing Quartz.NET
+
+```bash
+dotnet add package Quartz
+dotnet add package Quartz.Extensions.Hosting
+dotnet add package Quartz.Extensions.DependencyInjection
+```
+
+For persistent storage:
+
+```bash
+dotnet add package Quartz.Serialization.Json
+```
+
+## Bootstrapping the Ideal Environment
+
+### Three core concepts before any code
+
+- **Job** - the actual work to perform, implemented as a class
+- **Trigger** - when and how often the job should run (a cron expression, a simple interval, or a one-time fire)
+- **Scheduler** - the runtime that pairs jobs with triggers and executes them
+
+This separation is deliberate and is what enables scenarios Hangfire's model doesn't cleanly support - the same job class can have multiple triggers, or a trigger can be reconfigured without touching the job's logic.
+
+### Registering Quartz with ASP.NET Core's hosting model
+
+```csharp
+var builder = WebApplication.CreateBuilder(args);
+
+builder.Services.AddQuartz(q =>
+{
+    var jobKey = new JobKey("DailySalesReport");
+    q.AddJob<DailySalesReportJob>(opts => opts.WithIdentity(jobKey));
+
+    q.AddTrigger(opts => opts
+        .ForJob(jobKey)
+        .WithIdentity("DailySalesReport-trigger")
+        .WithCronSchedule("0 0 6 * * ?")); // 6 AM daily
+});
+
+builder.Services.AddQuartzHostedService(opts => opts.WaitForJobsToComplete = true);
+
+var app = builder.Build();
+app.Run();
+```
+
+`WaitForJobsToComplete = true` ensures a graceful shutdown waits for in-flight jobs to finish rather than killing them mid-execution - worth setting explicitly rather than leaving at the default.
+
+### Defining a job
+
+```csharp
+public class DailySalesReportJob(IReportService reportService, ILogger<DailySalesReportJob> logger) : IJob
+{
+    public async Task Execute(IJobExecutionContext context)
+    {
+        logger.LogInformation("Generating daily sales report");
+        await reportService.GenerateDailySalesReportAsync();
+    }
+}
+```
+
+Jobs are resolved through DI automatically when registered via `AddJob<T>`, so constructor injection works the same as anywhere else in your application.
+
+### Persistent storage, so schedules survive a restart
+
+```csharp
+builder.Services.AddQuartz(q =>
+{
+    q.UsePersistentStore(store =>
+    {
+        store.UseProperties = true;
+        store.UseJsonSerializer();
+        store.UseSqlServer(builder.Configuration.GetConnectionString("Quartz")!);
+        store.UseClustering(); // enable if running multiple instances
+    });
+});
+```
+
+`UseClustering()` is what allows multiple instances of your application to share the same job store without duplicate execution - Quartz.NET coordinates which node runs a given trigger, which is exactly the clustering support Hangfire lacks natively.
+
+### Calendar exclusions, for rules Hangfire can't express
+
+```csharp
+q.AddCalendar<HolidayCalendar>("holidays", new HolidayCalendar(), replace: true, updateTriggers: true);
+
+q.AddTrigger(opts => opts
+    .ForJob(jobKey)
+    .WithCronSchedule("0 0 9 * * MON-FRI")
+    .ModifiedByCalendar("holidays"));
+```
+
+This is the kind of scheduling rule - "every weekday, except these specific dates" - that's genuinely awkward to express without a calendar-aware scheduler.
+
+## Core Workflow
+
+- **Define jobs as classes implementing `IJob`, resolved through DI.** Keep job logic itself thin, delegating to injected application services the same discipline as any other entry point.
+- **Use triggers to express *when*, keeping that separate from job logic.** A job shouldn't know or care about its own schedule - that's the trigger's responsibility, which is what lets you reschedule without touching job code.
+- **Enable clustering explicitly if running multiple instances.** Without it, multiple instances each independently think they should run every trigger, causing duplicate execution.
+
+## Verifying Your Setup
+
+1. **Jobs execute on the expected schedule** - confirm a test job with a short interval trigger fires as expected before trusting a production cron schedule
+2. **Persistent storage survives a restart** - confirm scheduled triggers are still present and correctly timed after restarting the application
+3. **Clustering prevents duplicate execution** - if running multiple instances, confirm a given trigger fires exactly once across the cluster, not once per instance
+4. **Graceful shutdown waits for in-flight jobs** - confirm `WaitForJobsToComplete` is behaving as expected during a deploy
+
+## Best Practices
+
+**Keep jobs stateless and idempotent where possible.** The same defensive design principle that applies to any scheduled or retried work - a job that isn't safe to occasionally run twice (due to a misfire recovery, for instance) can cause real problems.
+
+**Use `UseClustering()` deliberately, not by default, and only when actually running multiple instances.** It adds real coordination overhead that's unnecessary for a single-instance deployment.
+
+**Reach for calendar exclusions and complex cron expressions only when you actually need them.** If your scheduling need is genuinely "run this every night," Quartz.NET's power is mostly unused overhead compared to a simpler tool - its complexity earns its keep specifically on hard scheduling rules.
+
+**Set misfire instructions deliberately for triggers where a missed fire matters.** Quartz.NET lets you configure what happens if a trigger's scheduled time passes while the scheduler was down (fire immediately, skip, or a custom policy) - the default may not match what you actually want for a given job.
+
+**Pair with external logging/monitoring since there's no built-in dashboard.** Quartz.NET doesn't give you Hangfire's out-of-the-box visibility - plan for how you'll observe job execution and failures from the start.
+
+## Comparison with Hangfire
+
+| | Quartz.NET | Hangfire |
+| --- | --- | --- |
+| Setup effort | Moderate - more configuration | Low |
+| Dashboard | None built in | Yes, built in |
+| Scheduling sophistication | Purpose-built for complex rules | Good for common cases |
+| Clustering | Purpose-built, explicit | Via shared storage |
+| Best fit | Genuinely complex scheduling requirements | Most teams wanting jobs with visibility |
+
+Quartz.NET is the right choice specifically when your scheduling rules are hard enough that Hangfire's simpler model becomes awkward - for typical recurring/delayed job needs, Hangfire's faster setup and built-in dashboard usually win out.
+
+## Frequently Asked Questions
+
+### Do I need persistent storage, or is in-memory scheduling enough?
+
+In-memory storage is fine for scenarios where losing schedule state on a restart is acceptable - development, or genuinely stateless recurring work that gets re-registered at startup anyway. For anything where a specific one-time trigger needs to survive a restart (a delayed job scheduled for a future date, for example), persistent storage via `UsePersistentStore` is necessary.
+
+### How does clustering prevent duplicate job execution?
+
+When `UseClustering()` is enabled with a shared persistent store, Quartz.NET instances coordinate through that shared store to determine which node should fire a given trigger, rather than each instance independently deciding to run it. This requires all clustered instances to point at the same database.
+
+### What's the difference between a job and a trigger?
+
+A job is the work itself - a class implementing `IJob` with an `Execute` method. A trigger defines when that job runs - a cron schedule, a simple interval, or a one-time fire. This separation lets the same job have multiple triggers, or a trigger be modified independently of the job's logic.
+
+### Does Quartz.NET have a dashboard like Hangfire's?
+
+Not built in - Quartz.NET doesn't ship with visibility tooling the way Hangfire does. Some third-party dashboards exist, and pairing Quartz.NET with your existing logging and monitoring stack is the more common approach for observing job execution and failures.
+
+### How do I handle a trigger that was missed because the scheduler was down?
+
+Configure a misfire instruction on the trigger, which tells Quartz.NET what to do when a scheduled fire time has passed without executing - options include firing immediately once the scheduler is back, skipping to the next scheduled time, or custom handling depending on the trigger type. The right choice depends on whether a missed run needs to happen late or is fine being skipped.
+
+### When is Quartz.NET overkill?
+
+When your actual scheduling need is simple - "run this job every night at 2 AM," with no time zone complexity, calendar exclusions, or strict non-overlap requirements. In that case, Quartz.NET's configuration overhead isn't buying you anything a simpler tool like Hangfire wouldn't already handle with less setup.
+
+### What's the most common mistake in a first Quartz.NET setup?
+
+Reaching for it when the actual scheduling need is simple, taking on real configuration complexity for no corresponding benefit. The second common mistake is forgetting `UseClustering()` when running multiple instances, leading to the same job firing once per instance instead of once total.

--- a/src/posts/2027-11-16-getting-started-with-coravel.md
+++ b/src/posts/2027-11-16-getting-started-with-coravel.md
@@ -1,0 +1,146 @@
+---
+author: Steve Kaschimer
+date: 2027-11-16
+image: /images/posts/2027-11-16-hero.webp
+image_alt: "A minimal single fluent-arrow glyph with no supporting infrastructure beneath it, chained through three small readable link segments ending in a plain clock marker."
+image_prompt: "A dark-mode technical editorial illustration on a near-black background with electric teal, amber, and off-white accents. Composition centers on a single thin teal arrow built from three small connected link segments, chained left to right, terminating in a plain unadorned clock marker with no cylinder, database, or panel shape anywhere beneath it, emphasizing zero supporting infrastructure. Mood is minimal, fast, and unburdened. Avoid: vendor logos, brand colors, circuit-board textures, gears, or generic clock clip art as the dominant motif."
+layout: post.njk
+site_title: Tech Notes
+summary: "Coravel's whole value proposition is that it doesn't ask you for anything - no database, no storage configuration, no dashboard to secure. A setup guide for the fluent scheduling API, PreventOverlapping, and knowing exactly where its zero-infrastructure boundaries are."
+tags: ["dotnet", "tooling", "developer-productivity"]
+title: "Getting Started with Coravel in .NET"
+---
+
+Coravel's whole value proposition is that it doesn't ask you for anything - no database, no storage configuration, no dashboard to secure. You add a package, write a fluent scheduling expression, and you're done. That simplicity is genuinely the point, not a limitation to work around, but it does mean the setup guide for Coravel is mostly about knowing exactly where its boundaries are, so you don't discover them the hard way after a restart wipes your schedule state.
+
+This guide covers installing Coravel, bootstrapping its scheduler (and its optional queuing and caching helpers), the core scheduling workflow, and the best practices for using Coravel specifically within the scope it's designed for. By the end you'll know exactly when Coravel's zero-infrastructure model is the right fit and when it's time to graduate to something with persistence.
+
+If you're deciding between background job libraries first, [a comparison of the top .NET background job libraries](/posts/2027-10-26-top-5-dotnet-background-job-libraries-compared/) covers where Coravel fits relative to Hangfire, Quartz.NET, Azure Functions, and Wolverine.
+
+## What You'll Need
+
+- .NET 8 SDK or later
+- Nothing else - no database, no external service, which is the entire point
+
+## Installing Coravel
+
+```bash
+dotnet add package Coravel
+```
+
+## Bootstrapping the Ideal Environment
+
+### Registering the scheduler
+
+```csharp
+var builder = WebApplication.CreateBuilder(args);
+
+builder.Services.AddScheduler();
+builder.Services.AddTransient<DailySalesReportJob>();
+
+var app = builder.Build();
+
+app.Services.UseScheduler(scheduler =>
+{
+    scheduler.Schedule<DailySalesReportJob>()
+        .DailyAtHour(6)
+        .PreventOverlapping("daily-sales-report");
+});
+
+app.Run();
+```
+
+`PreventOverlapping` is worth using by default on any job whose execution time could plausibly exceed its scheduling interval - it stops a slow-running job from starting a second overlapping execution before the first finishes.
+
+### Defining an invocable job
+
+```csharp
+public class DailySalesReportJob(IReportService reportService, ILogger<DailySalesReportJob> logger) : IInvocable
+{
+    public async Task Invoke()
+    {
+        logger.LogInformation("Generating daily sales report");
+        await reportService.GenerateDailySalesReportAsync();
+    }
+}
+```
+
+`IInvocable` is Coravel's job interface - register the class with DI, and Coravel resolves it fresh for each invocation, so constructor injection works normally.
+
+### Coravel's fluent scheduling API
+
+```csharp
+scheduler.Schedule<CleanupTempFilesJob>().Hourly();
+scheduler.Schedule<SendDigestEmailJob>().Weekly().Monday().At(9, 0);
+scheduler.Schedule<HealthCheckJob>().EveryFiveMinutes();
+scheduler.Schedule<CustomCronJob>().Cron("0 */3 * * *"); // cron is also supported directly
+```
+
+The fluent syntax covers the common cases readably; cron expressions remain available directly for anything the fluent API doesn't have a named method for.
+
+## Core Workflow
+
+- **Schedule jobs at startup, once, in `UseScheduler`.** There's no runtime API for dynamically adding schedules the way some other tools support - Coravel's scheduling is defined declaratively when the app starts.
+- **Use `PreventOverlapping` for anything whose duration is uncertain.** Without it, a slow job and a short interval can result in overlapping executions competing for the same resources.
+- **Remember schedule state doesn't persist.** A restart clears everything - Coravel re-registers the schedule from your `UseScheduler` code on every startup, which is fine since nothing was meant to persist independently of that code anyway.
+
+## Verifying Your Setup
+
+1. **Jobs fire on the expected schedule** - confirm a short-interval test job (like `EveryMinute()`) executes as expected before trusting a longer production schedule
+2. **`PreventOverlapping` is applied where needed** - for any job whose execution time could exceed its interval, confirm overlapping runs are actually prevented
+3. **Only one instance is running Coravel's scheduler, if you're horizontally scaled** - since Coravel has no built-in multi-instance coordination, confirm you're not accidentally running the same schedule redundantly across instances
+4. **Jobs are resolved through DI correctly** - confirm constructor-injected dependencies in your `IInvocable` classes resolve as expected
+
+## Best Practices
+
+**Use Coravel specifically for single-instance applications with a small number of straightforward jobs.** This is the scope it's designed for - stretching it beyond that (multiple instances, jobs needing persistence or history) means fighting the tool rather than using it as intended.
+
+**Always use `PreventOverlapping` unless you're certain a job's duration will never exceed its schedule interval.** This is cheap insurance against a slow job compounding into multiple overlapping executions.
+
+**If you scale to multiple instances, either accept redundant execution for idempotent jobs, or move to a tool with coordination support.** Coravel has no built-in mechanism to prevent every instance from independently running the same schedule - know this going in rather than discovering it in production.
+
+**Don't rely on Coravel for anything where a missed or failed job needs to be visible after the fact.** There's no dashboard or job history - if visibility into failures matters, either add your own logging/alerting around each job or reach for a tool (like Hangfire) that provides this natively.
+
+**Treat Coravel's queuing and caching helpers as convenient extras, not a reason alone to adopt it.** They're useful if you're already using Coravel for scheduling, but not compelling enough on their own to choose over dedicated caching (Redis, `IMemoryCache`) or queuing tools.
+
+## Comparison with Hangfire
+
+| | Coravel | Hangfire |
+| --- | --- | --- |
+| Setup effort | Lowest - zero infrastructure | Low, but requires storage |
+| Persistence | None | Yes |
+| Dashboard | None | Yes, built in |
+| Multi-instance coordination | None | Yes, via shared storage |
+| Best fit | Small apps, single instance, simple jobs | Most teams wanting jobs with visibility and durability |
+
+Coravel is the right choice specifically when Hangfire's infrastructure (a database, a dashboard to secure) is more than your application actually needs - the moment persistence, multi-instance coordination, or job visibility become real requirements, that's the signal to move to Hangfire or another tool with those features built in.
+
+## Frequently Asked Questions
+
+### Does Coravel survive an application restart?
+
+Not in the sense of preserving in-flight or missed job state - but your schedule itself is re-registered from your `UseScheduler` code every time the app starts, so recurring jobs continue on schedule going forward. What's lost is any state about jobs that were due or running at the moment of restart, since Coravel doesn't persist that anywhere.
+
+### Can I run Coravel across multiple instances of my app?
+
+Not with built-in coordination - Coravel has no mechanism to prevent multiple instances from each independently running the same scheduled job. If you scale horizontally, either ensure your jobs are safe to run redundantly (fully idempotent, low-cost), or move to a tool like Hangfire or Quartz.NET that coordinates execution across instances.
+
+### Does Coravel have a dashboard like Hangfire's?
+
+No - there's no built-in visibility into job history, execution status, or failures. If you need that, you're either building your own logging/alerting around each job, or Coravel isn't the right tool for that requirement.
+
+### How do I prevent a slow job from overlapping with its next scheduled run?
+
+Use `.PreventOverlapping("some-unique-key")` when scheduling the job. This ensures a new execution won't start while a previous one with the same key is still running, which is important for anything whose duration is uncertain relative to its scheduling interval.
+
+### What else does Coravel offer besides scheduling?
+
+Lightweight queuing (`IQueue`) for fire-and-forget background work, and a simple in-memory caching abstraction, both usable independently of the scheduler. They're convenient if you're already using Coravel, but not typically a reason to adopt it on their own over dedicated tools for those specific needs.
+
+### Should I start with Coravel and migrate to Hangfire later if I outgrow it?
+
+That's a reasonable path if you're genuinely unsure how much scheduling complexity you'll need - Coravel's low setup cost means starting there isn't a large sunk cost if you do outgrow it. Just recognize the signals early: needing job history, multi-instance coordination, or persistence across restarts are all clear indicators it's time to move to Hangfire or another tool built for those requirements.
+
+### What's the most common mistake in a first Coravel setup?
+
+Using it in a multi-instance deployment without realizing there's no coordination between instances, resulting in the same job running once per instance instead of once total. The second common mistake is skipping `PreventOverlapping` on a job whose execution time isn't reliably shorter than its schedule interval.

--- a/src/posts/2027-11-23-getting-started-with-wolverine.md
+++ b/src/posts/2027-11-23-getting-started-with-wolverine.md
@@ -1,0 +1,190 @@
+---
+author: Steve Kaschimer
+date: 2027-11-23
+image: /images/posts/2027-11-23-hero.webp
+image_alt: "A message-envelope glyph with a small embedded clock corner, connected to a two-part atomic-commit marker showing a database symbol and the envelope locked together as one unit."
+image_prompt: "A dark-mode technical editorial illustration on a near-black background with electric teal, amber, and off-white accents. Composition centers on a flat envelope-shaped glyph with a small amber clock icon tucked into its corner, implying scheduling folded into a broader messaging concept rather than standing alone. Beside it, a database-row icon and a second small envelope are joined by a solid teal bracket, implying they commit together as a single atomic unit. Mood is unified, deliberate, and broader in scope than the other posts in the series. Avoid: vendor logos, brand colors, circuit-board textures, gears, or generic database-cylinder clip art as the dominant motif."
+layout: post.njk
+site_title: Tech Notes
+summary: "Wolverine is the one entry in this series where getting started with background jobs and getting started with the whole library are almost the same document - scheduling is one feature of a much broader messaging framework. A setup guide for convention-based handlers, the durable outbox, and cron jobs versus delayed messages."
+tags: ["dotnet", "messaging", "architecture", "performance"]
+title: "Getting Started with Wolverine in .NET"
+---
+
+Wolverine is the one entry in this series where "getting started with background jobs" and "getting started with the whole library" are almost the same document - scheduling is one feature of a much broader messaging framework, not the framework's reason for existing. That's worth internalizing before you write any code: if you came here purely for a job scheduler, Wolverine's in-process mediation, distributed messaging, and durable outbox are all things you're adopting alongside scheduling, not optional extras you can ignore.
+
+This guide covers installing Wolverine, bootstrapping handlers and the durable outbox that gives scheduled and published messages real delivery guarantees, the core patterns for commands, events, and scheduled jobs under one handler model, and the best practices for using Wolverine's breadth deliberately rather than accidentally. By the end you'll understand both how to schedule background work in Wolverine and why that capability sits inside a larger design.
+
+If you're deciding between background job libraries first, [a comparison of the top .NET background job libraries](/posts/2027-10-26-top-5-dotnet-background-job-libraries-compared/) covers where Wolverine fits relative to Hangfire, Quartz.NET, Coravel, and Azure Functions - including why it's usually the wrong choice if scheduling is genuinely your only need.
+
+## What You'll Need
+
+- .NET 8 SDK or later
+- A database if you want the durable outbox - SQL Server or PostgreSQL (via Marten) are supported
+- Some familiarity with message-driven thinking (commands, events, handlers), since that's Wolverine's core vocabulary
+
+## Installing Wolverine
+
+```bash
+dotnet add package WolverineFx
+```
+
+For durable outbox support with SQL Server:
+
+```bash
+dotnet add package WolverineFx.SqlServer
+```
+
+## Bootstrapping the Ideal Environment
+
+### Registering Wolverine
+
+```csharp
+var builder = WebApplication.CreateBuilder(args);
+
+builder.Host.UseWolverine(opts =>
+{
+    opts.PersistMessagesWithSqlServer(builder.Configuration.GetConnectionString("Wolverine")!);
+    opts.Services.AddDbContext<AppDbContext>(dbOpts =>
+        dbOpts.UseSqlServer(builder.Configuration.GetConnectionString("Default")));
+});
+
+var app = builder.Build();
+app.Run();
+```
+
+Unlike MediatR, Wolverine doesn't require implementing `IRequest` or `IRequestHandler<T>` interfaces - handlers are discovered by naming and parameter convention, which is part of what keeps its handler code notably free of framework-specific ceremony.
+
+### Handlers: no interfaces required
+
+```csharp
+public record ProcessOrderCommand(int OrderId);
+
+public class ProcessOrderHandler
+{
+    public static async Task Handle(ProcessOrderCommand command, AppDbContext db, ILogger<ProcessOrderHandler> logger)
+    {
+        var order = await db.Orders.FindAsync(command.OrderId);
+        if (order is null) throw new OrderNotFoundException(command.OrderId);
+
+        order.Status = OrderStatus.Processing;
+        await db.SaveChangesAsync();
+
+        logger.LogInformation("Order {OrderId} processed", command.OrderId);
+    }
+}
+```
+
+Wolverine finds this handler by convention - a public method named `Handle` (or `HandleAsync`) taking the message type as its first parameter - and generates the dispatch code at compile time via source generators, rather than resolving it through runtime reflection the way MediatR does.
+
+### Scheduled jobs
+
+Wolverine has a distinct concept for background jobs specifically: scheduled jobs that send messages, separate from the message handling itself.
+
+```csharp
+public class CleanupExpiredOrdersJob
+{
+    public async Task ExecuteAsync(IMessageBus bus) =>
+        await bus.SendAsync(new CleanupExpiredOrdersCommand());
+}
+```
+
+```csharp
+builder.Host.UseWolverine(opts =>
+{
+    opts.Schedule.CronJob<CleanupExpiredOrdersJob>("0 */5 * * * ?");
+});
+```
+
+The job itself doesn't contain the actual cleanup logic - it sends a command, and a separate handler processes that command. This indirection is deliberate: it means the same durability, retry, and outbox guarantees that apply to any Wolverine message also apply to work triggered by a schedule.
+
+### The durable outbox: real delivery guarantees
+
+```csharp
+public class OrderService(IMessageBus bus, AppDbContext db)
+{
+    public async Task PlaceOrderAsync(Order order)
+    {
+        db.Orders.Add(order);
+        await bus.PublishAsync(new OrderPlacedEvent(order.Id));
+        await db.SaveChangesAsync(); // Wolverine coordinates this with the outbox
+    }
+}
+```
+
+With the outbox configured, the database write and the message publish are committed atomically - either both happen, or neither does. This solves a real, easy-to-miss reliability problem: publishing a message and then having the corresponding database transaction fail (or vice versa) leaves your system in an inconsistent state without an outbox coordinating the two.
+
+### Delayed messages, without a separate scheduling concept
+
+```csharp
+await bus.ScheduleAsync(new CancelIfUnpaidCommand(orderId), TimeSpan.FromHours(24));
+```
+
+Unlike the cron-based scheduled job above, this schedules a one-time message for future delivery - conceptually similar to Hangfire's `Schedule` method, but using the same message/handler model as everything else in Wolverine rather than a separate job API.
+
+## Core Workflow
+
+- **Model background work as messages with handlers, not standalone job classes.** This is the core mental shift from the other four tools in this series - Wolverine wants you thinking in commands and events, with scheduling as one way those messages get triggered.
+- **Use the durable outbox for anything where message delivery correctness matters**, not just for distributed messaging - even in-process publishing benefits from the same durability guarantees.
+- **Reserve cron-style scheduled jobs for genuinely recurring work, and delayed messages for one-time future execution.** Wolverine's `Schedule.CronJob` and `bus.ScheduleAsync` map to these two distinct needs respectively.
+
+## Verifying Your Setup
+
+1. **Handlers are discovered correctly** - confirm Wolverine's startup diagnostics (or a test message) show your handler being found by convention, not silently ignored due to a naming mismatch
+2. **The outbox is actually coordinating writes and publishes** - test a scenario where the database write would fail and confirm the corresponding message isn't published either
+3. **Scheduled jobs fire on their cron schedule** - confirm a `CronJob` registration executes at the expected interval
+4. **Delayed messages arrive at the expected time** - confirm `ScheduleAsync` messages are delivered close to their intended delay, not immediately or dropped
+
+## Best Practices
+
+**Don't adopt Wolverine purely for scheduling if that's genuinely your only need.** Its scope is much broader than a scheduler, and taking on that scope for one feature is a poor trade unless you're also getting value from its messaging capabilities.
+
+**Use the durable outbox whenever message delivery correctness actually matters.** The atomic coordination between database writes and message publishing is one of Wolverine's most concretely valuable features - underusing it means missing much of the reliability benefit of adopting Wolverine at all.
+
+**Keep handler methods focused and let Wolverine's middleware handle cross-cutting concerns.** Wolverine's middleware model integrates directly into the generated dispatch code (rather than a runtime pipeline), which is part of its performance advantage - use it for logging, validation, and transaction handling rather than repeating that logic in every handler.
+
+**Model scheduled cron jobs as message-senders, not as containers for the actual work.** The pattern shown above - a scheduled job sends a command, a separate handler does the work - keeps the same delivery guarantees and testability as any other Wolverine message.
+
+**If you're already using MediatR and considering Wolverine, evaluate it as a broader replacement, not a drop-in swap.** Wolverine's value is in unifying in-process mediation with messaging and scheduling - treating it as "MediatR but faster" undersells (and underuses) what it actually offers.
+
+## Comparison with Hangfire
+
+| | Wolverine | Hangfire |
+| --- | --- | --- |
+| Scope | Full messaging framework (in-process, distributed, scheduling) | Background job processing specifically |
+| Handler model | Convention-based, no interfaces, source-generated | `IBackgroundJobClient`, method expressions |
+| Delivery guarantees | Durable outbox, atomic with database writes | Retry-based, storage-backed |
+| Dashboard | None dedicated | Yes, built in |
+| Best fit | Teams already doing (or planning) message-driven architecture | Most teams wanting jobs with visibility |
+
+If your system's architecture is already (or heading toward) message-driven - CQRS, event-driven service communication - Wolverine unifying that with scheduling under one model is a real advantage. If you just need reliable background jobs with visibility, Hangfire remains the more direct fit.
+
+## Frequently Asked Questions
+
+### Do I need to use Wolverine's messaging features to use its scheduling, or can I use scheduling alone?
+
+Technically you can use just the scheduling pieces, but doing so means adopting Wolverine's full conceptual model (handlers, message dispatch, the outbox) for a feature set Hangfire or Quartz.NET would give you with far less overhead. If scheduling really is your only need, those tools are the more direct fit.
+
+### What's the difference between Schedule.CronJob and bus.ScheduleAsync?
+
+`Schedule.CronJob` registers a recurring job on a cron expression, evaluated at startup and run on that schedule going forward. `bus.ScheduleAsync` schedules a one-time message for delivery after a specified delay, called from application code at the point you want to schedule something - conceptually closer to Hangfire's `Schedule` method for delayed jobs.
+
+### How does Wolverine's durable outbox actually work?
+
+It coordinates a database transaction (via EF Core or Marten) with message publishing, so both are committed atomically as a single unit - if the database transaction fails, the message isn't published, and vice versa. This solves the classic "dual write" problem where publishing a message and writing to a database independently can end up inconsistent if one succeeds and the other fails.
+
+### Is Wolverine faster than MediatR?
+
+Generally yes, for in-process dispatch - Wolverine uses compile-time source generation to build dispatch code rather than MediatR's runtime reflection-based approach, which shows up as reduced startup cost and lower per-call overhead, particularly in larger applications with many handlers.
+
+### Does Wolverine require external infrastructure like RabbitMQ or Azure Service Bus?
+
+Not necessarily - Wolverine supports in-memory transport for purely in-process messaging and scheduling, with RabbitMQ, Azure Service Bus, and other transports available when you need genuinely distributed messaging between services. The durable outbox does require a database (SQL Server or PostgreSQL via Marten) if you want that specific guarantee.
+
+### Should I migrate from MediatR to Wolverine?
+
+Consider it if you're already finding yourself bolting distributed messaging, an outbox, or scheduling onto MediatR via separate libraries - Wolverine unifies those under one model. If MediatR is meeting your needs as a pure in-process mediator with no messaging ambitions, there's less urgency, though MediatR's shift toward commercial licensing is a separate factor worth weighing for some teams.
+
+### What's the most common mistake when adopting Wolverine?
+
+Adopting it purely for background job scheduling without realizing (or wanting) the broader messaging framework that comes with it, leading to unnecessary conceptual overhead for teams that just needed a scheduler. The second common mistake is not using the durable outbox where it would actually matter, missing one of Wolverine's most concrete reliability benefits.

--- a/src/posts/2027-11-30-getting-started-with-azure-functions-timer-triggers.md
+++ b/src/posts/2027-11-30-getting-started-with-azure-functions-timer-triggers.md
@@ -1,0 +1,177 @@
+---
+author: Steve Kaschimer
+date: 2027-11-30
+image: /images/posts/2027-11-30-hero.webp
+image_alt: "A cloud-bounded clock icon fully detached from any host shape, connected by a dashed line to a small isolated-worker box marked separate from a fading in-process silhouette."
+image_prompt: "A dark-mode technical editorial illustration on a near-black background with electric teal, amber, and off-white accents. Composition centers on a small cloud-bounded clock icon floating with no connecting line to any host or application shape, emphasizing full decoupling from a process's lifecycle. A dashed teal line runs to a small solid rectangle labeled by position as an isolated worker, distinct from a faint, fading dotted-outline rectangle beside it representing a deprecated in-process model. Mood is decoupled, managed, and forward-looking. Avoid: vendor logos, brand colors, circuit-board textures, gears, or generic cloud clip art as the dominant motif."
+layout: post.njk
+site_title: Tech Notes
+summary: "Azure Functions timer triggers solve a problem the other four background job tools in this series structurally can't: what happens when your job needs to run even if your main application isn't. A setup guide for the isolated worker model, Azure's 6-field cron format, and designing for idempotency under serverless retries."
+tags: ["dotnet", "cloud", "architecture", "devops"]
+title: "Getting Started with Azure Functions Timer Triggers in .NET"
+---
+
+Azure Functions timer triggers solve a problem the other four tools in this series structurally can't: what happens when your job needs to run even if your main application isn't. An in-process scheduler is only as reliable as the app hosting it - if that app is down for a deploy, crashed, or scaled to zero, nothing runs. A timer-triggered Azure Function is its own deployable unit, on its own schedule, independent of any web app's lifecycle. That's the whole appeal, and it comes with a real platform commitment in exchange.
+
+This guide covers setting up an Azure Functions project with a timer trigger using the current isolated worker model (the in-process model's support ends November 2026, so this is the only path worth building on new), bootstrapping dependency injection and configuration correctly, the core patterns for reliable execution, and the best practices for designing timer-triggered functions that behave correctly under retries and cold starts. By the end you'll have a background job that runs independently of your main application's process.
+
+If you're deciding between background job libraries first, [a comparison of the top .NET background job libraries](/posts/2027-10-26-top-5-dotnet-background-job-libraries-compared/) covers where Azure Functions fits relative to Hangfire, Quartz.NET, Coravel, and Wolverine.
+
+## What You'll Need
+
+- .NET 8 SDK or later
+- Azure Functions Core Tools v4
+- An Azure subscription for deployment (local development and testing don't require one)
+
+```bash
+npm install -g azure-functions-core-tools@4
+```
+
+## Installing and Scaffolding
+
+Create a new Functions project targeting the isolated worker model - this is the default for new projects using current tooling, but worth confirming explicitly:
+
+```bash
+func init MyApp.Functions --worker-runtime dotnet-isolated --target-framework net8.0
+cd MyApp.Functions
+func new --template "Timer trigger" --name DailySalesReportFunction
+```
+
+This scaffolds a `Program.cs` using the isolated worker host builder, plus a function class with a `[Function]`-attributed method and a `[TimerTrigger]` parameter.
+
+## Bootstrapping the Ideal Environment
+
+### The isolated worker host, with dependency injection wired up
+
+```csharp
+// Program.cs
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.DependencyInjection;
+
+var host = new HostBuilder()
+    .ConfigureFunctionsWebApplication()
+    .ConfigureServices(services =>
+    {
+        services.AddScoped<IReportService, ReportService>();
+        services.AddDbContext<AppDbContext>(options =>
+            options.UseSqlServer(Environment.GetEnvironmentVariable("SqlConnectionString")));
+    })
+    .Build();
+
+host.Run();
+```
+
+This is a meaningful departure from the older in-process model's `Startup.cs` - in the isolated worker model, your function runs as a genuinely separate process from the Functions host, giving you full control over the DI container and middleware pipeline the same way you would in any other .NET application.
+
+### The timer-triggered function
+
+```csharp
+public class DailySalesReportFunction(IReportService reportService, ILogger<DailySalesReportFunction> logger)
+{
+    [Function(nameof(DailySalesReportFunction))]
+    public async Task Run([TimerTrigger("0 0 6 * * *")] TimerInfo timerInfo)
+    {
+        logger.LogInformation("Generating daily sales report. Next run: {NextRun}", timerInfo.ScheduleStatus?.Next);
+        await reportService.GenerateDailySalesReportAsync();
+    }
+}
+```
+
+The cron expression here is a 6-field NCronTab expression (seconds-minutes-hours-day-month-weekday), which differs slightly from the 5-field format used elsewhere - worth double-checking against Azure's documentation rather than assuming standard cron syntax transfers directly.
+
+### Configuration: local vs. deployed
+
+Locally, settings live in `local.settings.json` (never committed to source control):
+
+```json
+{
+  "IsEncrypted": false,
+  "Values": {
+    "AzureWebJobsStorage": "UseDevelopmentStorage=true",
+    "FUNCTIONS_WORKER_RUNTIME": "dotnet-isolated",
+    "SqlConnectionString": "Server=localhost;Database=MyAppDb;Trusted_Connection=True;"
+  }
+}
+```
+
+In Azure, the equivalent values are set as Application Settings on the Function App, ideally pulling secrets from Azure Key Vault rather than storing them directly.
+
+### Retry policies, since the platform doesn't guarantee correctness of your logic
+
+```csharp
+[Function(nameof(DailySalesReportFunction))]
+[FixedDelayRetry(5, "00:00:10")]
+public async Task Run([TimerTrigger("0 0 6 * * *")] TimerInfo timerInfo)
+{
+    // ...
+}
+```
+
+`FixedDelayRetry` (or `ExponentialBackoffRetry`) handles retrying the function on failure - but the platform retrying your code doesn't make your code idempotent by itself; that's still your responsibility.
+
+## Core Workflow
+
+- **Design every timer-triggered function to be idempotent.** Retries and rare duplicate invocations are a real possibility on any serverless platform - a function that isn't safe to run twice with the same effective input is a latent bug.
+- **Use Application Insights for observability rather than assembling your own.** The integration is deep and largely automatic once configured, giving you execution history, failures, and duration without extra instrumentation code.
+- **Keep functions focused on one responsibility.** A timer trigger orchestrating a report generation should delegate the actual report logic to an injected service, the same discipline that applies to any other entry point in this series.
+
+## Verifying Your Setup
+
+1. **The function runs locally on schedule** - use `func start` and confirm the timer fires at the expected interval during local testing (temporarily shortening the schedule for faster feedback is a common technique)
+2. **Cron expression matches intent** - Azure's 6-field format has caught people expecting standard 5-field cron; verify against a NCronTab reference or the Azure documentation directly
+3. **Dependency injection resolves correctly** - confirm constructor-injected services in your function class resolve without error
+4. **Retry behavior matches expectations** - deliberately throw an exception in a test function and confirm the configured retry policy behaves as expected
+
+## Best Practices
+
+**Build on the isolated worker model for anything new.** The in-process model's support ends November 10, 2026 - there's no reason to build new functions on a model with a clear expiration date.
+
+**Design for idempotency from the start.** Serverless retry semantics mean your function may execute more than once for a given logical trigger - treat this as a certainty to design around, not an edge case.
+
+**Use Key Vault for secrets rather than Application Settings directly, in production.** Application Settings are convenient but not the most secure place for sensitive connection strings and API keys at scale.
+
+**Account for cold starts in your design, especially on Consumption plans.** A function that hasn't run recently may take longer to start executing - if timing precision matters, understand your hosting plan's cold-start characteristics (Premium and Dedicated plans largely avoid this; Consumption doesn't).
+
+**Recognize the platform commitment you're making.** Migrating away from Azure Functions later is a real project, not a configuration change - this is a reasonable trade-off if you're already committed to Azure, but worth being deliberate about rather than defaulting into.
+
+## Comparison with Hangfire
+
+| | Azure Functions (Timer) | Hangfire |
+| --- | --- | --- |
+| Process independence | Fully decoupled from any app's lifecycle | Runs inside your app's process |
+| Scaling | Elastic, managed by the platform | Manual, tied to your app's instances |
+| Persistence/reliability | Managed by Azure | Managed by your chosen storage backend |
+| Observability | Deep Application Insights integration | Built-in dashboard |
+| Portability | Real Azure lock-in | Portable across any .NET hosting environment |
+
+Azure Functions solves a structural reliability problem (running independently of any single app's uptime) that Hangfire, by design, can't - at the cost of genuine platform commitment. For teams not otherwise invested in Azure, that trade-off needs to be deliberate, not incidental.
+
+## Frequently Asked Questions
+
+### Should I use the in-process or isolated worker model for a new project?
+
+Isolated worker, without much debate - Microsoft is ending support for the in-process model on November 10, 2026, and the isolated model additionally offers better dependency isolation and the ability to target non-LTS .NET versions. There's no good reason to start a new project on the in-process model at this point.
+
+### What cron format does Azure Functions' TimerTrigger use?
+
+A 6-field NCronTab expression: seconds, minutes, hours, day of month, month, day of week - one field more than the standard 5-field cron format used by most other tools in this comparison. This difference has caused real confusion for people assuming standard cron syntax transfers directly; verify against Azure's documentation when writing a new schedule.
+
+### Does a timer trigger guarantee my function runs exactly once?
+
+No - like most serverless retry models, Azure Functions targets reliable execution but doesn't guarantee exactly-once semantics under all failure conditions. Design your function logic to be idempotent, the same defensive principle that applies to any retriable background work.
+
+### How do I test a timer trigger locally without waiting for its actual schedule?
+
+Use the Azure Functions Core Tools (`func start`) and temporarily shorten the cron expression to something like every minute for local testing, reverting to the intended production schedule before deploying. There's also an admin API endpoint that can manually invoke a function for testing without waiting on its trigger at all.
+
+### What's a cold start, and does it affect timer triggers?
+
+A cold start is the delay incurred when a function app that hasn't been recently active needs to initialize before executing - most relevant on Consumption plans, less so on Premium or Dedicated plans which keep instances warm. For timer triggers where exact timing matters, understand which hosting plan you're on and its cold-start characteristics.
+
+### How does Azure Functions handle secrets and configuration?
+
+Locally, via `local.settings.json` (excluded from source control). In Azure, via Application Settings on the Function App, ideally referencing Azure Key Vault for sensitive values rather than storing secrets directly in settings, which is the more secure pattern for production deployments.
+
+### What's the most common mistake in a first Azure Functions timer trigger setup?
+
+Building on the in-process model out of habit or an outdated tutorial, when the isolated worker model is both the current recommendation and the only supported path going forward. The second common mistake is assuming standard 5-field cron syntax works in `[TimerTrigger]` without checking Azure's 6-field format first.


### PR DESCRIPTION
## Summary

- Schedules and drafts the .NET Background Job Libraries Tuesday track: a comparison anchor post plus five getting-started guides, running weekly Tuesdays 2027-10-26 through 2027-11-30, picking up the cadence directly after the .NET Message Brokers track
- Moves the series from `editorial-plan.md`'s Backlog into a dated `## 📅 Tuesday Track - .NET Background Job Libraries (October-November 2027)` section, all entries `Status: draft` with `File:` paths, and updates the Backlog intro count from seven to six remaining series

### Posts added

- **Anchor:** The Top 5 Background Job Libraries for .NET Compared: Which One Should You Choose? (2027-10-26) - Hangfire, Quartz.NET, Coravel, Azure Functions (timer triggers), and Wolverine compared, starting from what a plain `BackgroundService` already gives you for free
- Getting Started with Hangfire in .NET (2027-11-02)
- Getting Started with Quartz.NET in .NET (2027-11-09)
- Getting Started with Coravel in .NET (2027-11-16)
- Getting Started with Wolverine in .NET (2027-11-23)
- Getting Started with Azure Functions Timer Triggers in .NET (2027-11-30)

Each setup guide cross-links back to the anchor post, mirroring the structure of the prior .NET ORMs/API Styles/Validation Approaches/Mapping Libraries/Caching Solutions/Message Brokers/Testing/Logging/Architecture tracks.

## Test plan

- [x] `npm run deploy` builds cleanly, all 6 posts render
- [x] `node scripts/a11y-check.js` (axe-core + Playwright) - zero violations across home/post/about/privacy/terms/404 in light and dark mode
- [x] Verified all 5 setup-guide cross-links resolve to the anchor post's output URL


---
_Generated by [Claude Code](https://claude.ai/code/session_01WKyNF7L5qzrfct8cec6A32)_