### PR TITLE
Add .NET Mocking Libraries Tuesday track (6 posts)

### DIFF
--- a/editorial-plan.md
+++ b/editorial-plan.md
@@ -1178,17 +1178,69 @@ Six posts on how a .NET service runs work outside the request/response cycle, pi
 
 ---
 
-## 📅 Backlog - Unscheduled Series
+## 📅 Tuesday Track - .NET Mocking Libraries (December 2027-January 2028)
 
-Six six-post series remain unscheduled, drawn from the drafts in `docs/article-ideas/`. They continue the Tuesday cadence once the .NET Background Job Libraries series ends on 2027-11-30, and they're listed here in priority order. They're deliberately undated - that horizon is too far out to put honest dates against - so each series gets one entry rather than six speculative ones, and entries are expanded into individual dated posts when a series moves onto the calendar.
+Six posts on how a .NET test isolates a system under test from its dependencies, picking up the Tuesday cadence directly from the Background Job Libraries track. A comparison post anchors the track and each of the five follow-ups is a complete setup for one mocking library.
 
-### .NET Mocking Libraries (6 posts)
-- **Status:** `idea`
-- **Source:** `docs/article-ideas/top-5-dotnet-mocking-libraries-compared.md` + 5 getting-started drafts
-- **Series:** Top 5 comparison, then Moq, NSubstitute, FakeItEasy, JustMock, Rocks
+### The Top 5 .NET Mocking Libraries Compared: Which One Should You Choose?
+- **Status:** `draft`
+- **Scheduled:** 2027-12-07
+- **Source:** `docs/article-ideas/top-5-dotnet-mocking-libraries-compared.md`
+- **File:** `src/posts/2027-12-07-top-5-dotnet-mocking-libraries-compared.md`
 - **Pitch:** Mocking in .NET used to be a two-horse syntax preference between Moq and NSubstitute. Moq 4.20's SponsorLink - which hashed a developer's Git email and sent it to a server without clear consent - was reverted within days, but the trust damage genuinely reshaped adoption, and an honest comparison can't skip it.
 - **Angle:** Compares the five on mechanism, syntax style, what they can actually mock, license, and community trajectory. The technical through-line is the same one running through the mapping and testing series - runtime proxy generation versus compile-time source generation - with Rocks representing the AOT-compatible, compile-time-checked direction. Doesn't declare Moq unusable; it gives the full picture, including that JustMock is the only option here that can mock statics, sealed types, and non-virtual members, which makes it the specific answer for legacy code.
 - **Tags:** `dotnet`, `testing`, `tooling`, `developer-productivity`
+
+### Getting Started with Moq in .NET
+- **Status:** `draft`
+- **Scheduled:** 2027-12-14
+- **Source:** `docs/article-ideas/getting-started-with-moq.md`
+- **File:** `src/posts/2027-12-14-getting-started-with-moq.md`
+- **Pitch:** Moq's `Setup`/`Returns`/`Verify` workflow is likely the mocking syntax the largest share of .NET developers already know. The one thing worth addressing directly: the 2023 SponsorLink incident, fully removed since 4.20.2, and what pinning to a current version actually means in 2026.
+- **Angle:** Covers the `Mock<T>`/`.Object` two-part model as the most common early confusion coming from NSubstitute, `It.IsAny<T>()`/`It.Is<T>()` argument matching, and `SetupSequence` for multi-call scenarios. Settles the version question directly - no need to pin pre-4.20 - and covers `MockBehavior.Strict` for teams that specifically want unconfigured calls to fail loudly.
+- **Tags:** `dotnet`, `testing`, `tooling`, `developer-productivity`
+
+### Getting Started with NSubstitute in .NET
+- **Status:** `draft`
+- **Scheduled:** 2027-12-21
+- **Source:** `docs/article-ideas/getting-started-with-nsubstitute.md`
+- **File:** `src/posts/2027-12-21-getting-started-with-nsubstitute.md`
+- **Pitch:** NSubstitute's defining decision is that there's no wrapper object - the substitute itself is both the fake and the configuration target, with no `.Setup()` call and no `.Object` to unwrap.
+- **Angle:** Covers the direct-call configuration pattern as the core mental shift from Moq, `Received()`/`DidNotReceive()` as the plain-English verification vocabulary, and the `callInfo` lambda for argument-dependent responses. Direct that NSubstitute doesn't support strict mocking by design - unconfigured calls succeed silently - and frames that as a deliberate trade-off to understand, not a gap to work around.
+- **Tags:** `dotnet`, `testing`, `tooling`, `developer-productivity`
+
+### Getting Started with FakeItEasy in .NET
+- **Status:** `draft`
+- **Scheduled:** 2027-12-28
+- **Source:** `docs/article-ideas/getting-started-with-fakeiteasy.md`
+- **File:** `src/posts/2027-12-28-getting-started-with-fakeiteasy.md`
+- **Pitch:** FakeItEasy's entire design fits behind one idea: whatever you're doing with a fake, stubbing or verifying, it goes through the same entry point, `A.CallTo(...)`, with no separate mental model for arranging versus asserting.
+- **Angle:** Covers `A.Fake<T>()` and the single `A.CallTo(...)` API for both stubbing and verification, `A<T>.Ignored`/`A<T>.That.Matches(...)` argument matching, and the precise `MustHaveHappened...` variants for exact interaction counts. Frames the one-API consistency as FakeItEasy's core value proposition and the reason to use it deliberately rather than mixing in habits from Moq or NSubstitute.
+- **Tags:** `dotnet`, `testing`, `tooling`, `developer-productivity`
+
+### Getting Started with JustMock in .NET
+- **Status:** `draft`
+- **Scheduled:** 2028-01-04
+- **Source:** `docs/article-ideas/getting-started-with-justmock.md`
+- **File:** `src/posts/2028-01-04-getting-started-with-justmock.md`
+- **Pitch:** JustMock answers a question the other four libraries in this series can't: what do you do when the code under test has a static dependency, a sealed class, or a non-virtual method, and refactoring it isn't realistic right now.
+- **Angle:** Covers the free JustMock Lite tier (`Mock.Create`/`Mock.Arrange`/`Mock.Assert`, comparable in scope to Moq) against the commercial elevated mode's Profiler API that mocks statics, sealed classes, and non-virtual members. Direct that elevated mode requires explicit CI/IDE enabling and a paid license, and that it's the pragmatic answer for legacy code specifically, not a default for new interface-driven projects.
+- **Tags:** `dotnet`, `testing`, `tooling`, `developer-productivity`
+
+### Getting Started with Rocks in .NET
+- **Status:** `draft`
+- **Scheduled:** 2028-01-11
+- **Source:** `docs/article-ideas/getting-started-with-rocks.md`
+- **File:** `src/posts/2028-01-11-getting-started-with-rocks.md`
+- **Pitch:** Rocks asks you to accept one trade upfront: a smaller community and a genuinely different syntax, in exchange for mocks that are ordinary, compiler-checked C# code instead of runtime-generated proxies.
+- **Angle:** Covers the `Rock.Create` → `.Methods()` → `.Instance()` → `.Verify()` flow as a direct consequence of source-generated architecture rather than arbitrary verbosity, and Native AOT/trimmed-deployment compatibility as the concrete reason to accept that trade-off. Honest that its smaller community shifts more troubleshooting burden onto the adopting team, and that it still can't mock statics or sealed classes the way JustMock's elevated mode can.
+- **Tags:** `dotnet`, `testing`, `tooling`, `performance`
+
+---
+
+## 📅 Backlog - Unscheduled Series
+
+Five six-post series remain unscheduled, drawn from the drafts in `docs/article-ideas/`. They continue the Tuesday cadence once the .NET Mocking Libraries series ends on 2028-01-11, and they're listed here in priority order. They're deliberately undated - that horizon is too far out to put honest dates against - so each series gets one entry rather than six speculative ones, and entries are expanded into individual dated posts when a series moves onto the calendar.
 
 ### .NET Architecture Quality Tools (6 posts)
 - **Status:** `idea`

--- a/src/posts/2027-12-07-top-5-dotnet-mocking-libraries-compared.md
+++ b/src/posts/2027-12-07-top-5-dotnet-mocking-libraries-compared.md
@@ -1,0 +1,164 @@
+---
+author: Steve Kaschimer
+date: 2027-12-07
+image: /images/posts/2027-12-07-hero.webp
+image_alt: "Five columns of abstract mocking glyphs positioned along a horizontal axis running from runtime proxy generation on the left to compile-time source generation on the right."
+image_prompt: "A dark-mode technical editorial illustration on a near-black background with electric teal, amber, and off-white accents. Composition is five vertical columns of equal width separated by thin hairline rules, each column topped by a distinct abstract glyph rendered in flat geometry: a wrapped proxy glyph shown as a rectangle inside a slightly larger outline, a direct unwrapped rectangle with no outer shell, a single consistent hexagonal entry-point glyph feeding two thin branches, a rectangle with a small elevated-key badge implying a deeper unlocked capability, and a solid compiled-code bracket glyph with a small checkmark seal. Beneath the glyphs, a shared horizontal axis labeled in monospaced type runs from 'runtime proxy' on the left to 'compile-time generation' on the right, with a small glowing teal dot positioned at a different point under each column. Mood is comparative, engineering-first, and non-partisan. Avoid: vendor logos, brand colors, circuit-board textures, gears, or generic checkmark clip art used as the dominant motif."
+layout: post.njk
+site_title: Tech Notes
+summary: "Mocking in .NET used to be a two-horse syntax preference between Moq and NSubstitute. Moq 4.20's SponsorLink incident reshaped adoption in a way an honest comparison can't skip. A practical breakdown of five mocking libraries, including which one is the only option that can mock statics and sealed classes."
+tags: ["dotnet", "testing", "tooling", "developer-productivity"]
+title: "The Top 5 .NET Mocking Libraries Compared: Which One Should You Choose?"
+---
+
+Mocking library comparisons in .NET used to be a simple two-horse race between Moq and NSubstitute, decided mostly by syntax preference. That changed in August 2023, when Moq 4.20 shipped a component called SponsorLink that read a developer's Git email, hashed it, and sent it to a server to check GitHub Sponsors status - without clear consent. The feature was reverted within days, but the trust damage wasn't, and it genuinely reshaped adoption patterns across the .NET ecosystem in a way this comparison can't honestly skip over.
+
+This guide compares five mocking libraries: Moq, NSubstitute, FakeItEasy, JustMock, and Rocks - the last one included specifically because it represents where a meaningful slice of the community has been heading since 2023: compile-time, source-generator-based mocking that sidesteps the runtime proxy-generation model (and the trust concerns that came with a library controlling what happens during your build) entirely. All five remain legitimate choices; the point of this comparison isn't to declare Moq unusable, but to give you the full picture - technical and otherwise - before you pick. This series continues with dedicated getting-started walkthroughs for each library.
+
+## Quick Comparison
+
+| | Moq | NSubstitute | FakeItEasy | JustMock | Rocks |
+| --- | --- | --- | --- | --- | --- |
+| **Mechanism** | Runtime proxy generation (Castle DynamicProxy) | Runtime proxy generation | Runtime proxy generation | Runtime proxy + optional Profiler API | Compile-time source generation |
+| **Syntax style** | Lambda-based (`Setup`/`Returns`/`Verify`) | Natural (`sub.Method().Returns(...)`), no Setup ceremony | Single consistent `A.CallTo(...)` API | Fluent AAA (`Arrange`/`Act`/`Assert`) | Source-generated, strongly typed per-interface |
+| **Mocks non-virtual/sealed/static** | No | No | No | Yes (commercial, Profiler API) | No |
+| **License** | Open source (post-SponsorLink, reverted) | Open source | Open source | Free tier + commercial | Open source |
+| **Community size** | Largest, though shaken by 2023 | Large, grew significantly post-2023 | Solid, loyal following | Smaller, commercial-focused | Small, newer |
+| **Best for** | Existing Moq codebases, teams unbothered by its history | New projects wanting the cleanest, lowest-ceremony syntax | Teams wanting one consistent API for stubbing and verification | Legacy code needing to mock statics/sealed/non-virtual members | Teams wanting AOT-compatible, compile-time-checked mocks |
+
+## Moq
+
+Moq remains the most widely used mocking library in .NET, with the richest feature set and the most existing documentation and Stack Overflow coverage of any option here. It's also the library whose 2023 incident is impossible to leave out of an honest comparison.
+
+**Strengths:**
+
+- The richest feature set of the mainstream options: argument matchers, sequential setups, callback chains, in-order verification, and support for protected virtual methods are all first-class
+- The largest community and the deepest well of existing documentation, examples, and troubleshooting resources, simply by virtue of having been the default for so long
+- Powerful, expressive lambda-based syntax (`mock.Setup(x => x.Method()).Returns(value)`) that many teams are already deeply familiar with
+
+**Weaknesses:**
+
+- In August 2023, version 4.20.0 shipped SponsorLink, a closed-source component that read a developer's Git email, hashed it, and sent the hash to an Azure service to check GitHub Sponsors status - without clear, explicit consent. It was reverted within days, but the trust damage prompted a real wave of migration to alternatives
+- Many organizations and teams responded by pinning to pre-4.20 versions, banning Moq outright, or migrating entirely - worth knowing if you're joining a team or evaluating a codebase's current stance
+- Same runtime proxy-generation limitations as NSubstitute and FakeItEasy - can't mock non-virtual members, sealed classes, or static methods without a different architecture entirely
+
+**Choose this when:** you're maintaining an existing Moq codebase with no urgent driver to migrate, or your team has evaluated the SponsorLink history and is comfortable pinning to a clean, current version.
+
+## NSubstitute
+
+NSubstitute's core design idea is that the substitute object itself is the mock - there's no separate wrapper type, no `.Object` property to unwrap, no `Setup()` call. You call `Substitute.For<T>()` and the returned object acts naturally as both the fake and the configuration target, which produces test code that reads close to plain English.
+
+**Strengths:**
+
+- The cleanest, most natural syntax of the mainstream options - `sub.Method().Returns(value)` with no ceremony, which measurably lowers cognitive load during code review
+- No SponsorLink-equivalent trust concerns, and it saw meaningfully increased adoption specifically as teams migrated away from Moq in 2023 and after
+- Async support "just works" without special-cased syntax, fitting naturally into modern, async-heavy .NET codebases
+
+**Weaknesses:**
+
+- Does not support strict mocks in the traditional sense - every unconfigured call succeeds silently by default, which some teams consider a real gap if they specifically want unconfigured calls to fail loudly
+- Same runtime proxy-generation limitations as Moq and FakeItEasy - interfaces and virtual members only
+- Its natural, minimal-ceremony syntax can occasionally make certain advanced scenarios (complex callback chains, some argument-matching patterns) less immediately discoverable than Moq's more explicit API
+
+**Choose this when:** you're starting a new project and want the lowest-friction, most readable syntax with no history to weigh, or you're migrating away from Moq and want the most commonly cited replacement path.
+
+## FakeItEasy
+
+FakeItEasy's whole design centers on one consistent entry point - everything, whether you're stubbing a return value or verifying a call happened, goes through `A.CallTo(...)` or `A.Fake<T>()`. That consistency is the library's main pitch: no separate mental model for "setting up" versus "asserting."
+
+**Strengths:**
+
+- One consistent API shape for both stubbing and verification, appealing specifically to teams who find having two different syntaxes for those two concerns (as some other libraries have) an unnecessary cognitive split
+- Mature and stable, with a loyal following that predates the Moq controversy - not simply a beneficiary of 2023's migration wave, but an established option in its own right
+- Clear, discoverable API surface, since nearly everything you need hangs off the single `A.` static class
+
+**Weaknesses:**
+
+- Smaller community than Moq or NSubstitute, meaning somewhat less third-party documentation and fewer examples to draw on when you hit an unusual scenario
+- Same runtime proxy-generation limitations shared by Moq and NSubstitute - no mocking of non-virtual, sealed, or static members
+- Less commonly the default recommendation in comparison articles relative to NSubstitute specifically, despite being a comparably mature and capable choice
+
+**Choose this when:** you want a single, consistent mental model for both stubbing and verification, and you're not specifically drawn to NSubstitute's no-`Setup()` minimalism.
+
+## JustMock
+
+JustMock, from Telerik/Progress, is architecturally different from the other mainstream open-source options - it offers a free tier (JustMock Lite) using standard proxy-based mocking, and a commercial tier that uses the .NET Profiling API to mock things the others structurally can't: static methods and classes, sealed classes, non-virtual members, private members, and even framework types like `DateTime` and `File`.
+
+**Strengths:**
+
+- The only option in this comparison that can mock static methods, sealed classes, and non-virtual members without requiring you to first refactor the code under test to be more mockable
+- Genuinely valuable for legacy codebases where introducing interfaces and virtual members everywhere isn't practical or is a much larger undertaking than the testing task at hand
+- A fluent, AAA-pattern (Arrange/Act/Assert) API that's approachable once you're working within its model
+- Actively maintained by Telerik with regular releases and CI/CD integrations (Azure Pipelines, GitLab, Jenkins)
+
+**Weaknesses:**
+
+- The advanced "elevated mocking" capabilities (statics, sealed classes, non-virtual members) require the commercial edition and the Profiler API, which needs explicit enabling and isn't part of the free tier
+- Real licensing cost for the full feature set, unlike the other four options in this comparison, which are all free and open source
+- Less commonly reached for outside legacy-code or enterprise contexts specifically because most well-designed, interface-driven codebases don't need its most distinctive capabilities
+
+**Choose this when:** you're working with legacy code that has static dependencies, sealed classes, or non-virtual members you can't easily refactor around, and the commercial license is justified by the testing capability it unlocks.
+
+## Rocks
+
+Rocks takes a fundamentally different technical approach from the other four: instead of generating mock proxies at runtime via a library like Castle DynamicProxy, it uses C# source generators to produce strongly-typed mock code at compile time. This is architecturally the same shift TUnit represents for test frameworks - moving work from runtime reflection/proxying to build-time generation.
+
+**Strengths:**
+
+- No runtime proxy generation at all - mocks are ordinary, source-generated C# code, which means full compatibility with Native AOT and trimmed deployments that runtime-proxy-based mocking libraries can't offer
+- Compile-time errors for mismatched setups, since the generated mock code is checked by the compiler the same as any other code, rather than failing at test-run time
+- No dependency on a runtime library controlling proxy generation behavior - a meaningful trust and transparency advantage in the specific post-SponsorLink context this comparison exists in
+
+**Weaknesses:**
+
+- Small community and much less real-world adoption than the four options above - fewer examples, less troubleshooting content, and a genuinely newer, less battle-tested project
+- The source-generator model means a different syntax and mental model from the proxy-based libraries most .NET developers already know, adding a real learning curve when migrating
+- As with any source-generator-based tool, build times can increase somewhat, and debugging generated code occasionally requires understanding what the generator actually produced
+
+**Choose this when:** you're building for Native AOT or trimmed deployments where runtime proxy generation isn't viable at all, or you specifically want compile-time-checked mocks and are comfortable adopting a newer, smaller-community tool to get there.
+
+## How to Decide
+
+A few heuristics that cover most real-world decisions:
+
+**Maintaining an existing Moq codebase, comfortable with its history?** Pin to a current, clean version and keep using it - there's no urgent technical reason to migrate a working, well-understood test suite.
+
+**Starting a new project and want the cleanest, lowest-ceremony syntax?** NSubstitute is the most commonly cited answer, and for good reason - readable, natural, and untouched by the trust concerns that shook Moq.
+
+**Want one consistent API shape for both stubbing and verification?** FakeItEasy's `A.CallTo(...)` model is worth serious consideration, not just as a Moq alternative but on its own technical merits.
+
+**Working with legacy code that has static, sealed, or non-virtual dependencies you can't refactor around?** JustMock is the only option here that can actually mock those without a larger refactor first - evaluate whether the commercial license is worth that specific capability.
+
+**Building for Native AOT or want compile-time-checked mocks?** Rocks is the right category of tool, with the honest caveat that you're trading ecosystem maturity for architectural advantages that may or may not matter for your specific deployment target.
+
+None of these decisions need to be permanent or absolute across an entire organization - it's reasonable for an existing Moq-based suite to keep working while new projects default to NSubstitute or another alternative, without a mandate to rewrite everything at once.
+
+## Frequently Asked Questions
+
+### Is Moq still safe to use after the SponsorLink incident?
+
+Technically, yes - SponsorLink was reverted within days of the backlash, and current versions don't contain it. The more relevant question for most teams isn't safety but trust: whether your organization is comfortable with a library that shipped that kind of component once, even briefly and even if reverted. Many teams pin to a specific known-clean version and monitor release notes going forward rather than avoiding Moq outright.
+
+### What exactly did the SponsorLink controversy involve?
+
+In August 2023, Moq 4.20.0 bundled a component that read the `user.email` value from a developer's local Git configuration, hashed it with SHA-256, and sent that hash to an Azure service to check whether the developer was sponsoring the project on GitHub Sponsors - without clear, explicit consent, and without this being disclosed prominently to users upgrading the package. The backlash was immediate and significant, and the maintainer reverted the change within days, but it fundamentally altered how much trust a meaningful part of the community places in the project.
+
+### Which library is the most common migration path away from Moq?
+
+NSubstitute is most frequently cited as the primary migration target, largely due to its clean, readable syntax and the fact that it saw a meaningful adoption bump specifically during and after the 2023 controversy. FakeItEasy is a strong second option for teams who prefer its single consistent API shape over NSubstitute's no-`Setup()` minimalism.
+
+### Can any of these libraries mock a static method or a sealed class?
+
+Only JustMock, and only in its commercial edition using the .NET Profiling API. Moq, NSubstitute, FakeItEasy, and Rocks all rely on generating a proxy or implementation for an interface or virtual member - none of them can intercept a static call or a sealed class's non-virtual members, which is architecturally why JustMock exists as a distinct option in this space.
+
+### Is Rocks actually production-ready, or just an interesting experiment?
+
+It's used in production by teams that specifically value its compile-time, AOT-compatible architecture, but it has meaningfully less real-world adoption and community support than the four more established options here. Evaluate it seriously if Native AOT compatibility or compile-time-checked mocks are genuine requirements, but go in aware you're trading ecosystem maturity for those specific architectural benefits.
+
+### Should I migrate my existing Moq test suite to another library?
+
+Not automatically, and not without a concrete reason - a large, working Moq-based test suite represents real, sunk engineering investment, and migration is genuine work with its own risk of introducing bugs into your safety net. The more common and lower-risk pattern is defaulting new projects or new test files to an alternative while leaving an existing, functioning Moq suite in place, rather than a wholesale rewrite driven purely by trust concerns about a component that's no longer present in current versions.
+
+### Does NSubstitute's lack of strict mocking matter in practice?
+
+It depends on your team's testing philosophy. NSubstitute's default behavior - unconfigured calls succeed silently rather than throwing - means a test won't fail just because you forgot to configure an interaction, which some teams prefer for reducing brittle tests, while others specifically want strict mocking to catch unexpected interactions early. If strict-by-default matters to you, this is a concrete technical reason to lean toward Moq or FakeItEasy instead.

--- a/src/posts/2027-12-14-getting-started-with-moq.md
+++ b/src/posts/2027-12-14-getting-started-with-moq.md
@@ -1,0 +1,162 @@
+---
+author: Steve Kaschimer
+date: 2027-12-14
+image: /images/posts/2027-12-14-hero.webp
+image_alt: "A wrapped proxy glyph shown as a rectangle inside a slightly larger outline, with a small amber version marker beside it indicating a clean, current release well past a past incident."
+image_prompt: "A dark-mode technical editorial illustration on a near-black background with electric teal, amber, and off-white accents. Composition centers on a solid rectangle enclosed within a slightly larger, thinner outline rectangle, implying a wrapped mock object distinct from its inner fake instance. Beside it, a small amber version-number badge sits cleanly separated from a faded, crossed-out marker representing a past concern now resolved. Mood is familiar, rich, and settled. Avoid: vendor logos, brand colors, circuit-board textures, gears, or generic checkmark clip art."
+layout: post.njk
+site_title: Tech Notes
+summary: "Moq's Setup/Returns/Verify workflow is likely the mocking syntax the largest share of .NET developers already know. A setup guide for the Mock<T>/.Object model, argument matching, sequential setups, and settling the SponsorLink version question."
+tags: ["dotnet", "testing", "tooling", "developer-productivity"]
+title: "Getting Started with Moq in .NET"
+---
+
+Moq's core workflow - `Setup`, `Returns`, `Verify` - is likely the mocking syntax the largest share of .NET developers already know, and that familiarity is a real reason to keep using it. The one thing worth addressing directly before anything else: in August 2023, Moq shipped a component called SponsorLink that harvested developer email hashes without clear consent. It was reverted within days, and current versions don't contain it, but knowing this history - and pinning to a version you trust - is part of using Moq responsibly in 2026, not optional background trivia.
+
+This guide covers installing Moq (with a note on version selection given its history), bootstrapping mocks and setups correctly, the core patterns for stubbing, verification, and argument matching, and the best practices that keep a Moq-based test suite maintainable. By the end you'll have a working mocking setup and a clear, informed stance on the version question.
+
+If you're deciding between mocking libraries first, [a comparison of the top .NET mocking libraries](/posts/2027-12-07-top-5-dotnet-mocking-libraries-compared/) covers where Moq fits relative to NSubstitute, FakeItEasy, JustMock, and Rocks - including the fuller context on SponsorLink.
+
+## What You'll Need
+
+- .NET 8 SDK or later
+- An existing test project (xUnit, NUnit, or MSTest all work identically well with Moq)
+
+## Installing Moq
+
+```bash
+dotnet add package Moq
+```
+
+Moq versions from 4.20.2 onward have SponsorLink fully removed - there's no need to pin to an old pre-4.20 version to avoid it, contrary to some outdated advice still circulating. Use a current version, but if your organization has a specific policy on this, confirm what it requires before adding the dependency.
+
+## Bootstrapping the Ideal Environment
+
+### Creating and configuring a mock
+
+```csharp
+public class OrderServiceTests
+{
+    [Fact]
+    public async Task ProcessOrder_MarksOrderAsProcessing()
+    {
+        var mockRepository = new Mock<IOrderRepository>();
+        var order = new Order { Id = 1, Status = OrderStatus.Pending };
+
+        mockRepository
+            .Setup(r => r.GetByIdAsync(1))
+            .ReturnsAsync(order);
+
+        var sut = new OrderService(mockRepository.Object);
+
+        await sut.ProcessAsync(1);
+
+        Assert.Equal(OrderStatus.Processing, order.Status);
+        mockRepository.Verify(r => r.SaveAsync(order), Times.Once);
+    }
+}
+```
+
+`new Mock<T>()` creates the mock; `.Object` is the actual fake instance you pass to your system under test - this indirection (mock wrapper vs. the object itself) is one of the more common early points of confusion coming from a library like NSubstitute, where the substitute object is used directly.
+
+### Argument matching
+
+```csharp
+mockRepository
+    .Setup(r => r.GetByIdAsync(It.IsAny<int>()))
+    .ReturnsAsync((int id) => new Order { Id = id });
+
+mockRepository
+    .Setup(r => r.SaveAsync(It.Is<Order>(o => o.Status == OrderStatus.Processing)))
+    .Returns(Task.CompletedTask);
+```
+
+`It.IsAny<T>()` matches any argument of that type; `It.Is<T>(predicate)` matches only arguments satisfying a specific condition - both are essential for setups that shouldn't be tightly coupled to one exact input value.
+
+### Verifying calls
+
+```csharp
+mockRepository.Verify(r => r.SaveAsync(It.IsAny<Order>()), Times.Once);
+mockRepository.Verify(r => r.DeleteAsync(It.IsAny<int>()), Times.Never);
+```
+
+`Times.Once`, `Times.Never`, `Times.Exactly(n)`, and others give you precise control over exactly how many times an interaction should have occurred - worth using specifically rather than defaulting to loose verification everywhere.
+
+### Sequential setups for multi-call scenarios
+
+```csharp
+mockRepository
+    .SetupSequence(r => r.GetNextIdAsync())
+    .ReturnsAsync(1)
+    .ReturnsAsync(2)
+    .ReturnsAsync(3);
+```
+
+`SetupSequence` returns different values on successive calls to the same setup - useful for testing retry logic, pagination, or any scenario where the same method is called multiple times with different expected results each time.
+
+## Core Workflow
+
+- **Mock only what your system under test actually depends on** - typically interfaces representing external dependencies (repositories, external services), not every collaborator regardless of whether it's actually a boundary worth isolating.
+- **Use `It.IsAny<T>()` for arguments the test doesn't care about, and specific values or `It.Is<T>()` for ones it does.** Over-specifying every argument makes tests brittle to unrelated changes; under-specifying makes them too permissive to catch real bugs.
+- **Verify only the interactions that matter to the behavior under test**, not every call the mock happened to receive - excessive verification couples tests too tightly to implementation details.
+
+## Verifying Your Setup
+
+1. **Mocks are configured and used correctly** - confirm `.Object` (not the `Mock<T>` wrapper itself) is what gets passed into the system under test
+2. **Argument matchers behave as expected** - confirm `It.Is<T>()` predicates correctly discriminate between matching and non-matching calls
+3. **Verification catches missing or unexpected interactions** - deliberately break a test's expected call count and confirm `Verify` actually fails
+4. **You're on a current Moq version with SponsorLink fully absent** - confirm your package version is 4.20.2 or later
+
+## Best Practices
+
+**Use a current Moq version - there's no need to pin to a pre-4.20 release.** SponsorLink was fully removed by 4.20.2; staying artificially behind on that basis alone means missing legitimate fixes and improvements for no remaining benefit.
+
+**Don't over-specify Setup calls with exact argument values when the test doesn't actually care about them.** Use `It.IsAny<T>()` for irrelevant parameters so the test stays focused on what it's actually verifying.
+
+**Reserve `Verify` for interactions that are genuinely part of the behavior under test.** Verifying every mock call regardless of relevance turns tests into brittle implementation-detail checks rather than behavior checks.
+
+**Use `MockBehavior.Strict` deliberately when you want unconfigured calls to fail loudly**, rather than the default loose behavior where unconfigured calls on non-void members return default values silently.
+
+**Keep mock setup close to the test that uses it, not buried in a shared base class doing too much.** Excessive shared setup makes individual tests harder to understand in isolation.
+
+## Comparison with NSubstitute
+
+| | Moq | NSubstitute |
+| --- | --- | --- |
+| Syntax | `mock.Setup(x => x.Method()).Returns(value)` | `sub.Method().Returns(value)` |
+| Accessing the fake | Via `.Object` | The substitute itself, no wrapper |
+| History | SponsorLink incident (2023, since reverted) | No comparable trust incident |
+| Feature richness | Very rich - sequences, callbacks, protected members | Solid, slightly less ceremony-heavy for advanced scenarios |
+| Community | Largest, though shaken by 2023 | Large, grew significantly post-2023 |
+
+Both are capable, mature libraries - the practical difference is largely syntax preference (explicit `Setup`/`.Object` vs. NSubstitute's more direct style) plus whichever weight your team puts on Moq's 2023 history.
+
+## Frequently Asked Questions
+
+### Do I need to avoid or pin an old version of Moq because of SponsorLink?
+
+No, not anymore - SponsorLink was fully removed starting with version 4.20.2, so current versions of Moq don't contain it. Some outdated advice from immediately after the incident still recommends pinning to pre-4.20 versions, but that's no longer necessary for avoiding SponsorLink specifically; it just means missing legitimate updates.
+
+### What's the difference between Mock<T> and Mock<T>.Object?
+
+`Mock<T>` is the wrapper you use to configure setups and verify calls. `.Object` is the actual fake instance implementing `T` that you pass to your system under test. This two-part model (configure the wrapper, pass the `.Object`) is Moq's core design and the most common point of confusion for developers coming from libraries like NSubstitute where the substitute object handles both roles directly.
+
+### What's the difference between It.IsAny<T>() and a specific value in Setup?
+
+`It.IsAny<T>()` matches any argument of that type, appropriate when the test doesn't care about the specific value passed. A specific value (or `It.Is<T>(predicate)` for a condition) matches only when the actual call satisfies it, appropriate when the specific argument matters to what you're verifying. Choosing the wrong one either makes tests too brittle (over-specified) or too permissive (under-specified) to be meaningful.
+
+### How do I test that a method was called with specific arguments?
+
+Use `Verify` with `It.Is<T>(predicate)` to check the call happened with arguments matching a specific condition, combined with a `Times` value to control how many times: `mock.Verify(x => x.Method(It.Is<Order>(o => o.Id == 1)), Times.Once)`.
+
+### What's MockBehavior.Strict, and when should I use it?
+
+By default (`MockBehavior.Loose`), calling an unconfigured member on a mock returns a default value rather than throwing. `MockBehavior.Strict` makes unconfigured calls throw instead, which is useful when you specifically want a test to fail if it exercises an interaction you didn't anticipate and explicitly set up.
+
+### Can I mock a static method or sealed class with Moq?
+
+No - Moq, like NSubstitute and FakeItEasy, relies on generating a runtime proxy for an interface or virtual member, which fundamentally can't intercept static calls or sealed class members. JustMock's commercial edition is the option in this comparison series specifically capable of that, using the .NET Profiling API.
+
+### What's the most common mistake in a first Moq setup?
+
+Forgetting to pass `.Object` and accidentally trying to use the `Mock<T>` wrapper itself as if it were the fake instance, which won't compile against code expecting the actual interface type. The second common mistake is over-specifying argument matchers with exact values where `It.IsAny<T>()` would make the test appropriately less brittle.

--- a/src/posts/2027-12-21-getting-started-with-nsubstitute.md
+++ b/src/posts/2027-12-21-getting-started-with-nsubstitute.md
@@ -1,0 +1,150 @@
+---
+author: Steve Kaschimer
+date: 2027-12-21
+image: /images/posts/2027-12-21-hero.webp
+image_alt: "A direct unwrapped rectangle with no outer shell, connected by a short straight line to a plain returns marker with no separate setup ceremony visible anywhere."
+image_prompt: "A dark-mode technical editorial illustration on a near-black background with electric teal, amber, and off-white accents. Composition centers on a single flat rectangle with no enclosing outline or wrapper shape around it, connected by one short direct teal line to a small returns-arrow marker, emphasizing there is no separate configuration layer. A faint plain-english speech-bubble outline sits beside it, implying natural, readable syntax. Mood is clean, natural, and unceremonious. Avoid: vendor logos, brand colors, circuit-board textures, gears, or generic checkmark clip art."
+layout: post.njk
+site_title: Tech Notes
+summary: "NSubstitute's defining decision is that there's no wrapper object - the substitute itself is both the fake and the configuration target. A setup guide for the direct-call configuration pattern, Received()/DidNotReceive() verification, and the deliberate no-strict-mode default."
+tags: ["dotnet", "testing", "tooling", "developer-productivity"]
+title: "Getting Started with NSubstitute in .NET"
+---
+
+NSubstitute's defining decision is that there's no wrapper object - `Substitute.For<T>()` returns something that behaves like the real interface and also happens to be your configuration target. There's no `.Object` to unwrap, no separate `Setup()` call before you can specify a return value; you just call the method on the substitute directly, and calling it again with `.Returns(...)` is how you configure it. That single design choice is responsible for most of what people mean when they say NSubstitute's syntax is "the cleanest."
+
+This guide covers installing NSubstitute, bootstrapping substitutes and configuring return values correctly, the core patterns for verification and argument matching, and the best practices that take advantage of its minimal-ceremony design without losing the precision strict mocking sometimes provides. By the end you'll have a test suite that reads close to plain English, and a clear understanding of the one behavior (no strict mode) worth knowing about upfront.
+
+If you're deciding between mocking libraries first, [a comparison of the top .NET mocking libraries](/posts/2027-12-07-top-5-dotnet-mocking-libraries-compared/) covers where NSubstitute fits relative to Moq, FakeItEasy, JustMock, and Rocks.
+
+## What You'll Need
+
+- .NET 8 SDK or later
+- An existing test project (xUnit, NUnit, or MSTest all work identically well with NSubstitute)
+
+## Installing NSubstitute
+
+```bash
+dotnet add package NSubstitute
+```
+
+## Bootstrapping the Ideal Environment
+
+### Creating and configuring a substitute
+
+```csharp
+public class OrderServiceTests
+{
+    [Fact]
+    public async Task ProcessOrder_MarksOrderAsProcessing()
+    {
+        var repository = Substitute.For<IOrderRepository>();
+        var order = new Order { Id = 1, Status = OrderStatus.Pending };
+
+        repository.GetByIdAsync(1).Returns(order);
+
+        var sut = new OrderService(repository);
+
+        await sut.ProcessAsync(1);
+
+        Assert.Equal(OrderStatus.Processing, order.Status);
+        await repository.Received(1).SaveAsync(order);
+    }
+}
+```
+
+Note there's no `.Setup()` call and no `.Object` property - `repository` itself is both the fake you pass to your system under test and the thing you configure directly by calling its methods.
+
+### Argument matching
+
+```csharp
+repository.GetByIdAsync(Arg.Any<int>()).Returns(callInfo => new Order { Id = callInfo.Arg<int>() });
+
+repository.SaveAsync(Arg.Is<Order>(o => o.Status == OrderStatus.Processing)).Returns(Task.CompletedTask);
+```
+
+`Arg.Any<T>()` and `Arg.Is<T>(predicate)` mirror Moq's `It.IsAny<T>()`/`It.Is<T>()` conceptually - use the former for arguments the test doesn't care about, the latter when a specific condition matters.
+
+### Verifying calls with Received
+
+```csharp
+await repository.Received(1).SaveAsync(order);
+await repository.DidNotReceive().DeleteAsync(Arg.Any<int>());
+```
+
+`Received(n)` (or the shorthand `Received()` for "at least once") and `DidNotReceive()` are NSubstitute's verification vocabulary - read almost as plain English, consistent with the library's overall design philosophy.
+
+### Configuring sequential returns
+
+```csharp
+repository.GetNextIdAsync().Returns(1, 2, 3);
+```
+
+Passing multiple values to `Returns(...)` configures NSubstitute to return them in sequence on successive calls - the equivalent of Moq's `SetupSequence`, expressed more compactly.
+
+## Core Workflow
+
+- **Call the method directly on the substitute to configure it - there's no separate setup step.** This is the core mental adjustment coming from Moq; lean into it rather than looking for a `.Setup()` equivalent.
+- **Use `Arg.Any<T>()` for irrelevant arguments, `Arg.Is<T>()` for conditions that matter.** The same discipline that applies to any mocking library's argument matching.
+- **Remember unconfigured calls succeed silently by default.** NSubstitute doesn't support strict mocking the way some other libraries do - calling an unconfigured member returns a default value rather than throwing, which is a deliberate design choice worth understanding rather than being surprised by.
+
+## Verifying Your Setup
+
+1. **Substitutes are created and configured correctly** - confirm calling a method directly on the substitute (no `.Setup()`) correctly configures its return behavior
+2. **Argument matchers behave as expected** - confirm `Arg.Is<T>()` predicates correctly discriminate between matching and non-matching calls
+3. **`Received`/`DidNotReceive` catch missing or unexpected interactions** - deliberately break a test's expected interaction and confirm verification actually fails
+4. **You understand the no-strict-mode default** - confirm your team is comfortable with unconfigured calls succeeding silently, or has a deliberate strategy for cases where that's not desired
+
+## Best Practices
+
+**Lean into the direct call syntax rather than looking for Moq-style ceremony.** `sub.Method().Returns(value)` is the whole pattern - there's no missing `.Setup()` to find.
+
+**Use `Arg.Is<T>()` for arguments that matter to the test's intent, and `Arg.Any<T>()` for everything else.** The same principle that applies to any mocking library - over- or under-specifying arguments both have real costs.
+
+**Be deliberate about the lack of strict mocking.** If your team specifically wants unconfigured calls to fail loudly (catching unintended interactions), know that NSubstitute doesn't provide this by default, and factor that into your choice or your testing conventions.
+
+**Use `callInfo` in `Returns(callInfo => ...)` when a mock's return value needs to depend on the arguments it received.** This is NSubstitute's mechanism for dynamic, argument-dependent responses, analogous to Moq's lambda-based `Returns` overloads.
+
+**Keep substitute configuration close to the test using it.** The same discipline that applies to any mocking library - excessive shared setup across many tests makes individual tests harder to understand in isolation.
+
+## Comparison with Moq
+
+| | NSubstitute | Moq |
+| --- | --- | --- |
+| Syntax | `sub.Method().Returns(value)` | `mock.Setup(x => x.Method()).Returns(value)` |
+| Accessing the fake | The substitute itself | Via `.Object` |
+| Strict mocking | Not supported - unconfigured calls succeed silently | Supported via `MockBehavior.Strict` |
+| History | No comparable trust incident | SponsorLink incident (2023, since reverted) |
+| Community | Large, grew significantly post-2023 | Largest, though shaken by 2023 |
+
+NSubstitute's cleaner syntax and lack of trust history make it a strong default for new projects; Moq's richer feature set (including strict mocking) remains a legitimate reason to prefer it for teams that want that specific capability.
+
+## Frequently Asked Questions
+
+### Why doesn't NSubstitute have a Setup() method like Moq?
+
+By design - NSubstitute's whole philosophy is that the substitute object itself is both the fake and the configuration target, so calling a method directly on it (followed by `.Returns(...)`) is how you configure behavior, with no separate setup step needed. This is the source of its cleaner, more natural-reading syntax.
+
+### Does NSubstitute support strict mocking, where unconfigured calls throw?
+
+No - this is a deliberate design choice, not a missing feature. Unconfigured calls on an NSubstitute substitute succeed silently, returning a default value rather than throwing. If your testing philosophy specifically requires strict-by-default behavior, that's a concrete reason to consider Moq (with `MockBehavior.Strict`) or FakeItEasy instead.
+
+### How do I configure a substitute's return value to depend on the arguments it receives?
+
+Use the `callInfo` lambda overload: `sub.Method(Arg.Any<int>()).Returns(callInfo => ComputeResult(callInfo.Arg<int>()))`. This gives you access to the actual arguments passed on each call, letting the mock's response vary dynamically rather than always returning the same fixed value.
+
+### What's the difference between Received() and Received(1)?
+
+`Received()` (no argument) verifies the call happened at least once. `Received(1)` verifies it happened exactly once. Use the specific count when the exact number of interactions matters to what you're testing, and the parameterless version when you just need to confirm an interaction occurred at all.
+
+### Can NSubstitute mock static methods or sealed classes?
+
+No - like Moq and FakeItEasy, NSubstitute relies on runtime proxy generation for interfaces and virtual members, which structurally can't intercept static calls or sealed class members. JustMock's commercial edition is the option in this comparison series capable of that specific scenario.
+
+### Is NSubstitute a safe choice with no trust or licensing concerns?
+
+Yes - it's open source with no comparable incident to Moq's SponsorLink history, and it saw meaningfully increased adoption specifically because of that contrast during and after 2023. It remains a strong, low-friction default for new projects on that basis alone, separate from its syntax advantages.
+
+### What's the most common mistake in a first NSubstitute setup?
+
+Looking for a `.Setup()` method out of habit from Moq and being confused when it doesn't exist, rather than configuring the substitute by calling its methods directly. The second common mistake is assuming unconfigured calls will fail the way they might in a strict-mode mocking library, when NSubstitute's default behavior is to succeed silently instead.

--- a/src/posts/2027-12-28-getting-started-with-fakeiteasy.md
+++ b/src/posts/2027-12-28-getting-started-with-fakeiteasy.md
@@ -1,0 +1,152 @@
+---
+author: Steve Kaschimer
+date: 2027-12-28
+image: /images/posts/2027-12-28-hero.webp
+image_alt: "A single consistent hexagonal entry-point glyph feeding two thin branches, one terminating in a returns marker and the other in a verification checkmark, sharing the same origin point."
+image_prompt: "A dark-mode technical editorial illustration on a near-black background with electric teal, amber, and off-white accents. Composition centers on a small solid hexagonal glyph on the left, with two thin teal branches emerging from the exact same point - one terminating in a returns-arrow marker, the other in a small verification checkmark - emphasizing both flow through one shared entry. Mood is unified, discoverable, and consistent. Avoid: vendor logos, brand colors, circuit-board textures, gears, or generic checkmark clip art as the dominant motif."
+layout: post.njk
+site_title: Tech Notes
+summary: "FakeItEasy's entire design fits behind one idea: whatever you're doing with a fake, stubbing or verifying, it goes through the same entry point, A.CallTo(...). A setup guide for the single unified API, argument matching, and the precise MustHaveHappened variants."
+tags: ["dotnet", "testing", "tooling", "developer-productivity"]
+title: "Getting Started with FakeItEasy in .NET"
+---
+
+FakeItEasy's entire design fits behind one idea: whatever you're doing with a fake - stubbing a return value or verifying a call happened - it goes through the same entry point, `A.`. There's no separate mental model for "arranging" versus "asserting" the way some libraries split those concerns into different syntaxes. Once you know `A.Fake<T>()` creates a fake and `A.CallTo(...)` is how you interact with it either way, you've learned most of the library.
+
+This guide covers installing FakeItEasy, bootstrapping fakes and configuring behavior correctly, the core patterns for stubbing, verification, and argument matching under its single unified API, and the best practices that make the most of that consistency. By the end you'll have a test suite where stubbing and verifying share one discoverable shape, rather than two.
+
+If you're deciding between mocking libraries first, [a comparison of the top .NET mocking libraries](/posts/2027-12-07-top-5-dotnet-mocking-libraries-compared/) covers where FakeItEasy fits relative to Moq, NSubstitute, JustMock, and Rocks.
+
+## What You'll Need
+
+- .NET 8 SDK or later
+- An existing test project (xUnit, NUnit, or MSTest all work identically well with FakeItEasy)
+
+## Installing FakeItEasy
+
+```bash
+dotnet add package FakeItEasy
+```
+
+## Bootstrapping the Ideal Environment
+
+### Creating and configuring a fake
+
+```csharp
+public class OrderServiceTests
+{
+    [Fact]
+    public async Task ProcessOrder_MarksOrderAsProcessing()
+    {
+        var repository = A.Fake<IOrderRepository>();
+        var order = new Order { Id = 1, Status = OrderStatus.Pending };
+
+        A.CallTo(() => repository.GetByIdAsync(1)).Returns(order);
+
+        var sut = new OrderService(repository);
+
+        await sut.ProcessAsync(1);
+
+        Assert.Equal(OrderStatus.Processing, order.Status);
+        A.CallTo(() => repository.SaveAsync(order)).MustHaveHappenedOnceExactly();
+    }
+}
+```
+
+`A.Fake<T>()` creates the fake - no wrapper type, used directly the same way NSubstitute's substitutes are. `A.CallTo(...)` is the single entry point for both configuring behavior (`.Returns(...)`) and verifying it happened (`.MustHaveHappenedOnceExactly()`), which is the whole point of FakeItEasy's design.
+
+### Argument matching
+
+```csharp
+A.CallTo(() => repository.GetByIdAsync(A<int>.Ignored)).Returns(order);
+
+A.CallTo(() => repository.SaveAsync(A<Order>.That.Matches(o => o.Status == OrderStatus.Processing)))
+    .Returns(Task.CompletedTask);
+```
+
+`A<T>.Ignored` matches any argument of that type, and `A<T>.That.Matches(predicate)` matches a specific condition - the same conceptual role as `It.IsAny<T>()`/`It.Is<T>()` in Moq or `Arg.Any<T>()`/`Arg.Is<T>()` in NSubstitute, expressed through FakeItEasy's own vocabulary.
+
+### Verifying calls
+
+```csharp
+A.CallTo(() => repository.SaveAsync(A<Order>.Ignored)).MustHaveHappenedOnceExactly();
+A.CallTo(() => repository.DeleteAsync(A<int>.Ignored)).MustNotHaveHappened();
+A.CallTo(() => repository.GetByIdAsync(A<int>.Ignored)).MustHaveHappened(2, Times.OrMore);
+```
+
+Because verification uses the same `A.CallTo(...)` shape as stubbing, there's no separate syntax to learn for assertions - just a different terminal call (`.MustHaveHappenedOnceExactly()` instead of `.Returns(...)`).
+
+### Sequential returns
+
+```csharp
+A.CallTo(() => repository.GetNextIdAsync()).ReturnsNextFromSequence(1, 2, 3);
+```
+
+`ReturnsNextFromSequence` is FakeItEasy's equivalent of Moq's `SetupSequence` or NSubstitute's multi-value `Returns(...)` - configuring different return values across successive calls.
+
+## Core Workflow
+
+- **Use `A.Fake<T>()` to create, and interact with the fake directly** - no wrapper object, the same pattern as NSubstitute.
+- **Route both stubbing and verification through `A.CallTo(...)`.** This consistency is FakeItEasy's core value proposition - lean into it rather than looking for a separate verification-specific syntax.
+- **Use `A<T>.Ignored` for irrelevant arguments, `A<T>.That.Matches(...)` for conditions that matter.** The same argument-matching discipline that applies across every mocking library in this series.
+
+## Verifying Your Setup
+
+1. **Fakes are created and configured correctly** - confirm `A.Fake<T>()` produces an instance usable directly, with `A.CallTo(...)` correctly configuring its behavior
+2. **Argument matchers behave as expected** - confirm `A<T>.That.Matches(...)` predicates correctly discriminate between matching and non-matching calls
+3. **Verification catches missing or unexpected interactions** - deliberately break a test's expected call count and confirm `MustHaveHappened...` assertions actually fail
+4. **Verification and stubbing both read consistently** - confirm your team is actually taking advantage of the one-API-shape consistency rather than mixing in patterns from other libraries out of habit
+
+## Best Practices
+
+**Route everything through `A.CallTo(...)` consistently.** The library's core value is having one shape for both stubbing and verification - inconsistent usage (or mixing in habits from another library) undermines the exact benefit you chose FakeItEasy for.
+
+**Use `A<T>.Ignored` for arguments the test doesn't care about, and `A<T>.That.Matches(...)` for ones it does.** Over- or under-specifying arguments has the same costs here as in any mocking library.
+
+**Choose the precise `MustHaveHappened...` variant that matches your actual intent.** `MustHaveHappenedOnceExactly()`, `MustHaveHappened(n, Times.OrMore)`, and others give you fine control - pick the one that actually expresses what you're testing, not just whichever compiles.
+
+**Keep fake configuration close to the test using it.** The same discipline that applies to any mocking library - excessive shared setup makes individual tests harder to understand in isolation.
+
+**Take advantage of FakeItEasy's discoverability by exploring what hangs off `A.` when uncertain.** Since nearly everything is accessible from that one entry point, IDE autocomplete on `A.` is a genuinely useful way to discover capabilities you might not know about yet.
+
+## Comparison with NSubstitute
+
+| | FakeItEasy | NSubstitute |
+| --- | --- | --- |
+| Syntax | Single API: `A.CallTo(...)` for both stubbing and verification | Direct calls on the substitute; `Received()`/`DidNotReceive()` for verification |
+| Accessing the fake | The fake itself, no wrapper | The substitute itself, no wrapper |
+| Consistency model | One shape for stub and verify | Two related but distinct patterns (direct call vs. Received) |
+| Strict mocking | Not supported by default, similar to NSubstitute | Not supported |
+| Community | Solid, loyal following | Large, grew significantly post-2023 |
+
+Both avoid a wrapper object and share similar ergonomics - the real difference is philosophical: FakeItEasy's single `A.CallTo(...)` entry point for everything versus NSubstitute's slightly more varied (but still minimal) syntax split between direct calls and `Received()`.
+
+## Frequently Asked Questions
+
+### What's the advantage of FakeItEasy's single A.CallTo(...) API over having separate stub and verify syntax?
+
+Consistency and discoverability - you only need to learn one pattern for interacting with a fake, whether you're configuring its behavior or checking that an interaction happened. Some teams find this genuinely reduces cognitive load; others don't find the distinction (as in Moq or NSubstitute, where stubbing and verification look somewhat different) to be a real problem in practice. It's a legitimate but ultimately stylistic differentiator.
+
+### Does FakeItEasy support strict mocking, where unconfigured calls throw?
+
+Not by default - similar to NSubstitute, unconfigured calls on a FakeItEasy fake return a default value rather than throwing. If strict-by-default behavior is a hard requirement for your testing philosophy, Moq's `MockBehavior.Strict` is the more direct fit among the mainstream open-source options.
+
+### What's the difference between MustHaveHappenedOnceExactly and MustHaveHappened?
+
+`MustHaveHappenedOnceExactly()` requires the call to have happened exactly one time, no more and no less. `MustHaveHappened(n, Times.OrMore)` (or similar variants) gives you more flexible count constraints - at least n times, exactly n times, or other combinations. Choose the variant that actually matches what you're verifying, rather than defaulting to the loosest one that happens to pass.
+
+### Can FakeItEasy mock static methods or sealed classes?
+
+No - like Moq and NSubstitute, FakeItEasy relies on runtime proxy generation for interfaces and virtual members. JustMock's commercial edition is the option in this comparison series capable of mocking statics and sealed classes, using the .NET Profiling API.
+
+### How do I make a fake's return value depend on the arguments it received?
+
+Use `A.CallTo(...).ReturnsLazily((call) => ComputeResult(call.GetArgument<int>(0)))`, FakeItEasy's mechanism for computing a dynamic return value based on the actual call, analogous to Moq's lambda-based `Returns` or NSubstitute's `callInfo` pattern.
+
+### Is FakeItEasy actively maintained and production-ready?
+
+Yes - it's a mature, established library with a loyal following that predates the Moq controversy, not simply a beneficiary of 2023's migration wave. It's a legitimate, well-supported choice on its own technical merits, separate from any comparison to Moq's history.
+
+### What's the most common mistake in a first FakeItEasy setup?
+
+Not taking advantage of the single `A.CallTo(...)` consistency and mixing in mental models from another mocking library, which can lead to verbose or inconsistent test code that doesn't reflect FakeItEasy's actual design intent. The second common mistake is choosing an imprecise `MustHaveHappened...` variant that happens to pass rather than one that actually expresses the specific interaction count being verified.

--- a/src/posts/2028-01-04-getting-started-with-justmock.md
+++ b/src/posts/2028-01-04-getting-started-with-justmock.md
@@ -1,0 +1,175 @@
+---
+author: Steve Kaschimer
+date: 2028-01-04
+image: /images/posts/2028-01-04-hero.webp
+image_alt: "A rectangle with a small elevated-key badge implying a deeper unlocked capability, distinct from a plainer twin rectangle beside it representing the free basic mode."
+image_prompt: "A dark-mode technical editorial illustration on a near-black background with electric teal, amber, and off-white accents. Composition centers on two nearly identical flat rectangles side by side - the left one plain, representing basic proxy-based mocking, the right one carrying a small amber key-shaped badge in its corner, implying an elevated, unlocked capability layered on top via a deeper mechanism. A faint lock icon sits above the badge, needing to be explicitly opened. Mood is capable, deliberate, and distinctly commercial in its advanced tier. Avoid: vendor logos, brand colors, circuit-board textures, gears, or generic checkmark clip art."
+layout: post.njk
+site_title: Tech Notes
+summary: "JustMock answers a question the other mocking libraries in this series can't: what do you do when the code under test has a static dependency, a sealed class, or a non-virtual method, and refactoring it isn't realistic right now. A setup guide for the free Lite tier and the commercial Profiler-based elevated mode."
+tags: ["dotnet", "testing", "tooling", "developer-productivity"]
+title: "Getting Started with JustMock in .NET"
+---
+
+JustMock exists to answer a question the other mocking libraries in this series can't: what do you do when the code you need to test has a static dependency, a sealed class, or a non-virtual method, and refactoring it to be more mockable isn't a realistic option right now? Every proxy-based mocking library (Moq, NSubstitute, FakeItEasy) requires an interface or virtual member to intercept - JustMock's commercial edition sidesteps that requirement entirely using the .NET Profiling API, at the cost of needing to actually enable that more invasive mode deliberately.
+
+This guide covers installing JustMock, bootstrapping both its free (Lite) and commercial (elevated) modes, the core patterns for basic mocking and the advanced scenarios that are JustMock's actual reason for existing, and the best practices for knowing when you need elevated mode versus when a simpler library would do. By the end you'll know exactly which mode a given testing scenario actually requires.
+
+If you're deciding between mocking libraries first, [a comparison of the top .NET mocking libraries](/posts/2027-12-07-top-5-dotnet-mocking-libraries-compared/) covers where JustMock fits relative to Moq, NSubstitute, FakeItEasy, and Rocks.
+
+## What You'll Need
+
+- .NET 8 SDK or later
+- For basic mocking (interfaces, virtual members): nothing beyond the NuGet package
+- For elevated mocking (statics, sealed classes, non-virtual members): the JustMock Profiler, enabled via Visual Studio or CI integration, and a commercial license
+
+## Installing JustMock
+
+For the free tier:
+
+```bash
+dotnet add package JustMock
+```
+
+This is JustMock Lite - basic proxy-based mocking of interfaces and virtual members, comparable in scope to Moq, NSubstitute, or FakeItEasy. It requires no profiler and no license.
+
+For elevated mocking (statics, sealed classes, non-virtual members), you need the commercial edition, licensed through Telerik/Progress, with the Profiler enabled via the JustMock Visual Studio extension or your CI pipeline's integration.
+
+## Bootstrapping the Ideal Environment
+
+### Basic mode: interfaces and virtual members
+
+```csharp
+public class OrderServiceTests
+{
+    [Fact]
+    public async Task ProcessOrder_MarksOrderAsProcessing()
+    {
+        var repository = Mock.Create<IOrderRepository>();
+        var order = new Order { Id = 1, Status = OrderStatus.Pending };
+
+        Mock.Arrange(() => repository.GetByIdAsync(1)).Returns(Task.FromResult(order));
+
+        var sut = new OrderService(repository);
+
+        await sut.ProcessAsync(1);
+
+        Assert.Equal(OrderStatus.Processing, order.Status);
+        Mock.Assert(() => repository.SaveAsync(order), Occurs.Once());
+    }
+}
+```
+
+`Mock.Create<T>()`, `Mock.Arrange(...)`, and `Mock.Assert(...)` follow JustMock's Arrange/Act/Assert-aligned naming - conceptually similar to Moq's `Setup`/`Verify`, just named to match the AAA testing pattern directly.
+
+### Elevated mode: mocking a static method
+
+This is where JustMock does something the other libraries in this comparison structurally can't:
+
+```csharp
+[Fact]
+public void ProcessOrder_UsesCurrentTimestamp()
+{
+    Mock.Arrange(() => DateTime.Now).Returns(new DateTime(2026, 1, 1));
+
+    var order = OrderService.CreateOrder();
+
+    Assert.Equal(new DateTime(2026, 1, 1), order.CreatedAt);
+}
+```
+
+Mocking `DateTime.Now` directly - a static, framework property - is exactly the kind of scenario that requires elevated mode and the Profiler API. Enable elevated mode from the JustMock menu in Visual Studio (or your CI's equivalent integration) before running tests that use this capability; forgetting to enable it is the most common reason an elevated-mode test fails mysteriously.
+
+### Mocking a sealed class
+
+```csharp
+[Fact]
+public void ProcessOrder_HandlesSealedDependency()
+{
+    var sealedDependency = Mock.Create<SealedPaymentProcessor>();
+    Mock.Arrange(() => sealedDependency.Charge(100m)).Returns(true);
+
+    var result = sealedDependency.Charge(100m);
+
+    Assert.True(result);
+}
+```
+
+The same `Mock.Create<T>()` syntax works for a sealed class once elevated mode is active - JustMock doesn't require different syntax for basic versus elevated scenarios, which is part of its appeal for legacy code where you don't want to rewrite tests as you gradually encounter harder-to-mock dependencies.
+
+### Partial mocking, keeping the real object mostly intact
+
+```csharp
+var order = Mock.Create<Order>(Behavior.CallOriginal);
+Mock.Arrange(() => order.CalculateDiscount()).Returns(0.1m);
+// order.OtherMethods() still execute their real implementation
+```
+
+Partial mocking lets you fake only specific members of an object while leaving the rest of its behavior real - useful for legacy classes where you need to isolate just one problematic dependency without faking the entire object.
+
+## Core Workflow
+
+- **Default to basic mode (JustMock Lite) whenever your code is already interface-driven or uses virtual members.** There's no reason to reach for elevated mode's added complexity and licensing cost for scenarios the free tier already handles.
+- **Reach for elevated mode specifically when refactoring toward mockability isn't practical right now.** Static dependencies, sealed classes, and non-virtual members in legacy code are exactly the scenario elevated mode exists for.
+- **Remember to enable/disable elevated mode explicitly around tests that need it.** This is a genuinely different operational step from any other library in this series - it's not automatic.
+
+## Verifying Your Setup
+
+1. **Basic mode tests run without needing the Profiler** - confirm interface and virtual-member mocking works with just the NuGet package, no elevated mode required
+2. **Elevated mode is actually enabled when needed** - confirm tests mocking statics, sealed classes, or non-virtual members fail clearly (not mysteriously) if elevated mode isn't active, and pass once it is
+3. **CI pipeline correctly enables the Profiler for elevated-mode tests** - confirm your CI configuration (Azure Pipelines, GitLab, Jenkins) includes JustMock's integration step, not just the test run itself
+4. **Licensing covers your actual usage** - confirm your team's license tier actually includes elevated mocking if your test suite depends on it
+
+## Best Practices
+
+**Use JustMock Lite (free) as your default, and only reach for the commercial elevated features when you actually hit a static, sealed, or non-virtual dependency you can't refactor around.** Paying for and configuring elevated mode for scenarios the free tier already covers is unnecessary overhead.
+
+**Treat elevated-mode dependencies as a signal, not just a testing convenience.** If you're regularly needing to mock statics or sealed classes, it's worth asking whether the code under test could be refactored toward more standard dependency injection over time - elevated mocking is a pragmatic tool for legacy code, not necessarily a permanent architectural stance.
+
+**Explicitly configure CI integration for elevated mode, don't assume it works out of the box.** The Profiler needs to be part of your build/test pipeline configuration - verify this is set up correctly rather than discovering a gap when elevated-mode tests fail in CI but pass locally.
+
+**Use partial mocking sparingly and deliberately.** It's a genuinely useful tool for legacy code, but faking part of an object while leaving the rest real can make test behavior harder to reason about if overused.
+
+**Budget for licensing costs as part of adopting JustMock's full capability.** Unlike every other library in this comparison, meaningful parts of JustMock's value proposition require a paid license - factor this into the decision honestly rather than assuming free-tier parity with the commercial features.
+
+## Comparison with Moq
+
+| | JustMock | Moq |
+| --- | --- | --- |
+| Mechanism | Proxy-based (free) + Profiler API (commercial) | Runtime proxy generation only |
+| Mocks statics/sealed/non-virtual | Yes, commercial edition only | No |
+| License | Free tier + commercial | Fully open source |
+| Best fit | Legacy code with hard-to-refactor dependencies | Standard interface-driven codebases |
+| Syntax | `Mock.Create`/`Mock.Arrange`/`Mock.Assert` | `Mock<T>`, `Setup`/`Returns`/`Verify` |
+
+For a standard, interface-driven codebase, Moq (or NSubstitute, or FakeItEasy) covers the need without any licensing cost. JustMock's real value is specifically for the harder cases those libraries can't reach at all.
+
+## Frequently Asked Questions
+
+### Do I need to pay for JustMock to use it at all?
+
+No - JustMock Lite is free and open source, covering basic mocking of interfaces and virtual members comparable to Moq, NSubstitute, or FakeItEasy. Payment is only required for the commercial edition's elevated mocking capabilities (statics, sealed classes, non-virtual members), which use the .NET Profiling API.
+
+### What is elevated mode, and why does it need to be explicitly enabled?
+
+Elevated mode activates JustMock's Profiler API integration, which intercepts calls at a lower level than standard proxy generation - capable of mocking things (statics, sealed classes, non-virtual members) that proxy-based approaches structurally can't reach. It requires explicit enabling (via the JustMock Visual Studio menu, or CI integration) because it's a more invasive mechanism than ordinary mocking, not something safe to have silently active for every test run by default.
+
+### Why would I mock a static method or sealed class instead of just refactoring the code?
+
+In an ideal world, you'd refactor toward interfaces and dependency injection. In practice, legacy codebases often have static dependencies deeply embedded across a large surface area, and refactoring everything before you can write any tests is often a much bigger, riskier undertaking than the actual testing task at hand. JustMock's elevated mocking lets you write meaningful tests now, with refactoring toward more standard patterns as a separate, incremental effort if desired.
+
+### Does JustMock work with xUnit, NUnit, and MSTest?
+
+Yes - JustMock integrates with all the major .NET test frameworks; its mocking API is independent of which test framework you use to structure and run the tests themselves.
+
+### How do I set up JustMock's elevated mode in a CI pipeline?
+
+JustMock provides specific integration steps for Azure Pipelines, GitLab CI/CD, Jenkins, and MSBuild - these need to be explicitly configured as part of your pipeline, since elevated mode's Profiler API requires the CI environment to activate it the same way Visual Studio does locally. Consult JustMock's current CI integration documentation for your specific platform, since this is a genuinely different setup step from any other library in this comparison.
+
+### Should I use JustMock for a new, greenfield project?
+
+Usually not as the default - if you're writing new, interface-driven code, Moq, NSubstitute, or FakeItEasy will cover your needs without licensing cost or the added complexity of elevated mode. JustMock's distinctive value is specifically for legacy code with dependencies the other libraries can't reach.
+
+### What's the most common mistake in a first JustMock setup?
+
+Forgetting to enable elevated mode before running tests that mock statics, sealed classes, or non-virtual members, resulting in confusing failures that don't clearly indicate the actual problem. The second common mistake is reaching for elevated mocking by default rather than defaulting to the free, simpler basic mode for code that's already interface-driven and doesn't need it.

--- a/src/posts/2028-01-11-getting-started-with-rocks.md
+++ b/src/posts/2028-01-11-getting-started-with-rocks.md
@@ -1,0 +1,165 @@
+---
+author: Steve Kaschimer
+date: 2028-01-11
+image: /images/posts/2028-01-11-hero.webp
+image_alt: "A solid compiled-code bracket glyph with a small checkmark seal, connected by a four-step chain of nodes distinct from the shorter two-step chains used by the other libraries."
+image_prompt: "A dark-mode technical editorial illustration on a near-black background with electric teal, amber, and off-white accents. Composition centers on a solid bracket-shaped glyph on the left with a small amber compiler-checkmark seal beside it, implying compiled, verified code rather than a runtime construct. To the right, four small connected nodes in a row represent a more explicit multi-step flow, each node slightly smaller than the last. Mood is precise, generated, and deliberately more structured than the rest of the series. Avoid: vendor logos, brand colors, circuit-board textures, gears, or generic checkmark clip art as the dominant motif beyond the single seal described."
+layout: post.njk
+site_title: Tech Notes
+summary: "Rocks asks you to accept one trade upfront: a smaller community and a genuinely different syntax, in exchange for mocks that are ordinary, compiler-checked C# code instead of runtime-generated proxies. A setup guide for the Create/Methods/Instance/Verify flow and Native AOT compatibility."
+tags: ["dotnet", "testing", "tooling", "performance"]
+title: "Getting Started with Rocks in .NET"
+---
+
+Rocks asks you to accept one trade upfront: a smaller community and a genuinely different syntax, in exchange for mocks that are ordinary, compiler-checked C# code instead of runtime-generated proxies. There's no `System.Reflection.Emit`, no IL generation happening behind the scenes that you can't step into while debugging - Rocks uses C# source generators to write real mock classes at build time, which is also exactly what makes it compatible with Native AOT and trimmed deployments in a way every proxy-based library in this comparison structurally isn't.
+
+This guide covers installing Rocks, bootstrapping expectations and mocks with its source-generated model, the core patterns for configuring and verifying behavior, and the best practices for adopting a tool whose architecture (not just its API) differs from what most .NET developers already know. By the end you'll have compile-time-checked mocks and a clear sense of when that trade-off is worth making.
+
+If you're deciding between mocking libraries first, [a comparison of the top .NET mocking libraries](/posts/2027-12-07-top-5-dotnet-mocking-libraries-compared/) covers where Rocks fits relative to Moq, NSubstitute, FakeItEasy, and JustMock.
+
+## What You'll Need
+
+- .NET 8 SDK or later (Rocks generates code targeting recent .NET versions - check current documentation for the exact minimum, since this has moved forward with each major release)
+- A recent C# language version, since Rocks relies on modern source generator capabilities
+
+## Installing Rocks
+
+```bash
+dotnet add package Rocks
+```
+
+That's the entire installation - no separate analyzer package or profiler to configure. Referencing the package is sufficient because Rocks operates entirely through source generation triggered at build time.
+
+## Bootstrapping the Ideal Environment
+
+### The core mocking pattern
+
+```csharp
+public interface IOrderRepository
+{
+    Task<Order?> GetByIdAsync(int id);
+    Task SaveAsync(Order order);
+}
+```
+
+```csharp
+[Fact]
+public async Task ProcessOrder_MarksOrderAsProcessing()
+{
+    var expectations = Rock.Create<IOrderRepository>();
+    var order = new Order { Id = 1, Status = OrderStatus.Pending };
+
+    expectations.Methods().GetByIdAsync(1).ReturnValue(Task.FromResult<Order?>(order));
+    expectations.Methods().SaveAsync(order);
+
+    var repository = expectations.Instance();
+    var sut = new OrderService(repository);
+
+    await sut.ProcessAsync(1);
+
+    Assert.Equal(OrderStatus.Processing, order.Status);
+    expectations.Verify();
+}
+```
+
+The pattern has three distinct steps, more explicit than the other libraries in this comparison: `Rock.Create<T>()` builds an expectations object, `.Methods()` configures what calls are expected and what they return, `.Instance()` produces the actual mock you pass to your system under test, and `.Verify()` confirms every configured expectation was actually met.
+
+### Why this looks different: source generation, not runtime proxying
+
+When you call `Rock.Create<IOrderRepository>()`, a source generator has already produced real, compilable C# code implementing `IOrderRepository` specifically for your test - not at test-run time via reflection, but at build time, checked by the compiler like any other code in your project. This is why you can set a breakpoint and step directly into the generated mock code during debugging, something that isn't meaningfully possible with a runtime-proxy-based library.
+
+### Configuring return values and verifying call counts
+
+```csharp
+var expectations = Rock.Create<IOrderRepository>();
+
+expectations.Methods().GetByIdAsync(Arg.Is<int>(id => id > 0))
+    .ReturnValue(Task.FromResult<Order?>(order));
+
+var repository = expectations.Instance();
+
+// ... use repository ...
+
+expectations.Verify(); // fails if configured expectations weren't met
+```
+
+Rocks' `Arg.Is<T>(predicate)` plays the same role as the equivalent argument matcher in any other library in this comparison - configuring a match condition rather than an exact value.
+
+### Handling properties and events
+
+```csharp
+var expectations = Rock.Create<IOrderNotifier>();
+expectations.Properties().Getters().IsEnabled().ReturnValue(true);
+
+var notifier = expectations.Instance();
+Assert.True(notifier.IsEnabled);
+```
+
+Rocks generates dedicated, strongly-typed configuration surfaces for methods, properties, and events separately - reflecting its overall design philosophy of exposing exactly what a given member type needs, generated specifically for the interface being mocked, rather than one generic API surface shared across every kind of member.
+
+## Core Workflow
+
+- **Create expectations, configure them, get the instance, use it, then verify.** This five-step flow (`Create` → configure → `Instance` → exercise → `Verify`) is more explicit than other libraries' patterns - treat the extra structure as the trade-off for compile-time safety, not unnecessary ceremony.
+- **Lean on IDE tooling and compiler errors rather than runtime failures for configuration mistakes.** Because mocks are real generated code, a lot of what would be a runtime exception in a proxy-based library becomes a compile error with Rocks instead.
+- **Use Rocks specifically where AOT compatibility or compile-time checking are genuine requirements**, not simply because it's newer - the syntax adjustment is real and worth being intentional about taking on.
+
+## Verifying Your Setup
+
+1. **Source generation is actually running** - confirm generated mock code appears in your build output (visible via "Go to Definition" or your IDE's generated files view) and that IntelliSense reflects it correctly
+2. **Expectations and verification work as intended** - confirm `.Verify()` fails when a configured expectation wasn't actually met, and passes when it was
+3. **Native AOT compatibility holds, if that's your reason for choosing Rocks** - confirm `dotnet publish` with AOT settings succeeds for a project using Rocks-based mocks
+4. **You can step into generated mock code while debugging** - confirm this genuinely works, since it's one of Rocks' concrete practical advantages over proxy-based libraries
+
+## Best Practices
+
+**Adopt Rocks specifically for AOT/trimming requirements or a genuine desire for compile-time-checked mocks**, not simply because it's the newest option. Its smaller community means more of the troubleshooting burden falls on you directly compared to Moq or NSubstitute.
+
+**Get comfortable with its more explicit, multi-step pattern rather than expecting Moq or NSubstitute's shorter syntax.** The extra structure (`Create` → `Methods()` → `Instance()` → `Verify()`) is a direct consequence of its source-generated architecture, not arbitrary verbosity.
+
+**Take advantage of being able to step into generated mock code during debugging.** This is a genuine, concrete benefit worth using when a test's mock-related behavior isn't doing what you expect - inspect the actual generated implementation rather than treating it as a black box.
+
+**Check current documentation for target framework requirements before committing**, since Rocks' generated code target has moved forward across major versions, and using an older guide's exact framework assumptions could be outdated.
+
+**Evaluate IDE and CI tooling compatibility given the smaller ecosystem.** Confirm your specific combination of IDE and build pipeline handles Rocks' source generators smoothly before adopting it for a project of real consequence.
+
+## Comparison with Moq
+
+| | Rocks | Moq |
+| --- | --- | --- |
+| Mechanism | Compile-time source generation | Runtime proxy generation |
+| Native AOT support | Yes | No |
+| Debugging | Can step into generated mock code | Proxy internals not meaningfully steppable |
+| Syntax | More explicit, multi-step (`Create`/`Methods`/`Instance`/`Verify`) | Concise (`Setup`/`Returns`/`Verify`) |
+| Community | Small, newer | Largest, most established |
+
+Rocks trades Moq's syntax familiarity and ecosystem size for genuine architectural advantages (AOT compatibility, compile-time checking, debuggable generated code) - the right choice depends on whether those specific advantages matter for your deployment target, not on which is "better" in the abstract.
+
+## Frequently Asked Questions
+
+### Why does Rocks use a different, more explicit syntax than Moq or NSubstitute?
+
+Because it's solving mocking a fundamentally different way - generating real C# code at compile time via source generators rather than a runtime proxy via reflection-emitted IL. The more explicit `Create`/`Methods()`/`Instance()`/`Verify()` flow reflects that architecture directly; it's not extra ceremony for its own sake, but a consequence of mocks being actual generated code rather than a dynamically synthesized object.
+
+### Does Rocks actually support Native AOT, or is that aspirational?
+
+Yes, genuinely - because Rocks generates real C# code at build time rather than relying on runtime reflection or dynamic proxy generation (both of which are hostile to AOT compilation), it's compatible with Native AOT and trimmed deployments in a way that Moq, NSubstitute, and FakeItEasy structurally are not, since all three depend on runtime proxy generation.
+
+### Can I step into Rocks' generated mock code while debugging?
+
+Yes - since the mock is ordinary, compiled C# code rather than IL emitted at runtime, your debugger can step into it the same way it would step into any other method in your codebase. This is one of Rocks' concrete, practical advantages, not just an architectural talking point.
+
+### Is Rocks a mature, battle-tested library?
+
+It's been under development for a number of years and has a working, capable feature set, but its real-world adoption and community size are meaningfully smaller than Moq, NSubstitute, or FakeItEasy. Evaluate it on its specific architectural merits for your use case (AOT compatibility, compile-time checking) rather than assuming equivalent ecosystem maturity to the more established options.
+
+### Do I need to learn a completely different mental model to use Rocks?
+
+The core concepts (create a mock, configure expected calls and return values, verify they happened) are the same as any mocking library - what's different is the specific syntax and the underlying mechanism. Expect a real but not enormous learning curve if you're coming from Moq or NSubstitute, mostly around Rocks' more explicit, multi-step configuration flow.
+
+### Can Rocks mock static methods or sealed classes like JustMock?
+
+No - Rocks still requires an interface or unsealed class with virtual members, since it generates an implementing type via source generation, the same fundamental requirement proxy-based libraries have (just satisfied through a different mechanism). JustMock's commercial elevated mode remains the only option in this comparison series capable of mocking statics and sealed classes.
+
+### What's the most common mistake when adopting Rocks?
+
+Adopting it purely because it's newer or technically interesting, without an actual AOT or compile-time-checking requirement driving the decision, and then being surprised by the smaller community and less familiar syntax compared to Moq or NSubstitute. The second common mistake is not checking current framework target requirements before starting, since Rocks' generated code target has moved forward across major releases.


### PR DESCRIPTION
## Summary

- Schedules and drafts the .NET Mocking Libraries Tuesday track: a comparison anchor post plus five getting-started guides, running weekly Tuesdays 2027-12-07 through 2028-01-11, picking up the cadence directly after the .NET Background Job Libraries track
- Moves the series from `editorial-plan.md`'s Backlog into a dated `## 📅 Tuesday Track - .NET Mocking Libraries (December 2027-January 2028)` section, all entries `Status: draft` with `File:` paths, and updates the Backlog intro count from six to five remaining series

### Posts added

- **Anchor:** The Top 5 .NET Mocking Libraries Compared: Which One Should You Choose? (2027-12-07) - Moq, NSubstitute, FakeItEasy, JustMock, and Rocks compared, with the full context on Moq's 2023 SponsorLink incident and which library is the only one that can mock statics/sealed classes
- Getting Started with Moq in .NET (2027-12-14)
- Getting Started with NSubstitute in .NET (2027-12-21)
- Getting Started with FakeItEasy in .NET (2027-12-28)
- Getting Started with JustMock in .NET (2028-01-04)
- Getting Started with Rocks in .NET (2028-01-11)

Each setup guide cross-links back to the anchor post, mirroring the structure of the prior .NET ORMs/API Styles/Validation Approaches/Mapping Libraries/Caching Solutions/Message Brokers/Background Job Libraries/Testing/Logging/Architecture tracks.

## Test plan

- [x] `npm run deploy` builds cleanly, all 6 posts render
- [x] `node scripts/a11y-check.js` (axe-core + Playwright) - zero violations across home/post/about/privacy/terms/404 in light and dark mode
- [x] Verified all 5 setup-guide cross-links resolve to the anchor post's output URL


---
_Generated by [Claude Code](https://claude.ai/code/session_01WKyNF7L5qzrfct8cec6A32)_