### PR TITLE
Add .NET Architecture Quality Tools Tuesday track (6 posts)

### DIFF
--- a/editorial-plan.md
+++ b/editorial-plan.md
@@ -1238,17 +1238,69 @@ Six posts on how a .NET test isolates a system under test from its dependencies,
 
 ---
 
-## 📅 Backlog - Unscheduled Series
+## 📅 Tuesday Track - .NET Architecture Quality Tools (January-February 2028)
 
-Five six-post series remain unscheduled, drawn from the drafts in `docs/article-ideas/`. They continue the Tuesday cadence once the .NET Mocking Libraries series ends on 2028-01-11, and they're listed here in priority order. They're deliberately undated - that horizon is too far out to put honest dates against - so each series gets one entry rather than six speculative ones, and entries are expanded into individual dated posts when a series moves onto the calendar.
+Six posts on how a .NET team keeps architecture decisions from silently drifting, picking up the Tuesday cadence directly from the Mocking Libraries track. A comparison post anchors the track and each of the five follow-ups is a complete setup for one enforcement tool.
 
-### .NET Architecture Quality Tools (6 posts)
-- **Status:** `idea`
-- **Source:** `docs/article-ideas/top-5-dotnet-architecture-quality-tools-compared.md` + 5 getting-started drafts
-- **Series:** Top 5 comparison, then SonarQube, NetArchTest, ArchUnitNET, NDepend, Roslyn Analyzers
+### The Top 5 .NET Architecture & Quality Enforcement Tools Compared: Which One Should You Choose?
+- **Status:** `draft`
+- **Scheduled:** 2028-01-18
+- **Source:** `docs/article-ideas/top-5-dotnet-architecture-quality-tools-compared.md`
+- **File:** `src/posts/2028-01-18-top-5-dotnet-architecture-quality-tools-compared.md`
 - **Pitch:** A team agrees the domain layer shouldn't reference infrastructure, everyone nods, and eighteen months later a deadline-pressured change adds exactly that reference. Code review might catch it. These tools make it a build failure instead of a hope.
 - **Angle:** Splits the five into two categories that routinely get conflated - architecture-testing libraries where rules are ordinary unit tests (NetArchTest, ArchUnitNET) versus broad static analysis platforms where architectural rules are one capability among many (SonarQube, NDepend, Roslyn Analyzers). Reframes the question from "which is best" to "which layer of enforcement am I adding," since feedback speed differs by orders of magnitude between compiler-integrated analysis, a test run, and a CI batch job. Pairs directly with the Clean Architecture post's claim that a dependency rule isn't real until something enforces it.
 - **Tags:** `dotnet`, `architecture`, `code-quality`, `testing`, `ci-cd`
+
+### Getting Started with SonarQube in .NET
+- **Status:** `draft`
+- **Scheduled:** 2028-01-25
+- **Source:** `docs/article-ideas/getting-started-with-sonarqube.md`
+- **File:** `src/posts/2028-01-25-getting-started-with-sonarqube.md`
+- **Pitch:** SonarQube's setup story is different from every other tool in this series in one important way: it's not a NuGet package you add and forget, it's a platform your CI pipeline talks to on every analysis run - which is exactly why it can do things a test-scoped library can't.
+- **Angle:** Covers the scanner's `begin`/`end` MSBuild wrapping, wiring up real coverage reports (a misconfigured 0% is worse than no metric at all), and configuring a quality gate focused on new-code conditions rather than demanding an existing codebase retroactively meet a high bar. Flags full Git history (`fetch-depth: 0`) as the easy-to-miss CI setting that silently degrades new-code analysis, and positions SonarQube as complementary to Roslyn Analyzers, not competing with them.
+- **Tags:** `dotnet`, `architecture`, `code-quality`, `ci-cd`
+
+### Getting Started with NetArchTest in .NET
+- **Status:** `draft`
+- **Scheduled:** 2028-02-01
+- **Source:** `docs/article-ideas/getting-started-with-netarchtest.md`
+- **File:** `src/posts/2028-02-01-getting-started-with-netarchtest.md`
+- **Pitch:** NetArchTest's entire value proposition is that architecture rules stop being something written in a design doc nobody rereads and start being something your build actually checks - and the setup is genuinely small enough to do on day one.
+- **Angle:** Covers the fluent `Types.InAssembly(...).Should()...` API for dependency-direction and naming rules, a dedicated architecture-test project referencing every layer under test, and including `FailingTypeNames` in every assertion so a failure is immediately actionable. Direct that rules should reflect real, agreed-upon decisions rather than speculative ones, and that a rule nobody can satisfy anymore deserves a conversation, not a silent deletion.
+- **Tags:** `dotnet`, `architecture`, `testing`, `developer-productivity`
+
+### Getting Started with ArchUnitNET in .NET
+- **Status:** `draft`
+- **Scheduled:** 2028-02-08
+- **Source:** `docs/article-ideas/getting-started-with-archunitnet.md`
+- **File:** `src/posts/2028-02-08-getting-started-with-archunitnet.md`
+- **Pitch:** ArchUnitNET's fluent API reads a lot like NetArchTest's - the real differences show up once you're modeling something more elaborate than "layer A shouldn't depend on layer B."
+- **Angle:** Covers `ArchLoader` for building the architecture model once per test class, named layers as a genuine readability and reuse win over repeated namespace strings, and slice rules for detecting cyclic dependencies between modules - a capability NetArchTest doesn't have natively. Frames the choice against NetArchTest as mostly stylistic for simple layered systems, and a real advantage specifically for Modular Monolith-style module-boundary checks.
+- **Tags:** `dotnet`, `architecture`, `testing`, `developer-productivity`
+
+### Getting Started with NDepend in .NET
+- **Status:** `draft`
+- **Scheduled:** 2028-02-15
+- **Source:** `docs/article-ideas/getting-started-with-ndepend.md`
+- **File:** `src/posts/2028-02-15-getting-started-with-ndepend.md`
+- **Pitch:** NDepend's reputation as the "Swiss Army knife" for .NET code quality comes down to CQLinq - a LINQ-based query language for interrogating your codebase's structure directly, so anything expressible in LINQ is a question you can ask about your code.
+- **Angle:** Covers writing CQLinq rules for both complexity metrics and dependency-direction checks, dependency graph and matrix visualization for spotting structural problems reading code doesn't surface, and quality gates driven by NDepend's own metrics for CI integration. Honest about the per-seat commercial licensing as the real differentiator from every other tool in this series, and that its value scales with codebase size and organizational complexity rather than being a default upgrade.
+- **Tags:** `dotnet`, `architecture`, `code-quality`, `tooling`
+
+### Getting Started with Roslyn Analyzers in .NET
+- **Status:** `draft`
+- **Scheduled:** 2028-02-22
+- **Source:** `docs/article-ideas/getting-started-with-roslyn-analyzers.md`
+- **File:** `src/posts/2028-02-22-getting-started-with-roslyn-analyzers.md`
+- **Pitch:** Roslyn Analyzers have the fastest feedback loop of any tool in this series for a simple reason: they run inside the same compiler that turns code into IL, so a violation shows up before you've even saved the file.
+- **Angle:** Covers installing an existing package (Roslynator, Meziantou.Analyzer) versus authoring a fully custom analyzer against the syntax tree/semantic model APIs, `.editorconfig` severity overrides committed to source control as what makes enforcement team-wide rather than per-developer, and treating warnings as errors in CI specifically while keeping local iteration fast. Flags `OutputItemType="Analyzer"` as the single most common reason a correctly written custom analyzer silently does nothing.
+- **Tags:** `dotnet`, `architecture`, `code-quality`, `developer-productivity`
+
+---
+
+## 📅 Backlog - Unscheduled Series
+
+Four six-post series remain unscheduled, drawn from the drafts in `docs/article-ideas/`. They continue the Tuesday cadence once the .NET Architecture Quality Tools series ends on 2028-02-22, and they're listed here in priority order. They're deliberately undated - that horizon is too far out to put honest dates against - so each series gets one entry rather than six speculative ones, and entries are expanded into individual dated posts when a series moves onto the calendar.
 
 ### CI/CD Platforms for .NET (6 posts)
 - **Status:** `idea`

--- a/src/posts/2028-01-18-top-5-dotnet-architecture-quality-tools-compared.md
+++ b/src/posts/2028-01-18-top-5-dotnet-architecture-quality-tools-compared.md
@@ -1,0 +1,165 @@
+---
+author: Steve Kaschimer
+date: 2028-01-18
+image: /images/posts/2028-01-18-hero.webp
+image_alt: "Five columns of abstract enforcement glyphs positioned along a horizontal axis running from instant compiler-integrated feedback on the left to slower batch-analysis dashboards on the right."
+image_prompt: "A dark-mode technical editorial illustration on a near-black background with electric teal, amber, and off-white accents. Composition is five vertical columns of equal width separated by thin hairline rules, each column topped by a distinct abstract glyph rendered in flat geometry: a narrow assembly-boundary glyph with a single directional arrow crossing a forbidden barrier line, a similar boundary glyph with a richer layered-slice pattern beneath it, a broad dashboard-panel glyph with a gauge and trend line, a lightning-fast in-editor squiggle-underline glyph, and a query-bracket glyph resembling a LINQ expression feeding into a small dependency-graph node cluster. Beneath the glyphs, a shared horizontal axis labeled in monospaced type runs from 'instant' on the left to 'batch analysis' on the right, with a small glowing teal dot positioned at a different point under each column. Mood is comparative, engineering-first, and non-partisan. Avoid: vendor logos, brand colors, circuit-board textures, gears, or generic checkmark clip art used as the dominant motif."
+layout: post.njk
+site_title: Tech Notes
+summary: "A team agrees the domain layer shouldn't reference infrastructure, everyone nods, and eighteen months later a deadline-pressured change adds exactly that reference. These tools make it a build failure instead of a hope. A practical breakdown of five ways to enforce architecture and quality automatically."
+tags: ["dotnet", "architecture", "code-quality", "testing", "ci-cd"]
+title: "The Top 5 .NET Architecture & Quality Enforcement Tools Compared: Which One Should You Choose?"
+---
+
+Architecture decisions have a way of degrading the moment nobody's actively enforcing them. A team agrees the domain layer shouldn't reference infrastructure, everyone nods, and eighteen months later a deadline-pressured developer adds exactly that reference because it was the fastest way to ship a fix. Code review might catch it. It might not. The tools in this comparison exist specifically to make that rule a build failure instead of a hope.
+
+This guide compares five tools .NET teams use to keep architecture and code quality honest over time: NetArchTest, ArchUnitNET, SonarQube, Roslyn Analyzers, and NDepend. They split into two real categories worth understanding upfront - NetArchTest and ArchUnitNET are architecture-testing libraries specifically (you write rules as unit tests), while SonarQube, Roslyn Analyzers, and NDepend are broader static analysis tools that happen to include architectural rule capability alongside a much wider net of code quality, security, and maintainability checks. Picking between them is less "which is best" and more "which layer of enforcement am I actually trying to add." This series continues with dedicated getting-started walkthroughs for each tool.
+
+## Quick Comparison
+
+| | NetArchTest | ArchUnitNET | SonarQube | Roslyn Analyzers | NDepend |
+| --- | --- | --- | --- | --- | --- |
+| **Category** | Architecture testing library | Architecture testing library | Broad static analysis platform | Compiler-integrated code analysis | Broad static analysis + architecture tool |
+| **Where it runs** | Inside your test suite | Inside your test suite | Separate server, CI-integrated | In the compiler itself, every build | Standalone tool + CI integration |
+| **Feedback speed** | Test-run speed | Test-run speed | CI pipeline speed (batch analysis) | Instant, at every keystroke/build | Analysis-run speed |
+| **Scope** | Dependency and naming rules specifically | Dependency and naming rules specifically | Code smells, security, duplication, coverage, architecture | Code style, correctness, API usage, custom rules | Code quality, dependency graphs, trend tracking, architecture |
+| **License** | Free, open source | Free, open source | Free (Community) + paid tiers | Free, built into the SDK | Commercial |
+| **Best for** | Lightweight, test-driven boundary enforcement | Same as NetArchTest, more expressive fluent API | Organization-wide quality gates across many repos | Real-time feedback on every keystroke, custom team rules | Deep dependency analysis and quality trend tracking over time |
+
+## NetArchTest
+
+NetArchTest is a fluent, ArchUnit-inspired library purpose-built for one job: writing architectural rules as ordinary unit tests. It reads types from a compiled assembly and lets you assert things like "classes in this namespace shouldn't depend on that namespace" using a chainable API that reads close to natural language.
+
+**Strengths:**
+
+- Minimal setup - it's a NuGet package added to your existing test project, with no separate server, license, or infrastructure
+- Runs as part of your normal test suite, meaning architecture violations show up in the same feedback loop as any other failing test, at the same speed
+- The fluent API (`Types.InAssembly(...).ShouldNot().HaveDependencyOn(...)`) is genuinely readable, making rules easy to write and easy for a reviewer to understand at a glance
+- Works well specifically for the dependency-direction rules that Clean Architecture, Modular Monolith, and similar patterns depend on being enforced
+
+**Weaknesses:**
+
+- Narrow in scope by design - it doesn't touch code smells, security vulnerabilities, duplication, or the broader quality concerns SonarQube or NDepend cover
+- Being reflection-based, it inspects compiled assemblies, which means rules run against build output, not live source - a minor but real distinction from analyzers that see your code as you type it
+- No dashboard, trend tracking, or visualization - results are pass/fail test output, nothing more
+
+**Choose this when:** you specifically want to enforce dependency-direction and structural rules (Clean Architecture layers, Modular Monolith boundaries) as part of your existing test suite, without adopting a broader static analysis platform.
+
+## ArchUnitNET
+
+ArchUnitNET is NetArchTest's closest sibling - also a fluent, architecture-testing library, also inspired by Java's ArchUnit, also designed to be written as unit tests. The choice between the two is largely about API expressiveness and specific feature preferences rather than a fundamentally different approach.
+
+**Strengths:**
+
+- A more expressive rule-definition API in some areas than NetArchTest, with richer support for describing layers, slices, and more complex structural relationships
+- First-class integration packages for xUnit, NUnit, and MSTest specifically, making it drop directly into whichever test framework your project already uses
+- Same core benefit as NetArchTest - architecture rules live in your test suite, run at test speed, and fail your build the same way any other test failure would
+
+**Weaknesses:**
+
+- Smaller adoption and community than NetArchTest specifically, despite comparable capability, meaning somewhat less documentation and fewer examples to draw on
+- Same narrow scope as NetArchTest - purely architectural/structural rules, not a substitute for broader code quality tooling
+- The choice between ArchUnitNET and NetArchTest often comes down to which specific rule syntax a team finds more natural, which isn't always obvious without trying both firsthand
+
+**Choose this when:** you want the same architecture-testing approach as NetArchTest but find its specific rule vocabulary or feature set (layer/slice modeling, in particular) a better fit for how you want to express your project's structure.
+
+## SonarQube
+
+SonarQube is a full static analysis platform, not a library you add to a test project - it runs as a server (self-hosted or SonarCloud) that your CI pipeline sends analysis results to, producing a dashboard tracking code smells, bugs, security vulnerabilities, duplication, test coverage, and yes, some architectural constraints like dependency cycles.
+
+**Strengths:**
+
+- Far broader scope than either architecture-testing library - one platform covering code smells, security hotspots, duplication, coverage trends, and some dependency/architecture checks together
+- Quality gates can block a pull request or deployment from proceeding if metrics fall below a defined threshold, giving you an organization-wide enforcement mechanism, not just a per-repo one
+- Strong for tracking trends over time across many repositories - a view NetArchTest or ArchUnitNET, being test-scoped, don't provide
+- Free Community edition covers a meaningful amount of functionality; paid tiers add more advanced security and portfolio-level features
+
+**Weaknesses:**
+
+- Requires standing up and maintaining a separate server (or paying for SonarCloud), which is real infrastructure overhead compared to a NuGet package
+- Feedback happens at CI/analysis speed, not at every keystroke or every local test run - a slower loop than compiler-integrated analyzers
+- Defining project-specific custom rules requires deeper engagement with SonarQube's SDK and API, more involved than NetArchTest's fluent rule syntax
+
+**Choose this when:** you want organization-wide quality gates, trend tracking, and a broad net of checks (not just architecture) across potentially many repositories, and you're willing to run the infrastructure (or pay for SonarCloud) to get it.
+
+## Roslyn Analyzers
+
+Roslyn Analyzers run inside the C# compiler itself - they're not a separate tool you invoke, they're part of the same compilation pipeline that turns your code into IL, which means violations surface as compiler warnings or errors directly in your IDE, as you type, not after a test run or a CI pass.
+
+**Strengths:**
+
+- The fastest possible feedback loop of anything in this comparison - violations appear in your editor in real time, often before you've even saved the file
+- Built into the .NET SDK itself, with a large existing ecosystem of analyzer packages (Roslynator alone brings 500+ rules) covering everything from code style to structural conventions
+- You can write fully custom analyzers for team-specific rules - not just consuming existing packages, but authoring your own compiler-integrated checks
+- Zero additional infrastructure - analyzers run as part of the build every team member already does
+
+**Weaknesses:**
+
+- Writing a custom analyzer from scratch has a real learning curve - it requires understanding Roslyn's syntax tree and semantic model APIs, meaningfully more involved than NetArchTest's fluent rule syntax
+- Existing analyzer packages cover a lot of ground, but architecture-specific dependency rules (like NetArchTest's "layer A shouldn't depend on layer B") are less commonly the focus of general-purpose analyzer packages, and require either a specialized package or custom authoring
+- Purely compile-time - can't express rules that need runtime information or need to reason across an entire compiled assembly the way NetArchTest's assembly-scanning approach can more naturally
+
+**Choose this when:** instant, in-editor feedback matters more than anything else, and you want either the broad existing ecosystem of analyzer packages or the ability to author fully custom, team-specific compiler rules.
+
+## NDepend
+
+NDepend is a commercial, deeply feature-rich static analysis tool often described as the "Swiss Army knife" for .NET code quality - dependency graph visualization, a powerful LINQ-based query language (CQLinq) for interrogating your codebase's structure, quality gates, and trend tracking, all in one standalone tool with CI integration.
+
+**Strengths:**
+
+- CQLinq lets you write arbitrarily sophisticated queries against your codebase's structure using LINQ syntax - genuinely more expressive and detailed than any other tool in this comparison for deep dependency analysis
+- Rich visualizations (dependency graphs, dependency matrices) that make it easier to spot structural problems humans miss reading code directly
+- Strong trend tracking - NDepend is well suited to answering "is our technical debt getting better or worse over time," not just "does this pass right now"
+- Can import Roslyn analyzer results, letting it serve as a unifying dashboard rather than purely a competing tool
+
+**Weaknesses:**
+
+- Commercial, per-seat licensing - a real cost compared to every other tool in this comparison except SonarQube's paid tiers
+- Windows-oriented tooling history (though it has broadened over time), worth checking against your team's actual platform mix
+- The learning curve for CQLinq, while powerful, is real - getting full value out of NDepend takes more investment than writing a NetArchTest fluent assertion
+
+**Choose this when:** you want the deepest possible dependency and quality analysis with strong visualization and trend tracking, and the licensing cost is justified by the insight it provides across a codebase of real size and complexity.
+
+## How to Decide
+
+A few heuristics that cover most real-world decisions:
+
+**Want to enforce dependency-direction rules (Clean Architecture layers, Modular Monolith boundaries) as part of your existing test suite, with minimal setup?** NetArchTest or ArchUnitNET - pick based on which rule syntax you find more natural after trying both on a small example.
+
+**Want organization-wide quality gates and trend tracking across many repositories, not just architecture?** SonarQube is built for exactly this, at the cost of running (or paying for) a separate platform.
+
+**Want the fastest possible feedback loop, ideally before you even finish typing?** Roslyn Analyzers are unmatched here - pair an existing package (Roslynator, Meziantou.Analyzer) with any custom rules your team needs.
+
+**Want the deepest dependency analysis and visualization, with budget for a commercial tool?** NDepend's CQLinq and dependency graphs go further than any free option in this comparison.
+
+These aren't mutually exclusive, and most mature .NET teams end up layering more than one. A common, effective combination: Roslyn Analyzers for instant, in-editor style and correctness feedback; NetArchTest or ArchUnitNET for dependency-direction rules living in the test suite; and SonarQube or NDepend for the organization-wide dashboard and trend view neither of the first two provides.
+
+## Frequently Asked Questions
+
+### Should I use NetArchTest or ArchUnitNET?
+
+Both solve the same problem with a very similar approach - try writing the same handful of rules in each and see which fluent API reads more naturally to your team. NetArchTest has somewhat wider adoption and more existing examples; ArchUnitNET offers richer modeling for layers and slices in some scenarios. Neither is a clearly superior technical choice over the other.
+
+### Do I need SonarQube or NDepend if I'm already using NetArchTest?
+
+They're not redundant - NetArchTest (and ArchUnitNET) enforce specific, narrow dependency and structural rules you define, while SonarQube and NDepend cover a much broader net of code smells, security issues, duplication, and general quality metrics, plus organization-wide trend tracking neither architecture-testing library provides. Many teams use both, for different layers of enforcement.
+
+### What's the difference between a Roslyn Analyzer and an architecture-testing library like NetArchTest?
+
+A Roslyn Analyzer runs inside the compiler itself, giving instant, in-editor feedback at the syntax/semantic level, well suited to style, correctness, and API-usage rules. NetArchTest runs as a unit test against a compiled assembly, well suited to dependency-direction and structural rules that are naturally expressed by asking "does this reflect all the types and check what depends on what." They're complementary tools solving different-shaped problems, not competing solutions to the same one.
+
+### Is NDepend worth the licensing cost compared to free alternatives?
+
+It depends on the depth of analysis and visualization you need. For straightforward dependency-direction enforcement, the free architecture-testing libraries (NetArchTest, ArchUnitNET) cover the need without cost. NDepend's value is in deeper, more sophisticated analysis (CQLinq queries, dependency graphs, long-term trend tracking) that becomes more valuable as codebase size and organizational complexity grow - evaluate against your actual scale, not as a default upgrade.
+
+### Can I write custom rules with Roslyn Analyzers the way I can with NetArchTest?
+
+Yes, but the effort is meaningfully different - NetArchTest's fluent API is designed for quickly expressing dependency rules in a few lines. Writing a custom Roslyn Analyzer requires understanding the compiler's syntax tree and semantic model APIs, a real learning investment, though the payoff is instant, in-editor feedback rather than test-run-speed feedback.
+
+### Do these tools replace code review?
+
+No - they automate the parts of review that are mechanical and easy to miss under time pressure (a stray dependency, a naming violation, a code smell), freeing human reviewers to focus on things automation genuinely can't judge well: whether an approach is the right one, whether a change makes sense in context, and design trade-offs. Treat them as raising the floor, not replacing the judgment a reviewer brings.
+
+### Which of these tools should a team adopt first if starting from nothing?
+
+Roslyn Analyzers, since they're free, already built into the SDK, and require no new infrastructure - adding an existing package like Roslynator is close to zero-cost and immediately useful. NetArchTest or ArchUnitNET is a natural second step once you have specific dependency-direction rules (from adopting Clean Architecture or a Modular Monolith, for instance) you want enforced automatically. SonarQube or NDepend become worth the additional investment once you're managing quality across multiple repositories or want deeper trend visibility than test-scoped tools provide.

--- a/src/posts/2028-01-25-getting-started-with-sonarqube.md
+++ b/src/posts/2028-01-25-getting-started-with-sonarqube.md
@@ -1,0 +1,169 @@
+---
+author: Steve Kaschimer
+date: 2028-01-25
+image: /images/posts/2028-01-25-hero.webp
+image_alt: "A broad dashboard-panel glyph with a gauge and trend line, connected by a longer pipeline path than the other tools' glyphs, implying a slower batch analysis loop reaching a shared platform."
+image_prompt: "A dark-mode technical editorial illustration on a near-black background with electric teal, amber, and off-white accents. Composition centers on a wide rectangular dashboard panel containing a small gauge meter and a rising trend line, connected on the left by a noticeably longer teal pipeline path with a small begin/end marker pair, implying analysis that runs as a distinct pipeline stage rather than instantly. Mood is broad, organizational, and deliberately slower-paced. Avoid: vendor logos, brand colors, circuit-board textures, gears, or generic checkmark clip art as the dominant motif."
+layout: post.njk
+site_title: Tech Notes
+summary: "SonarQube's setup story is different from every other tool in this series: it's not a NuGet package you add and forget, it's a platform your CI pipeline talks to on every run. A setup guide for the scanner's begin/end wrapping, real coverage reports, and a quality gate that actually blocks bad code."
+tags: ["dotnet", "architecture", "code-quality", "ci-cd"]
+title: "Getting Started with SonarQube in .NET"
+---
+
+SonarQube's setup story is different from every other tool in this series in one important way: it's not a NuGet package you add and forget, it's a platform - either a server you run yourself or SonarCloud, hosted for you - that your CI pipeline talks to on every analysis run. That extra piece of infrastructure is exactly why it can do things a test-scoped library can't: quality gates that block a pull request, trend tracking across months of commits, and a dashboard covering far more than architecture alone.
+
+This guide covers setting up SonarQube for a .NET project, bootstrapping the SonarScanner for .NET in your build pipeline, configuring a quality gate that actually blocks bad code, and the best practices that keep SonarQube's broader scope from becoming noise nobody looks at. By the end you'll have automated analysis running on every push, with a gate that means something.
+
+If you're deciding between architecture/quality tools first, [a comparison of the top .NET architecture and quality enforcement tools](/posts/2028-01-18-top-5-dotnet-architecture-quality-tools-compared/) covers where SonarQube fits relative to NetArchTest, ArchUnitNET, Roslyn Analyzers, and NDepend.
+
+## What You'll Need
+
+- A SonarQube Server instance (self-hosted, free Community Build available) or a SonarCloud account (hosted)
+- .NET 8 SDK or later
+- The SonarScanner for .NET, installed as a global tool or via your CI platform's dedicated task
+
+```bash
+dotnet tool install --global dotnet-sonarscanner
+```
+
+## Installing and Scaffolding
+
+SonarQube analysis for .NET wraps your normal build with a `begin`/`end` step - the scanner hooks into MSBuild to collect analysis data during the actual compilation, then uploads results afterward:
+
+```bash
+dotnet sonarscanner begin \
+  /k:"my-app" \
+  /d:sonar.host.url="https://sonarqube.example.com" \
+  /d:sonar.token="$SONAR_TOKEN"
+
+dotnet build
+
+dotnet sonarscanner end /d:sonar.token="$SONAR_TOKEN"
+```
+
+The `begin` step downloads your project's configured quality profiles and prepares the build for analysis; `dotnet build` runs as normal but with analysis instrumentation attached; `end` uploads the collected results to your SonarQube instance.
+
+## Bootstrapping the Ideal Environment
+
+### CI integration (GitHub Actions example)
+
+```yaml
+# .github/workflows/sonarqube.yml
+name: SonarQube Analysis
+on: [push, pull_request]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '8.0.x'
+
+      - name: Install SonarScanner
+        run: dotnet tool install --global dotnet-sonarscanner
+
+      - name: Build and Analyze
+        env:
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+        run: |
+          dotnet sonarscanner begin /k:"my-app" /d:sonar.host.url="${{ vars.SONAR_HOST_URL }}" /d:sonar.token="$SONAR_TOKEN"
+          dotnet build --no-incremental
+          dotnet sonarscanner end /d:sonar.token="$SONAR_TOKEN"
+```
+
+`fetch-depth: 0` matters here - SonarQube's analysis (particularly new-code detection and blame information) needs full Git history, not the shallow clone GitHub Actions uses by default.
+
+### Including test coverage
+
+```bash
+dotnet test --collect:"XPlat Code Coverage"
+```
+
+```bash
+dotnet sonarscanner begin \
+  /k:"my-app" \
+  /d:sonar.host.url="$SONAR_HOST_URL" \
+  /d:sonar.token="$SONAR_TOKEN" \
+  /d:sonar.cs.opencover.reportsPaths="**/coverage.opencover.xml"
+```
+
+Coverage reports need to be generated before `sonarscanner end` runs and pointed at explicitly via the `sonar.cs.opencover.reportsPaths` parameter (or the equivalent for your chosen coverage format) - without this, SonarQube's dashboard will show a coverage metric of zero regardless of your actual test suite.
+
+### Configuring a quality gate
+
+In the SonarQube UI: **Administration → Quality Gates**, define conditions like "no new bugs," "coverage on new code ≥ 80%," or "no new critical vulnerabilities." Assign this gate to your project, and configure your CI to fail the build (or at minimum, decorate the pull request) if the gate fails.
+
+For GitHub, GitLab, Bitbucket, and Azure DevOps, SonarQube supports pull request decoration - posting the quality gate result and specific issues directly as PR comments, so reviewers see the analysis without leaving their normal workflow.
+
+## Core Workflow
+
+- **Run analysis on every push and pull request**, not just periodically - the value of a quality gate comes from catching issues before merge, not from an occasional retrospective report.
+- **Point SonarQube at real coverage reports**, not leave the metric unconfigured - a dashboard showing 0% coverage because reports weren't wired up is worse than not showing coverage at all, since it looks like a real (bad) number.
+- **Configure the quality gate to block merges on genuinely important conditions**, not an exhaustive list that becomes noise - new bugs, new vulnerabilities, and coverage on new code are usually the meaningful core; expand deliberately from there.
+
+## Verifying Your Setup
+
+1. **Analysis runs successfully and appears in the dashboard** - confirm a pushed commit triggers analysis and results show up in the SonarQube UI
+2. **Coverage reports are actually being picked up** - confirm the coverage percentage shown reflects your real test suite, not zero
+3. **Quality gate blocks or decorates correctly** - deliberately introduce an issue that should fail your configured gate and confirm the PR is decorated (or the build fails) as expected
+4. **Full Git history is available to the scanner** - confirm your CI checkout step isn't using a shallow clone that limits new-code detection accuracy
+
+## Best Practices
+
+**Use `fetch-depth: 0` (or your CI platform's equivalent) for full Git history.** SonarQube's new-code analysis and blame information depend on it - a shallow clone silently degrades analysis quality without an obvious error.
+
+**Wire up coverage reports explicitly and verify the number reflects reality.** An unconfigured coverage metric showing zero looks like a real, alarming number rather than a configuration gap - confirm it's actually pulling from your test run.
+
+**Keep the quality gate focused on conditions that genuinely matter**, especially "new code" conditions rather than demanding an existing codebase retroactively meet a high bar all at once. New-code-focused gates let you improve incrementally without being blocked by pre-existing debt.
+
+**Use pull request decoration so results appear where developers already work.** Requiring someone to separately check a SonarQube dashboard is friction that reduces how much the tool actually gets used.
+
+**Pair with NetArchTest or ArchUnitNET for dependency-direction rules specifically.** SonarQube's architecture-related checks (dependency cycles, some structural rules) exist but aren't as deep or expressive as a dedicated architecture-testing library - use both for their respective strengths.
+
+## Comparison with Roslyn Analyzers
+
+| | SonarQube | Roslyn Analyzers |
+| --- | --- | --- |
+| Where it runs | Separate server/service, CI-integrated | Inside the compiler, every build |
+| Feedback speed | CI pipeline speed (batch) | Instant, in-editor |
+| Scope | Code smells, security, coverage, duplication, some architecture | Style, correctness, custom rules |
+| Infrastructure | Real - a server or SonarCloud subscription | None - built into the SDK |
+| Trend tracking | Strong, dashboard-based over time | None built in |
+
+They're genuinely complementary rather than competing - Roslyn Analyzers give instant, in-editor feedback on individual issues as you write code; SonarQube gives an organization-wide dashboard and trend view that a compiler-integrated tool structurally can't provide.
+
+## Frequently Asked Questions
+
+### Do I need to self-host SonarQube, or can I use a hosted option?
+
+Both are viable - SonarQube Server (self-hosted, including a free Community Build) gives you full control and no per-analysis cost beyond your own infrastructure. SonarCloud is the hosted equivalent, removing the need to run your own server at the cost of a subscription for private repositories (public/open-source repos are typically free).
+
+### Why does my coverage percentage show 0% even though I have tests?
+
+Almost always because the coverage report wasn't generated before the scanner's `end` step, or the report path wasn't correctly specified via `sonar.cs.opencover.reportsPaths` (or the equivalent parameter for your coverage format). Confirm `dotnet test --collect:"XPlat Code Coverage"` actually produces a report file, and that its path matches what you're passing to the scanner.
+
+### Why does my CI checkout need full Git history for SonarQube?
+
+SonarQube's new-code analysis (measuring metrics specifically on recently changed code, which is central to how most quality gates are configured) and blame/authorship information both depend on having the actual commit history available, not just the current snapshot a shallow clone provides. Set `fetch-depth: 0` (GitHub Actions) or your CI platform's equivalent full-history option.
+
+### What's a quality gate, and how strict should it be?
+
+A quality gate is a set of conditions (like "zero new bugs" or "80% coverage on new code") that a project must meet to pass analysis - typically used to block a pull request or deployment. Start with a focused set of conditions on new code specifically, rather than demanding an existing codebase retroactively meet a high bar everywhere, so the gate is achievable and meaningful rather than either toothless or immediately failing on unrelated legacy debt.
+
+### Can SonarQube replace a dedicated architecture-testing library like NetArchTest?
+
+Not fully - SonarQube includes some architectural checks (dependency cycles, certain structural rules) but isn't as deep or purpose-built for expressing dependency-direction rules as NetArchTest or ArchUnitNET. Many teams use SonarQube for its broader quality-gate and trend-tracking role alongside a dedicated architecture-testing library for the specific dependency rules that matter most to their design.
+
+### Does SonarQube slow down my CI pipeline significantly?
+
+It adds real time - the scanner instruments the build and uploads analysis results, which is a meaningfully slower step than a plain `dotnet build`. Many teams run SonarQube analysis as a separate CI job/stage from the main build and test pipeline, so it doesn't block fast feedback on basic build/test failures while still gating merges on its own timeline.
+
+### What's the most common mistake in a first SonarQube setup?
+
+Not wiring up coverage reports correctly, resulting in a misleading 0% coverage metric on the dashboard. The second common mistake is using a shallow Git checkout in CI, which silently degrades SonarQube's new-code detection accuracy without producing an obvious error to alert you to the problem.

--- a/src/posts/2028-02-01-getting-started-with-netarchtest.md
+++ b/src/posts/2028-02-01-getting-started-with-netarchtest.md
@@ -1,0 +1,194 @@
+---
+author: Steve Kaschimer
+date: 2028-02-01
+image: /images/posts/2028-02-01-hero.webp
+image_alt: "A narrow assembly-boundary glyph with a single directional arrow crossing a forbidden barrier line, with a small failing-type label attached directly to the crossing point."
+image_prompt: "A dark-mode technical editorial illustration on a near-black background with electric teal, amber, and off-white accents. Composition centers on two flat rectangles side by side, separated by a solid amber barrier line, with a single thin arrow attempting to cross from the left rectangle into the right one, intercepted directly at the barrier. A small label tag hangs from the interception point, implying a diagnostic name attached to the violation. Mood is lightweight, direct, and test-driven. Avoid: vendor logos, brand colors, circuit-board textures, gears, or generic checkmark clip art as the dominant motif."
+layout: post.njk
+site_title: Tech Notes
+summary: "NetArchTest's entire value proposition is that architecture rules stop being something written in a design doc nobody rereads and start being something your build actually checks. A setup guide for the fluent Types.InAssembly() API and keeping failures actionable."
+tags: ["dotnet", "architecture", "testing", "developer-productivity"]
+title: "Getting Started with NetArchTest in .NET"
+---
+
+NetArchTest's entire value proposition is that architecture rules stop being something written in a design doc nobody rereads and start being something your build actually checks. The setup is genuinely small - a NuGet package and a test class - which is exactly why it's worth doing early in a project rather than after the dependency violations it would have caught have already accumulated.
+
+This guide covers installing NetArchTest, bootstrapping a dedicated architecture test project, the core rule patterns for enforcing dependency direction and naming conventions, and the best practices that keep these tests useful rather than either too loose to matter or too brittle to survive normal refactoring. By the end you'll have your architecture's rules enforced the same way any other regression is - automatically, on every build.
+
+If you're deciding between architecture/quality tools first, [a comparison of the top .NET architecture and quality enforcement tools](/posts/2028-01-18-top-5-dotnet-architecture-quality-tools-compared/) covers where NetArchTest fits relative to ArchUnitNET, SonarQube, Roslyn Analyzers, and NDepend.
+
+## What You'll Need
+
+- .NET 8 SDK or later
+- An existing test project (xUnit, NUnit, or MSTest all work identically well) - either a dedicated architecture-test project or a section of your existing test suite
+
+## Installing NetArchTest
+
+```bash
+dotnet add package NetArchTest.Rules
+```
+
+## Bootstrapping the Ideal Environment
+
+### A dedicated architecture test project
+
+Rather than scattering architecture rules across your regular unit test files, create a dedicated project so they're easy to find and reason about as a set:
+
+```bash
+dotnet new xunit -n MyApp.ArchitectureTests
+cd MyApp.ArchitectureTests
+dotnet add package NetArchTest.Rules
+dotnet add reference ../MyApp.Core/MyApp.Core.csproj
+dotnet add reference ../MyApp.Infrastructure/MyApp.Infrastructure.csproj
+dotnet add reference ../MyApp.Web/MyApp.Web.csproj
+```
+
+The test project needs references to every layer/project it's writing rules about, since NetArchTest inspects compiled assemblies directly.
+
+### Enforcing Clean Architecture's dependency rule
+
+```csharp
+public class ArchitectureTests
+{
+    [Fact]
+    public void Core_Should_Not_Depend_On_Infrastructure()
+    {
+        var result = Types.InAssembly(typeof(Order).Assembly)
+            .Should()
+            .NotHaveDependencyOn("MyApp.Infrastructure")
+            .GetResult();
+
+        Assert.True(result.IsSuccessful, string.Join(", ", result.FailingTypeNames ?? []));
+    }
+
+    [Fact]
+    public void Core_Should_Not_Depend_On_Web()
+    {
+        var result = Types.InAssembly(typeof(Order).Assembly)
+            .Should()
+            .NotHaveDependencyOn("MyApp.Web")
+            .GetResult();
+
+        Assert.True(result.IsSuccessful);
+    }
+}
+```
+
+Including `result.FailingTypeNames` in the assertion failure message is worth doing consistently - when this test fails, you want to immediately see which type introduced the violation, not just that "some rule somewhere failed."
+
+### Enforcing naming and structural conventions
+
+```csharp
+[Fact]
+public void Controllers_Should_Have_ApiController_Attribute()
+{
+    var result = Types.InAssembly(typeof(Program).Assembly)
+        .That()
+        .Inherit(typeof(ControllerBase))
+        .Should()
+        .HaveCustomAttribute(typeof(ApiControllerAttribute))
+        .GetResult();
+
+    Assert.True(result.IsSuccessful);
+}
+
+[Fact]
+public void Repository_Classes_Should_Be_Sealed()
+{
+    var result = Types.InAssembly(typeof(OrderRepository).Assembly)
+        .That()
+        .ImplementInterface(typeof(IOrderRepository))
+        .Should()
+        .BeSealed()
+        .GetResult();
+
+    Assert.True(result.IsSuccessful);
+}
+```
+
+Rules like these catch consistency drift that's easy to introduce accidentally (a new repository class that forgot to be `sealed`, a new controller missing `[ApiController]`) without anyone deliberately deciding to break the convention.
+
+### Combining conditions with And()/Or()
+
+```csharp
+[Fact]
+public void Handlers_Should_Reside_In_Correct_Namespace()
+{
+    var result = Types.InAssembly(typeof(Program).Assembly)
+        .That()
+        .ImplementInterface(typeof(IRequestHandler<,>))
+        .And()
+        .AreClasses()
+        .Should()
+        .ResideInNamespaceStartingWith("MyApp.Application.Handlers")
+        .GetResult();
+
+    Assert.True(result.IsSuccessful);
+}
+```
+
+## Core Workflow
+
+- **Write one rule per architectural decision your team has actually made.** Don't invent rules speculatively - each test should reflect a real, agreed-upon constraint, so a failure clearly means "this violates something we decided," not "this tripped an arbitrary check."
+- **Include failing type names in assertion messages.** A failing architecture test should immediately tell the next developer what to fix, not just that something's wrong somewhere in the assembly.
+- **Run architecture tests as part of your normal CI pipeline**, the same as any other test - there's no separate invocation needed, since they're ordinary tests in your chosen framework.
+
+## Verifying Your Setup
+
+1. **Rules catch real violations** - temporarily introduce a deliberate violation (a `Core` class referencing `Infrastructure`) and confirm the corresponding test fails
+2. **Failure messages are actionable** - confirm a failing test's output tells you which specific type violated the rule, not just that the rule failed
+3. **Tests run in CI, not just locally** - confirm your CI pipeline actually executes the architecture test project alongside your regular test suite
+4. **Rules reflect current, real decisions** - periodically review whether existing rules still match your team's actual architecture, removing or updating any that have gone stale
+
+## Best Practices
+
+**Keep architecture tests in a dedicated project, separate from regular unit tests.** This makes the full set of enforced architectural decisions easy to review and discover, rather than scattered throughout the codebase.
+
+**Write rules that reflect real decisions the team has made, not aspirational or speculative ones.** A rule nobody agreed to is just friction; a rule reflecting a genuine architectural decision is protection.
+
+**Include diagnostic information (failing type names) in every assertion.** The whole value of catching a violation early is lost if the failure message doesn't tell the next developer what to actually fix.
+
+**Revisit and prune rules periodically as the architecture evolves.** A stale rule that no longer reflects the team's actual intent is worse than no rule - it either gets bypassed with frustration or, worse, quietly disabled entirely.
+
+**Pair NetArchTest with a broader static analysis tool if you need more than dependency/structural rules.** NetArchTest is deliberately narrow - code smells, security, and duplication are better covered by SonarQube, Roslyn Analyzers, or NDepend.
+
+## Comparison with ArchUnitNET
+
+| | NetArchTest | ArchUnitNET |
+| --- | --- | --- |
+| Rule syntax | `Types.InAssembly(...).Should()...` | Similar fluent style, richer layer/slice modeling |
+| Test framework integration | Works with any framework via NuGet | Dedicated packages per framework (xUnit, NUnit, MSTestV2) |
+| Community/adoption | Somewhat wider | Smaller, but comparable capability |
+| Best fit | Straightforward dependency-direction rules | More complex layer/slice modeling needs |
+
+Both solve the same problem with a comparably expressive fluent API - the choice between them is largely about which rule vocabulary your team finds more natural, not a significant capability gap.
+
+## Frequently Asked Questions
+
+### Do architecture tests run differently from regular unit tests?
+
+No - they're ordinary tests in whichever framework you're using (xUnit, NUnit, MSTest), just asserting against `NetArchTest.Rules`' `Types.InAssembly(...)` API instead of application logic. They run in your normal `dotnet test` invocation and CI pipeline exactly like any other test.
+
+### Why does my architecture test project need references to every layer it's testing?
+
+NetArchTest inspects compiled assemblies via reflection, so it needs a project reference to each assembly it's writing rules about - it can't reason about types it doesn't have access to. This is different from source-level tools like Roslyn Analyzers, which see your code without needing a compiled reference.
+
+### How do I make a failing architecture test actually useful for debugging?
+
+Include `result.FailingTypeNames` (or similar diagnostic properties from the `GetResult()` object) in your assertion failure message. Without it, a failing test just says "the rule failed" without telling the next developer which specific type caused it, turning a useful early warning into a frustrating scavenger hunt.
+
+### Can NetArchTest catch things like code duplication or security issues?
+
+No - it's deliberately scoped to dependency-direction and structural rules (naming conventions, inheritance, attribute presence). For code smells, security vulnerabilities, or duplication, you need a broader tool like SonarQube, Roslyn Analyzers, or NDepend, ideally used alongside NetArchTest rather than instead of it.
+
+### Should every project have architecture tests from day one?
+
+For projects following a deliberate structural pattern (Clean Architecture, Modular Monolith), yes - setting up a handful of core dependency-direction rules early is cheap and prevents the exact kind of drift those patterns are meant to guard against. For very small or short-lived projects without meaningful architectural decisions to enforce, it's less urgent.
+
+### What happens if a legitimate change needs to violate an existing rule?
+
+That's a signal to have an explicit conversation about whether the rule (or the change) needs to be reconsidered, rather than just deleting the test to make it pass. Architecture rules should evolve deliberately alongside genuine shifts in the system's design, not get silently bypassed under deadline pressure.
+
+### What's the most common mistake in a first NetArchTest setup?
+
+Writing rules without including diagnostic failure information, so a failing test tells you something's wrong but not what - turning what should be a fast fix into a search. The second common mistake is letting rules go stale as the architecture legitimately evolves, rather than treating the rule set itself as something that needs periodic review.

--- a/src/posts/2028-02-08-getting-started-with-archunitnet.md
+++ b/src/posts/2028-02-08-getting-started-with-archunitnet.md
@@ -1,0 +1,183 @@
+---
+author: Steve Kaschimer
+date: 2028-02-08
+image: /images/posts/2028-02-08-hero.webp
+image_alt: "A boundary glyph similar to a plain barrier line but with a richer layered-slice pattern beneath it, showing several stacked modules each guarded against circular connections to each other."
+image_prompt: "A dark-mode technical editorial illustration on a near-black background with electric teal, amber, and off-white accents. Composition centers on two flat rectangles separated by a solid barrier line, echoing a simpler boundary glyph, but beneath them sits a richer pattern of several small stacked module blocks, each connected by thin lines that deliberately avoid forming closed loops, implying acyclic slice checking. Mood is more expressive and structured than a simpler sibling tool. Avoid: vendor logos, brand colors, circuit-board textures, gears, or generic checkmark clip art as the dominant motif."
+layout: post.njk
+site_title: Tech Notes
+summary: "ArchUnitNET's fluent API reads a lot like NetArchTest's - the real differences show up once you're modeling something more elaborate than layer A shouldn't depend on layer B. A setup guide for named layers, slice rules, and cyclic-dependency detection between modules."
+tags: ["dotnet", "architecture", "testing", "developer-productivity"]
+title: "Getting Started with ArchUnitNET in .NET"
+---
+
+ArchUnitNET's fluent API reads a lot like NetArchTest's - both are ArchUnit-inspired, both express rules as unit tests, both let you assert dependency-direction constraints in a chainable, readable syntax. The real differences show up once you're modeling something more elaborate than "layer A shouldn't depend on layer B" - ArchUnitNET's support for layers and slices as first-class concepts gives you a more expressive vocabulary for describing genuinely structured systems, at the cost of a slightly larger API surface to learn.
+
+This guide covers installing ArchUnitNET, bootstrapping architecture rules with its layer and slice modeling, the core patterns for common rules, and the best practices that keep an ArchUnitNET-based rule set expressive without becoming its own maintenance burden. By the end you'll have architecture rules enforced automatically, with a richer vocabulary for expressing more complex structural constraints than a simpler tool provides.
+
+If you're deciding between architecture/quality tools first, [a comparison of the top .NET architecture and quality enforcement tools](/posts/2028-01-18-top-5-dotnet-architecture-quality-tools-compared/) covers where ArchUnitNET fits relative to NetArchTest, SonarQube, Roslyn Analyzers, and NDepend.
+
+## What You'll Need
+
+- .NET 8 SDK or later
+- An existing test project - ArchUnitNET has dedicated integration packages for xUnit, NUnit, and MSTestV2
+
+## Installing ArchUnitNET
+
+```bash
+dotnet add package ArchUnitNET.xUnit
+```
+
+Substitute `ArchUnitNET.NUnit` or `ArchUnitNET.MSTestV2` depending on your test framework - each package includes the core ArchUnitNET library plus framework-specific integration.
+
+## Bootstrapping the Ideal Environment
+
+### Loading the architecture under test
+
+```csharp
+public class ArchitectureTests
+{
+    private static readonly Architecture Architecture = new ArchLoader()
+        .LoadAssemblies(
+            typeof(Order).Assembly,           // Core
+            typeof(OrderRepository).Assembly, // Infrastructure
+            typeof(Program).Assembly)         // Web
+        .Build();
+}
+```
+
+`ArchLoader` builds a model of your codebase's structure once, which every rule in the test class then queries against - worth making this a static field so it's loaded once per test class rather than rebuilt per test.
+
+### Defining layers explicitly
+
+```csharp
+private static readonly IObjectProvider<IType> CoreLayer =
+    Types().That().ResideInNamespace("MyApp.Core").As("Core");
+
+private static readonly IObjectProvider<IType> InfrastructureLayer =
+    Types().That().ResideInNamespace("MyApp.Infrastructure").As("Infrastructure");
+
+private static readonly IObjectProvider<IType> WebLayer =
+    Types().That().ResideInNamespace("MyApp.Web").As("Web");
+```
+
+Naming layers explicitly like this is one of ArchUnitNET's more expressive features over a simpler tool - it lets you write layer-oriented rules that read naturally, rather than repeating namespace strings across every individual rule.
+
+### Enforcing a layered dependency rule
+
+```csharp
+[Fact]
+public void Core_Should_Not_Depend_On_Infrastructure_Or_Web()
+{
+    IArchRule rule = Types().That().Are(CoreLayer)
+        .Should().NotDependOnAny(InfrastructureLayer.Or(WebLayer));
+
+    rule.Check(Architecture);
+}
+```
+
+`rule.Check(Architecture)` throws an assertion failure (integrated with your test framework via the package you installed) if the rule is violated - no separate `Assert.True(result.IsSuccessful)` boilerplate needed, since the framework integration package handles that directly.
+
+### Naming and attribute conventions
+
+```csharp
+[Fact]
+public void Controllers_Should_Have_ApiController_Attribute()
+{
+    IArchRule rule = Classes().That().AreAssignableTo(typeof(ControllerBase))
+        .Should().BeDecorated(typeof(ApiControllerAttribute));
+
+    rule.Check(Architecture);
+}
+
+[Fact]
+public void Repository_Implementations_Should_Be_Sealed()
+{
+    IArchRule rule = Classes().That().ImplementInterface(typeof(IOrderRepository))
+        .Should().BeSealed();
+
+    rule.Check(Architecture);
+}
+```
+
+### Slice-based rules for module boundaries
+
+```csharp
+[Fact]
+public void Modules_Should_Not_Have_Cyclic_Dependencies()
+{
+    var slices = SliceRuleDefinition.Slices()
+        .Matching("MyApp.Modules.(*)..")
+        .Should().BeFreeOfCycles();
+
+    slices.Check(Architecture);
+}
+```
+
+Slice rules are one of ArchUnitNET's more distinctive capabilities - checking for cyclic dependencies between modules matched by a namespace pattern, useful specifically for Modular Monolith architectures where module boundaries need to stay acyclic.
+
+## Core Workflow
+
+- **Load the architecture once per test class, reuse across rules.** `ArchLoader` builds a full model of the assemblies you point it at - rebuilding it per test is unnecessary overhead.
+- **Name layers explicitly when your rules span more than a simple two-namespace check.** This is where ArchUnitNET's expressiveness pays off compared to repeating namespace strings across many rules.
+- **Use slice rules specifically for module-boundary and cyclic-dependency checks**, a capability that goes beyond what a simpler dependency-direction-only tool provides.
+
+## Verifying Your Setup
+
+1. **Rules catch real violations** - temporarily introduce a deliberate violation and confirm the corresponding rule's `Check(Architecture)` call fails the test
+2. **Layer definitions match your actual namespace structure** - confirm each named layer (`CoreLayer`, `InfrastructureLayer`, etc.) captures the types you intend, not an over- or under-inclusive set
+3. **Slice rules correctly identify module boundaries** - confirm your slice pattern (`"MyApp.Modules.(*).."`) matches your actual module namespace structure
+4. **Tests run in CI alongside your regular suite** - confirm architecture tests execute as part of your normal pipeline
+
+## Best Practices
+
+**Define named layers once and reuse them across multiple rules**, rather than repeating namespace-matching logic in every individual test - this is where ArchUnitNET's richer modeling genuinely pays off over a simpler namespace-string-per-rule approach.
+
+**Use slice rules for module boundary and cyclic-dependency checks specifically.** This is a capability worth using deliberately if you're working with a Modular Monolith or similarly module-oriented architecture, not something to reach for by default in a simpler layered system.
+
+**Load the architecture once per test class via a static field**, not per individual test method - `ArchLoader` doing a full assembly scan repeatedly is unnecessary and slows down your test suite for no benefit.
+
+**Keep rule definitions readable by naming things well.** ArchUnitNET's fluent API is expressive, but a rule chained across many conditions without clear naming can become just as hard to parse as the problem it's meant to prevent.
+
+**Pair with a broader static analysis tool for anything beyond structural/dependency rules.** Like NetArchTest, ArchUnitNET is deliberately scoped to architecture and structure - code smells, security, and duplication need SonarQube, Roslyn Analyzers, or NDepend.
+
+## Comparison with NetArchTest
+
+| | ArchUnitNET | NetArchTest |
+| --- | --- | --- |
+| Layer/slice modeling | First-class, explicit named layers and slice rules | Less explicit - namespace strings per rule |
+| Cyclic dependency detection | Built-in via slice rules | Not a first-class feature |
+| Test framework integration | Dedicated packages per framework | Single package, framework-agnostic |
+| Community/adoption | Smaller | Somewhat wider |
+
+ArchUnitNET's richer modeling is a genuine advantage for more structurally complex systems (especially Modular Monoliths needing cyclic-dependency checks); for a simpler two- or three-layer Clean Architecture setup, the difference from NetArchTest is mostly stylistic.
+
+## Frequently Asked Questions
+
+### What's the advantage of named layers over NetArchTest's namespace-string approach?
+
+Readability and reuse - once you define `CoreLayer` and `InfrastructureLayer` as named providers, every subsequent rule referencing them reads clearly and doesn't repeat namespace-matching logic. For a small number of simple rules the difference is minor; for a larger rule set spanning many layers, it meaningfully reduces duplication and improves clarity.
+
+### What are slice rules, and when should I use them?
+
+Slice rules check for structural properties (most commonly, freedom from cyclic dependencies) across a set of "slices" matched by a namespace pattern - typically your application's modules. They're particularly valuable for Modular Monolith architectures, where verifying that modules don't have circular dependencies on each other is a meaningful, checkable architectural guarantee.
+
+### Do I need to rebuild the Architecture object for every test?
+
+No, and you shouldn't - build it once via a static field (typically using `ArchLoader`) and reuse it across every rule in the test class. Rebuilding it per test re-scans your assemblies unnecessarily and slows down your test suite.
+
+### How does rule.Check(Architecture) differ from NetArchTest's result.IsSuccessful pattern?
+
+`rule.Check(Architecture)` integrates directly with your test framework via ArchUnitNET's framework-specific package (xUnit, NUnit, or MSTestV2), throwing a test failure automatically on violation. NetArchTest's pattern returns a result object you assert on manually (`Assert.True(result.IsSuccessful)`), giving you more direct access to diagnostic details like failing type names as part of that manual assertion.
+
+### Can ArchUnitNET detect cyclic dependencies between modules?
+
+Yes, via slice rules - this is one of its more distinctive capabilities compared to NetArchTest, which doesn't have an equivalent first-class cyclic-dependency check. If module cycle detection is a specific requirement, it's a real point in ArchUnitNET's favor.
+
+### Should I choose ArchUnitNET over NetArchTest for a simple Clean Architecture setup?
+
+Not necessarily - for straightforward two- or three-layer dependency-direction rules, both tools handle the job comparably well, and the choice comes down to syntax preference. ArchUnitNET's advantages (named layers, slice rules) matter more as your structural rules become more elaborate, particularly for Modular Monolith-style module boundary checks.
+
+### What's the most common mistake in a first ArchUnitNET setup?
+
+Rebuilding the `Architecture` object per test instead of loading it once per test class, adding unnecessary overhead to the test suite. The second common mistake is not taking advantage of named layers for rule sets with more than a couple of simple dependency checks, ending up with repeated namespace-matching logic that ArchUnitNET's modeling was specifically designed to avoid.

--- a/src/posts/2028-02-15-getting-started-with-ndepend.md
+++ b/src/posts/2028-02-15-getting-started-with-ndepend.md
@@ -1,0 +1,142 @@
+---
+author: Steve Kaschimer
+date: 2028-02-15
+image: /images/posts/2028-02-15-hero.webp
+image_alt: "A query-bracket glyph resembling a LINQ expression feeding into a small dependency-graph node cluster, with a distinct commercial-key badge marking it apart from the free tools around it."
+image_prompt: "A dark-mode technical editorial illustration on a near-black background with electric teal, amber, and off-white accents. Composition centers on a thin bracket-shaped glyph resembling a LINQ query expression on the left, connected by a teal line to a small cluster of interconnected nodes on the right representing a dependency graph. A small amber key-shaped badge sits beside the query bracket, implying a licensed, unlocked capability distinct from the free tools around it. Mood is deep, deliberate, and premium. Avoid: vendor logos, brand colors, circuit-board textures, gears, or generic checkmark clip art as the dominant motif."
+layout: post.njk
+site_title: Tech Notes
+summary: "NDepend's reputation as the Swiss Army knife for .NET code quality comes down to CQLinq - a LINQ-based query language for interrogating your codebase's structure directly. A setup guide for writing CQLinq rules, dependency visualization, and honest licensing considerations."
+tags: ["dotnet", "architecture", "code-quality", "tooling"]
+title: "Getting Started with NDepend in .NET"
+---
+
+NDepend's reputation as the "Swiss Army knife" for .NET code quality comes down to one specific capability the rest of this comparison series doesn't have: CQLinq, a LINQ-based query language for interrogating your codebase's structure directly. Instead of learning a bespoke fluent API like NetArchTest's or configuring rules through a web UI like SonarQube's, you write actual LINQ queries against your code - which means anything you can express in LINQ, you can ask about your codebase, without waiting for the tool to have a purpose-built feature for that specific question.
+
+This guide covers installing and running NDepend, bootstrapping a baseline analysis and your first CQLinq rules, the core patterns for dependency visualization and trend tracking, and the best practices for getting real value out of a tool with genuine depth rather than just running a default report once and forgetting about it. By the end you'll have NDepend integrated into your workflow with rules that reflect your team's actual priorities.
+
+If you're deciding between architecture/quality tools first, [a comparison of the top .NET architecture and quality enforcement tools](/posts/2028-01-18-top-5-dotnet-architecture-quality-tools-compared/) covers where NDepend fits relative to NetArchTest, ArchUnitNET, SonarQube, and Roslyn Analyzers - including the licensing consideration that sets it apart from every other tool in this series.
+
+## What You'll Need
+
+- A licensed copy of NDepend (commercial; a trial is available for evaluation)
+- .NET 8 SDK or later
+- Visual Studio is the most integrated experience, though NDepend also runs standalone and via CI integration without it
+
+## Installing and Scaffolding
+
+Install the NDepend Visual Studio extension for the most integrated experience, or download the standalone NDepend application for CI/command-line use. For a first analysis:
+
+1. Open NDepend (or the Visual Studio extension) and choose **Analyze .NET assemblies**, pointing it at your solution or built output
+2. NDepend scans your assemblies and produces a baseline analysis - dependency graphs, metrics, and a first-pass quality report
+
+For CI integration, NDepend provides a console tool that can run analysis as part of a build pipeline:
+
+```bash
+NDepend.Console.exe MyApp.ndproj /OutDir NDependOut
+```
+
+This generates an HTML report and, if configured, XML output your CI can parse for pass/fail decisions.
+
+## Bootstrapping the Ideal Environment
+
+### Your first CQLinq rule
+
+CQLinq queries live in NDepend's rule editor and read like ordinary LINQ against a `codebase` object exposing your analyzed assemblies:
+
+```csharp
+// Methods with high cyclomatic complexity
+from m in Application.Methods
+where m.CyclomaticComplexity > 20
+orderby m.CyclomaticComplexity descending
+select new { m, m.CyclomaticComplexity }
+```
+
+Running this immediately lists every method exceeding a complexity threshold, ranked - no separate configuration screen, just a LINQ query you can adjust freely.
+
+### Enforcing a dependency-direction rule via CQLinq
+
+```csharp
+// Core should not depend on Infrastructure
+from t in Application.Types
+where t.ParentNamespace.Name == "MyApp.Core"
+where t.DependsOn("MyApp.Infrastructure")
+select t
+```
+
+This is functionally similar to what NetArchTest or ArchUnitNET would express in their own fluent APIs, but written as a direct LINQ query - worth knowing if your team is already comfortable with LINQ and would rather express architecture rules that way than learn a separate DSL.
+
+### Setting up quality gates
+
+In NDepend's dashboard, define rules with pass/fail thresholds (e.g., "no critical rule violations," "technical debt ratio below X%") and mark them as quality gate conditions. Configure your CI's console tool invocation to exit with a non-zero code if the gate fails, the same enforcement pattern as SonarQube's quality gates but driven by NDepend's own rule set and metrics.
+
+### Dependency graph visualization
+
+NDepend's dependency graph and dependency matrix views are interactive visualizations of your codebase's actual structure - useful specifically for spotting problems that are hard to see reading code directly: an unexpected coupling between two modules that were supposed to be independent, or a component with a surprisingly large number of incoming dependencies that makes it risky to change.
+
+## Core Workflow
+
+- **Start from NDepend's default rule set, then customize deliberately.** It ships with a substantial library of built-in CQLinq rules covering common code quality concerns - review and adjust rather than starting from a blank slate.
+- **Use CQLinq for anything the built-in rules don't already express**, treating it as a genuine query language rather than a limited configuration surface - if you can express the question in LINQ, you can ask NDepend about it.
+- **Check the dependency graph/matrix periodically, not just the pass/fail metrics.** Some structural problems are much easier to spot visually than through a list of rule violations.
+
+## Verifying Your Setup
+
+1. **Analysis runs successfully against your actual solution** - confirm NDepend produces a report reflecting your real codebase's structure and metrics
+2. **CQLinq rules return expected results** - test a rule against a codebase area you know has (or doesn't have) a specific issue, confirming the query behaves as intended
+3. **Quality gate integrates with CI correctly** - confirm a deliberately introduced violation causes the CI step to fail as configured
+4. **Trend data accumulates over multiple analysis runs** - confirm the dashboard's historical view reflects data from more than a single run, since trend tracking is one of NDepend's core value propositions
+
+## Best Practices
+
+**Invest time in learning CQLinq rather than only using default rules.** The querying flexibility is NDepend's most distinctive capability relative to every other tool in this comparison - underusing it means paying for a feature you're not getting value from.
+
+**Use the dependency graph and matrix views deliberately, not just as a novelty.** They surface structural problems (unexpected coupling, risky high-fan-in components) that are genuinely hard to spot by reading code or scanning a metrics list.
+
+**Track trends over time, not just pass/fail on the current commit.** NDepend's historical view is one of its real advantages over test-scoped architecture libraries - use it to answer "is our technical debt trend improving," not just "does this commit pass."
+
+**Confirm your licensing covers your actual team size and CI usage before committing architecturally to it.** NDepend's per-seat commercial licensing is a real, ongoing cost - factor it into the decision honestly rather than assuming free-tool-equivalent economics.
+
+**Pair with Roslyn Analyzers for the fastest possible in-editor feedback**, using NDepend for the deeper, trend-oriented analysis it's specifically strong at. NDepend's analysis runs are not instant the way compiler-integrated analyzers are.
+
+## Comparison with NetArchTest
+
+| | NDepend | NetArchTest |
+| --- | --- | --- |
+| Rule language | CQLinq (full LINQ query language) | Fluent API specific to dependency rules |
+| Scope | Broad - metrics, dependencies, trends, visualization | Narrow - dependency-direction and structural rules |
+| Visualization | Rich (dependency graphs, matrices) | None |
+| Trend tracking | Strong, built in | None |
+| License | Commercial | Free, open source |
+
+NDepend can express everything NetArchTest can (and considerably more) via CQLinq, but at real licensing cost and a steeper learning curve - the choice comes down to whether you need NDepend's broader scope and visualization, or whether NetArchTest's narrower, free, purpose-built tool already covers your actual need.
+
+## Frequently Asked Questions
+
+### Is NDepend worth the cost compared to free alternatives like NetArchTest or Roslyn Analyzers?
+
+It depends on what you actually need. For straightforward dependency-direction enforcement, the free architecture-testing libraries cover the need without cost. NDepend's value is in its combination of deep CQLinq querying, rich visualization, and long-term trend tracking - capabilities that become more valuable as codebase size and organizational complexity grow, and that no free tool in this comparison fully replicates together.
+
+### Do I need to know LINQ well to use CQLinq effectively?
+
+Comfort with LINQ syntax (from, where, select, orderby) translates directly - if your team already writes LINQ queries against application data, the same mental model applies to querying your codebase's structure through NDepend. It's a real but not enormous learning curve if you're already LINQ-fluent.
+
+### Can NDepend replace SonarQube?
+
+There's real overlap - both offer quality gates, metrics, and dashboards - but they're not identical. SonarQube's strength is broader multi-language, multi-repository organizational quality gates with a strong open-source/free tier; NDepend's strength is deep, LINQ-queryable .NET-specific structural analysis and visualization. Some teams use one, some use both for their respective strengths, and the choice often comes down to budget and how central deep dependency analysis specifically is to your needs.
+
+### How often should I run NDepend analysis?
+
+For trend tracking to be meaningful, run it on every build or at least every merge to your main branch, the same cadence you'd use for SonarQube. Periodic (e.g., weekly) analysis is better than none, but loses the fine-grained trend detail and immediate feedback that per-commit analysis provides.
+
+### What's the difference between NDepend's dependency graph and dependency matrix views?
+
+The dependency graph is a node-and-edge visualization showing which components depend on which, good for getting an intuitive sense of overall structure. The dependency matrix is a more compact, grid-based view better suited to precisely identifying specific coupling relationships and cycles in larger codebases where a graph would become visually overwhelming. Both are worth using - graphs for intuition, matrices for precision.
+
+### Can NDepend import results from Roslyn Analyzers?
+
+Yes - NDepend can import Roslyn analyzer diagnostics, letting it serve as a unifying dashboard that combines its own CQLinq-based analysis with results from analyzer packages you're already running, rather than requiring you to check two entirely separate tools.
+
+### What's the most common mistake when adopting NDepend?
+
+Running the default analysis once, treating it as a one-time report rather than an ongoing part of the workflow, and missing the trend-tracking value that comes from consistent, repeated analysis over time. The second common mistake is never learning CQLinq beyond the built-in rules, effectively using an expensive, deeply capable tool as if it were a much simpler one.

--- a/src/posts/2028-02-22-getting-started-with-roslyn-analyzers.md
+++ b/src/posts/2028-02-22-getting-started-with-roslyn-analyzers.md
@@ -1,0 +1,194 @@
+---
+author: Steve Kaschimer
+date: 2028-02-22
+image: /images/posts/2028-02-22-hero.webp
+image_alt: "A lightning-fast in-editor squiggle-underline glyph appearing directly beneath a single line of code with no round trip to any external process, a small custom-rule variant branching off beside it."
+image_prompt: "A dark-mode technical editorial illustration on a near-black background with electric teal, amber, and off-white accents. Composition centers on a single flat line representing a line of code, with a wavy amber squiggle-underline appearing directly beneath a short segment of it, with no arrow or path leading anywhere else, emphasizing there is no round trip to an external process. A smaller secondary squiggle branches off to the side, representing a custom-authored rule distinct from a pre-built package rule. Mood is instant, immediate, and compiler-native. Avoid: vendor logos, brand colors, circuit-board textures, gears, or generic checkmark clip art as the dominant motif."
+layout: post.njk
+site_title: Tech Notes
+summary: "Roslyn Analyzers have the fastest feedback loop of any tool in this series because they run inside the same compiler that turns your code into IL. A setup guide for installing existing analyzer packages, configuring severity via .editorconfig, and authoring a custom analyzer for team-specific rules."
+tags: ["dotnet", "architecture", "code-quality", "developer-productivity"]
+title: "Getting Started with Roslyn Analyzers in .NET"
+---
+
+Roslyn Analyzers have the fastest feedback loop of any tool in this comparison for a simple reason: they run inside the same compiler that turns your code into IL, so a violation shows up as a squiggly line in your editor before you've even saved the file, not after a test run or a CI pass. That immediacy is available two ways - installing an existing analyzer package with hundreds of pre-built rules, or writing your own for something specific to your team that no general-purpose package would know to check.
+
+This guide covers installing existing analyzer packages, configuring severity and enforcement through `.editorconfig`, the basics of authoring a custom analyzer for a team-specific rule, and the best practices that keep analyzer warnings meaningful rather than becoming background noise everyone ignores. By the end you'll have instant, in-editor enforcement for both off-the-shelf and genuinely custom rules.
+
+If you're deciding between architecture/quality tools first, [a comparison of the top .NET architecture and quality enforcement tools](/posts/2028-01-18-top-5-dotnet-architecture-quality-tools-compared/) covers where Roslyn Analyzers fit relative to NetArchTest, ArchUnitNET, SonarQube, and NDepend.
+
+## What You'll Need
+
+- .NET 8 SDK or later - analyzer support is built directly into the SDK, no separate installation needed for the mechanism itself
+- For authoring custom analyzers: the `Microsoft.CodeAnalysis.Analyzers` and `Microsoft.CodeAnalysis.CSharp` packages, plus familiarity with Roslyn's syntax tree and semantic model concepts
+
+## Installing Existing Analyzer Packages
+
+For a broad set of ready-made rules covering style and structural conventions:
+
+```bash
+dotnet add package Roslynator.Analyzers
+```
+
+For security and design-intent-focused rules:
+
+```bash
+dotnet add package Meziantou.Analyzer
+```
+
+Both install as ordinary NuGet packages and start producing warnings immediately on the next build - no separate configuration step required to get initial value, though tuning severity (below) is worth doing deliberately.
+
+## Bootstrapping the Ideal Environment
+
+### Configuring severity via .editorconfig
+
+Analyzer rules default to whatever severity the package author chose, which isn't always what your team wants. Override specific rules in `.editorconfig`:
+
+```ini
+# .editorconfig
+[*.cs]
+# Escalate a specific rule to an error, failing the build
+dotnet_diagnostic.RCS1123.severity = error
+
+# Downgrade a rule your team has deliberately decided not to follow
+dotnet_diagnostic.RCS1021.severity = none
+
+# Set a default severity for analyzer categories
+dotnet_analyzer_diagnostic.category-Style.severity = suggestion
+```
+
+Committing `.editorconfig` to source control means every team member and CI run applies the same severity configuration - this is the mechanism that turns "a warning someone might notice" into "a build failure nobody can miss," for the rules you actually want enforced strictly.
+
+### Treating warnings as errors in CI specifically
+
+```xml
+<!-- Directory.Build.props -->
+<Project>
+  <PropertyGroup Condition="'$(CI)' == 'true'">
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+  </PropertyGroup>
+</Project>
+```
+
+A common pattern: let analyzer warnings stay warnings locally (so they don't block a developer's inner loop), but treat them as errors specifically in CI, so nothing merges with unaddressed warnings even if a local build was run without noticing them.
+
+### Authoring a custom analyzer for a team-specific rule
+
+Custom analyzers require their own project, typically referencing `Microsoft.CodeAnalysis.CSharp.Workspaces`:
+
+```csharp
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public class NoConsoleWriteLineAnalyzer : DiagnosticAnalyzer
+{
+    private static readonly DiagnosticDescriptor Rule = new(
+        id: "MYAPP001",
+        title: "Avoid Console.WriteLine in production code",
+        messageFormat: "Use ILogger instead of Console.WriteLine",
+        category: "Design",
+        defaultSeverity: DiagnosticSeverity.Warning,
+        isEnabledByDefault: true);
+
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => [Rule];
+
+    public override void Initialize(AnalysisContext context)
+    {
+        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+        context.EnableConcurrentExecution();
+        context.RegisterSyntaxNodeAction(AnalyzeInvocation, SyntaxKind.InvocationExpression);
+    }
+
+    private static void AnalyzeInvocation(SyntaxNodeAnalysisContext context)
+    {
+        var invocation = (InvocationExpressionSyntax)context.Node;
+        if (invocation.Expression is MemberAccessExpressionSyntax
+            {
+                Expression: IdentifierNameSyntax { Identifier.Text: "Console" },
+                Name.Identifier.Text: "WriteLine"
+            })
+        {
+            context.ReportDiagnostic(Diagnostic.Create(Rule, invocation.GetLocation()));
+        }
+    }
+}
+```
+
+This is a genuinely different level of effort from installing an existing package - you're working directly with Roslyn's syntax tree API. But it's the only way to enforce a rule truly specific to your codebase's conventions with the same instant, in-editor feedback that off-the-shelf analyzers provide.
+
+### Packaging and referencing a custom analyzer
+
+```xml
+<ItemGroup>
+  <ProjectReference Include="..\MyApp.Analyzers\MyApp.Analyzers.csproj"
+                    OutputItemType="Analyzer"
+                    ReferenceOutputAssembly="false" />
+</ItemGroup>
+```
+
+`OutputItemType="Analyzer"` is what tells the compiler to actually run your project as an analyzer rather than link it as a normal dependency - easy to forget and a common reason a custom analyzer silently does nothing.
+
+## Core Workflow
+
+- **Install existing analyzer packages first, and only author custom ones for rules genuinely specific to your team.** Most style and correctness needs are already covered by mature packages like Roslynator - don't reinvent what already exists.
+- **Configure severity deliberately via `.editorconfig`, don't leave every rule at its package default.** Some defaults will be too strict for your team's conventions, others too lenient for rules you actually want enforced.
+- **Treat warnings as errors in CI, even if you keep them as warnings locally.** This balances fast local iteration against nothing slipping through unnoticed at merge time.
+
+## Verifying Your Setup
+
+1. **Existing analyzer packages produce warnings on real violations** - confirm a deliberately introduced style or correctness issue triggers the expected warning in your editor
+2. **`.editorconfig` severity overrides take effect** - confirm a rule you escalated to `error` actually fails the build, and one you downgraded to `none` no longer appears
+3. **CI treats warnings as errors, even if local builds don't** - confirm your CI configuration actually enforces this distinction
+4. **Custom analyzers are correctly referenced as analyzers, not regular dependencies** - confirm `OutputItemType="Analyzer"` is set and your custom rule actually fires
+
+## Best Practices
+
+**Start with an existing, mature analyzer package before writing anything custom.** Roslynator's 500+ rules and Meziantou.Analyzer's security/design focus cover a huge amount of ground for zero authoring effort.
+
+**Use `.editorconfig` and commit it to source control.** This is what makes severity configuration a team-wide, version-controlled decision rather than an individual IDE setting that varies by developer.
+
+**Escalate genuinely important rules to `error`, and don't let everything sit at `warning` by default.** A warning that never blocks anything is easy to accumulate and eventually ignore entirely - reserve `error` for rules where a violation should never merge.
+
+**Author custom analyzers only for rules that are genuinely team- or codebase-specific**, and that existing packages don't already cover. The authoring investment is real; make sure it's buying you something a NuGet package search wouldn't have already solved.
+
+**Remember `OutputItemType="Analyzer"` when referencing a custom analyzer project.** This is the single most common reason a correctly written custom analyzer appears to do nothing - it's being referenced as a normal library instead of run as an analyzer.
+
+## Comparison with SonarQube
+
+| | Roslyn Analyzers | SonarQube |
+| --- | --- | --- |
+| Where it runs | Inside the compiler, every build | Separate server/service, CI-integrated |
+| Feedback speed | Instant, in-editor | CI pipeline speed (batch) |
+| Custom rules | Full custom authoring via Roslyn APIs | Custom rules via SonarQube's own SDK |
+| Infrastructure | None - built into the SDK | Real - a server or SonarCloud subscription |
+| Trend tracking | None built in | Strong, dashboard-based over time |
+
+They're complementary rather than competing - Roslyn Analyzers catch issues the instant you write them; SonarQube provides the organization-wide dashboard and trend view a compiler-integrated tool structurally can't offer. Many mature teams run both.
+
+## Frequently Asked Questions
+
+### Do I need any special setup to use Roslyn Analyzers, or are they built in?
+
+The mechanism is built directly into the .NET SDK and C# compiler - no separate installation needed. What you install are analyzer *packages* (Roslynator, Meziantou.Analyzer, or your own custom ones) that plug into that already-present mechanism.
+
+### How do I stop a specific analyzer rule from firing without disabling the whole package?
+
+Set its severity to `none` for that specific rule ID in `.editorconfig`: `dotnet_diagnostic.RCS1021.severity = none`. This lets you adopt a package's rules selectively rather than all-or-nothing, silencing specific rules your team has deliberately decided not to follow.
+
+### Why would I write a custom analyzer instead of just using code review to catch a specific issue?
+
+A custom analyzer catches the issue instantly, for every developer, on every keystroke - before it's ever committed, let alone reviewed. Code review is valuable for judgment calls a machine can't make, but for a mechanically checkable rule (a specific anti-pattern, a required naming convention, a banned API), an analyzer catches it earlier and more consistently than relying on a human reviewer to remember and notice every time.
+
+### What's the difference between treating warnings as errors locally versus in CI only?
+
+Treating warnings as errors everywhere means a developer's local build fails the moment a rule is violated, which can slow down exploratory or in-progress work. Treating them as errors only in CI (via a conditional `TreatWarningsAsErrors` in `Directory.Build.props`) keeps local iteration fast while still guaranteeing nothing with unaddressed warnings merges - a common, pragmatic middle ground.
+
+### Why isn't my custom analyzer running even though the code compiles?
+
+The most common cause is forgetting `OutputItemType="Analyzer"` (and typically `ReferenceOutputAssembly="false"`) on the project reference to your analyzer project - without it, the compiler treats it as a normal library dependency rather than running it as an analyzer during compilation.
+
+### Can Roslyn Analyzers enforce architecture rules like NetArchTest does?
+
+To a limited degree with custom authoring, but it's not their natural strength - NetArchTest and ArchUnitNET are purpose-built for assembly-level dependency-direction rules with a much simpler API for that specific job. Roslyn Analyzers excel at syntax- and semantic-level rules checkable within a single file or method; cross-assembly dependency rules are possible but more awkward to express than with a dedicated architecture-testing library.
+
+### What's the most common mistake in a first Roslyn Analyzers setup?
+
+Not committing `.editorconfig` to source control, leaving severity configuration as an individual, inconsistent IDE setting rather than a team-wide, enforced decision. The second common mistake, specific to custom analyzers, is forgetting `OutputItemType="Analyzer"` on the project reference, leading to confusion about why a correctly written analyzer never fires.


### PR DESCRIPTION
## Summary

- Schedules and drafts the .NET Architecture Quality Tools Tuesday track: a comparison anchor post plus five getting-started guides, running weekly Tuesdays 2028-01-18 through 2028-02-22, picking up the cadence directly after the .NET Mocking Libraries track
- Moves the series from `editorial-plan.md`'s Backlog into a dated `## 📅 Tuesday Track - .NET Architecture Quality Tools (January-February 2028)` section, all entries `Status: draft` with `File:` paths, and updates the Backlog intro count from five to four remaining series

### Posts added

- **Anchor:** The Top 5 .NET Architecture & Quality Enforcement Tools Compared: Which One Should You Choose? (2028-01-18) - NetArchTest, ArchUnitNET, SonarQube, Roslyn Analyzers, and NDepend compared, framed around "which layer of enforcement am I adding" rather than a single winner
- Getting Started with SonarQube in .NET (2028-01-25)
- Getting Started with NetArchTest in .NET (2028-02-01)
- Getting Started with ArchUnitNET in .NET (2028-02-08)
- Getting Started with NDepend in .NET (2028-02-15)
- Getting Started with Roslyn Analyzers in .NET (2028-02-22)

Each setup guide cross-links back to the anchor post, mirroring the structure of the prior .NET ORMs/API Styles/Validation Approaches/Mapping Libraries/Caching Solutions/Message Brokers/Background Job Libraries/Mocking Libraries/Testing/Logging/Architecture tracks.

## Test plan

- [x] `npm run deploy` builds cleanly, all 6 posts render
- [x] `node scripts/a11y-check.js` (axe-core + Playwright) - zero violations across home/post/about/privacy/terms/404 in light and dark mode
- [x] Verified all 5 setup-guide cross-links resolve to the anchor post's output URL


---
_Generated by [Claude Code](https://claude.ai/code/session_01WKyNF7L5qzrfct8cec6A32)_