### PR TITLE
Add CI/CD Platforms for .NET Tuesday track (6 posts)

### DIFF
--- a/editorial-plan.md
+++ b/editorial-plan.md
@@ -1298,17 +1298,69 @@ Six posts on how a .NET team keeps architecture decisions from silently drifting
 
 ---
 
-## 📅 Backlog - Unscheduled Series
+## 📅 Tuesday Track - CI/CD Platforms for .NET (February-April 2028)
 
-Four six-post series remain unscheduled, drawn from the drafts in `docs/article-ideas/`. They continue the Tuesday cadence once the .NET Architecture Quality Tools series ends on 2028-02-22, and they're listed here in priority order. They're deliberately undated - that horizon is too far out to put honest dates against - so each series gets one entry rather than six speculative ones, and entries are expanded into individual dated posts when a series moves onto the calendar.
+Six posts on where a .NET team actually runs its builds and deployments, picking up the Tuesday cadence directly from the Architecture Quality Tools track. A comparison post anchors the track and each of the five follow-ups is a complete setup for one CI/CD platform.
 
-### CI/CD Platforms for .NET (6 posts)
-- **Status:** `idea`
-- **Source:** `docs/article-ideas/top-5-cicd-platforms-dotnet-compared.md` + 5 getting-started drafts
-- **Series:** Top 5 comparison, then GitHub Actions, Azure DevOps, GitLab CI, Jenkins, TeamCity
+### The Top 5 CI/CD Platforms for .NET Compared: Which One Should You Choose?
+- **Status:** `draft`
+- **Scheduled:** 2028-02-29
+- **Source:** `docs/article-ideas/top-5-cicd-platforms-dotnet-compared.md`
+- **File:** `src/posts/2028-02-29-top-5-cicd-platforms-dotnet-compared.md`
 - **Pitch:** GitHub Actions leads organizational adoption at roughly a third of teams, with Jenkins and GitLab CI behind it. But adoption share answers "what do most teams use," not "what should this team use" - and for .NET specifically the answer depends mostly on where the code already lives and how much governance the organization actually needs.
 - **Angle:** Compares the five on hosting model, repo coupling, .NET-specific fit, governance, and cost model. The research is consistent that there's no universal winner, so the comparison resolves on repo host and control appetite rather than a feature matrix. Gives Azure DevOps an honest hearing as frequently the cheapest option for Windows-heavy workloads and the strongest out-of-the-box governance story, which is easy to miss when GitHub Actions is the unexamined default.
 - **Tags:** `dotnet`, `ci-cd`, `devops`, `platform-engineering`, `tooling`
+
+### Getting Started with GitHub Actions for .NET
+- **Status:** `draft`
+- **Scheduled:** 2028-03-07
+- **Source:** `docs/article-ideas/getting-started-with-github-actions-dotnet.md`
+- **File:** `src/posts/2028-03-07-getting-started-with-github-actions-dotnet.md`
+- **Pitch:** A working GitHub Actions build-and-test workflow takes about ten lines, which is exactly why the real setup work lives elsewhere - caching NuGet correctly, pinning actions to a commit SHA, and using OIDC instead of long-lived cloud credentials.
+- **Angle:** Covers `setup-dotnet`'s built-in caching keyed to lock files, matrix builds across OS/version combinations, SHA-pinning third-party actions against supply-chain risk, and OIDC-based Azure login as the default over static service-principal secrets. Separates CI triggers from CD triggers explicitly and covers GitHub Environments with required reviewers as the enforced human gate before production.
+- **Tags:** `dotnet`, `ci-cd`, `devops`, `tooling`
+
+### Getting Started with Azure DevOps for .NET
+- **Status:** `draft`
+- **Scheduled:** 2028-03-14
+- **Source:** `docs/article-ideas/getting-started-with-azure-devops-dotnet.md`
+- **File:** `src/posts/2028-03-14-getting-started-with-azure-devops-dotnet.md`
+- **Pitch:** Azure Pipelines' YAML feels familiar if you know GitHub Actions - steps, stages, triggers - but the vocabulary is genuinely different underneath, and the payoff is real specifically where Azure is the deployment target.
+- **Angle:** Covers the `Cache@2` task as the explicit equivalent of `setup-dotnet`'s caching, multi-stage pipelines with `dependsOn` for build/deploy separation, workload identity federation as Azure DevOps' answer to OIDC, and native deployment tasks (`AzureWebApp@1`) over raw CLI scripting. Direct that Azure DevOps works against GitHub-hosted repos too, and is frequently the cheapest option specifically for Windows-heavy build workloads.
+- **Tags:** `dotnet`, `ci-cd`, `cloud`, `devops`, `tooling`
+
+### Getting Started with GitLab CI for .NET
+- **Status:** `draft`
+- **Scheduled:** 2028-03-21
+- **Source:** `docs/article-ideas/getting-started-with-gitlab-ci-dotnet.md`
+- **File:** `src/posts/2028-03-21-getting-started-with-gitlab-ci-dotnet.md`
+- **Pitch:** GitLab CI's single-file, single-platform philosophy means your `.gitlab-ci.yml` sits inside the same product that hosts the repo, runs security scans, and tracks issues - which changes the setup calculus from just build/test/deploy.
+- **Angle:** Covers `stages`/`rules` as GitLab's job-scoping vocabulary, cache keys tied to lock file contents, and including the built-in Dependency-Scanning and Container-Scanning templates as the platform's clearest differentiator over stitching a third-party scanner onto GitHub Actions or Azure DevOps. Frames adopting GitLab CI as a broader platform commitment, not a narrow CI/CD-only decision.
+- **Tags:** `dotnet`, `ci-cd`, `devops`, `security`, `tooling`
+
+### Getting Started with Jenkins for .NET
+- **Status:** `draft`
+- **Scheduled:** 2028-03-28
+- **Source:** `docs/article-ideas/getting-started-with-jenkins-dotnet.md`
+- **File:** `src/posts/2028-03-28-getting-started-with-jenkins-dotnet.md`
+- **Pitch:** Jenkins asks more of you before your first pipeline even runs than any other platform in this series - provisioning the server, installing plugins, configuring agents - work every cloud-hosted alternative hands you for free the moment you push a YAML file.
+- **Angle:** Covers Declarative Pipeline syntax in a Jenkinsfile, Docker agents as the fix for "works on my Jenkins host but nowhere else," the Credentials plugin over hardcoded secrets, and `input` steps as Jenkins' built-in manual approval gate. Honest throughout that the real cost isn't the free software, it's the ongoing infrastructure and maintenance burden - estimated $800-2,500/month for a 20-person team - and that this needs existing operational capacity to be worth it.
+- **Tags:** `dotnet`, `ci-cd`, `devops`, `platform-engineering`, `tooling`
+
+### Getting Started with TeamCity for .NET
+- **Status:** `draft`
+- **Scheduled:** 2028-04-04
+- **Source:** `docs/article-ideas/getting-started-with-teamcity-dotnet.md`
+- **File:** `src/posts/2028-04-04-getting-started-with-teamcity-dotnet.md`
+- **Pitch:** TeamCity's build configuration UI is a genuinely good way to learn the concepts, but the moment there's more than one project, Kotlin DSL - version-controlled, code-based pipeline definitions - is the real setup decision that determines whether configuration is reviewable or a black box.
+- **Angle:** Covers migrating from UI-configured builds to Kotlin DSL (with TeamCity's own DSL-generation as a starting point), snapshot dependencies for genuine multi-project build chains that parallelize independent builds and gate on prerequisites, and omitted VCS triggers as TeamCity's manual-approval mechanism for deployment configurations. Direct that its build-chain sophistication earns its keep specifically for complex, multi-project .NET solutions, not a single simple project.
+- **Tags:** `dotnet`, `ci-cd`, `devops`, `tooling`
+
+---
+
+## 📅 Backlog - Unscheduled Series
+
+Three six-post series remain unscheduled, drawn from the drafts in `docs/article-ideas/`. They continue the Tuesday cadence once the CI/CD Platforms for .NET series ends on 2028-04-04, and they're listed here in priority order. They're deliberately undated - that horizon is too far out to put honest dates against - so each series gets one entry rather than six speculative ones, and entries are expanded into individual dated posts when a series moves onto the calendar.
 
 ### .NET Deployment Options (6 posts)
 - **Status:** `idea`

--- a/src/posts/2028-02-29-top-5-cicd-platforms-dotnet-compared.md
+++ b/src/posts/2028-02-29-top-5-cicd-platforms-dotnet-compared.md
@@ -1,0 +1,168 @@
+---
+author: Steve Kaschimer
+date: 2028-02-29
+image: /images/posts/2028-02-29-hero.webp
+image_alt: "Five columns of abstract CI/CD glyphs positioned along a horizontal axis running from tight repo-host coupling on the left to fully repo-agnostic self-hosted control on the right."
+image_prompt: "A dark-mode technical editorial illustration on a near-black background with electric teal, amber, and off-white accents. Composition is five vertical columns of equal width separated by thin hairline rules, each column topped by a distinct abstract glyph rendered in flat geometry: a small pipeline glyph fused directly into a repo-shaped outline with no gap between them, a similar fused glyph but with a small Azure-cloud accent shape beside it, an all-in-one platform glyph combining a pipeline with a shield and a repo icon in one continuous shape, a build-chain glyph shown as several small connected nodes branching and rejoining, and a standalone server-rack glyph with a pipeline running independently beside it, not fused to anything. Beneath the glyphs, a shared horizontal axis labeled in monospaced type runs from 'tight repo coupling' on the left to 'self-hosted control' on the right, with a small glowing teal dot positioned at a different point under each column. Mood is comparative, engineering-first, and non-partisan. Avoid: vendor logos, brand colors, circuit-board textures, gears, or generic checkmark clip art used as the dominant motif."
+layout: post.njk
+site_title: Tech Notes
+summary: "GitHub Actions leads organizational adoption, but adoption share answers what most teams use, not what your team should use. For .NET specifically, the answer depends on where the code already lives and how much governance the organization needs. A practical breakdown of five CI/CD platforms."
+tags: ["dotnet", "ci-cd", "devops", "platform-engineering", "tooling"]
+title: "The Top 5 CI/CD Platforms for .NET Compared: Which One Should You Choose?"
+---
+
+CI/CD platform comparisons tend to get treated as a popularity contest, and the popularity numbers are genuinely useful data - GitHub Actions leads organizational adoption at roughly a third of teams, with Jenkins and GitLab CI rounding out the top three. But adoption share answers "what do most teams use," not "what should your team use," and for .NET specifically, the honest answer depends heavily on where your code already lives and how much governance your organization actually needs.
+
+This guide compares five CI/CD platforms .NET teams reach for most often: GitHub Actions, Azure DevOps, GitLab CI, TeamCity, and Jenkins. None of these are wrong choices - the research is remarkably consistent that there's no universal winner, only the best fit for a given repo host, governance model, and infrastructure preference. What matters is matching the platform to where your code already lives and how much control your organization actually needs over the build infrastructure itself. This series continues with dedicated getting-started walkthroughs for each platform with .NET.
+
+## Quick Comparison
+
+| | GitHub Actions | Azure DevOps | GitLab CI | TeamCity | Jenkins |
+| --- | --- | --- | --- | --- | --- |
+| **Hosting model** | Cloud (GitHub-hosted or self-hosted runners) | Cloud (Microsoft-hosted or self-hosted agents) | Cloud (GitLab.com) or self-managed | Cloud or fully self-hosted | Self-hosted (infrastructure is your responsibility) |
+| **Repo coupling** | Tightest with GitHub | Tightest with Azure Repos, works with GitHub too | Tightest with GitLab | Repo-agnostic | Repo-agnostic |
+| **.NET-specific fit** | Strong, broad community actions | Deepest for Windows-heavy/Microsoft-stack teams | Strong, especially paired with GitLab's broader DevOps platform | Strong build orchestration, enterprise-grade | Strong via plugins, requires more setup |
+| **Governance/compliance** | Requires GitHub Enterprise for complex governance | Strong out of the box, enterprise-friendly | Strong, especially self-managed | Strong, self-hosted control | Strong, but entirely your responsibility to build |
+| **Cost model** | Free tier generous; pay per minute beyond it | Often cheapest for Windows-heavy workloads | Free tier + paid tiers | License-based | Free software, real infrastructure and maintenance cost |
+| **Best for** | Teams already on GitHub | Windows/Microsoft-stack-heavy teams, enterprise governance | Teams wanting one platform for repos, CI, and security scanning | Teams wanting deep build orchestration control, self-hosted | Teams needing maximum customization and full infrastructure control |
+
+## GitHub Actions
+
+GitHub Actions leads CI/CD adoption in 2026 by a clear margin, and for .NET teams already hosting code on GitHub, it's consistently the natural default - YAML-based workflows, a massive marketplace of community actions, and zero friction between where your code lives and where it builds.
+
+**Strengths:**
+
+- The tightest possible integration with GitHub itself - pull requests, checks, and deployments all live in the same interface developers already use daily
+- A generous free tier for public and reasonably-sized private repositories, with per-minute billing beyond that threshold
+- An enormous marketplace of community and first-party actions, meaning most .NET-specific needs (NuGet publishing, Azure deployment, test reporting) already have a well-maintained action rather than requiring custom scripting
+- The official GitHub Actions Importer CLI supports migrating from Jenkins, CircleCI, Azure DevOps, and GitLab CI, with Jenkins pipelines reportedly migrating at 70-90% accuracy - a real, practical path if you're consolidating tooling
+
+**Weaknesses:**
+
+- Build speed on standard runners can lag behind purpose-built compute providers (like CircleCI) for genuinely heavy test suites, though this gap narrows with self-hosted runners
+- Complex enterprise governance requirements push you toward GitHub Enterprise, which carries real cost at scale
+- Security requires deliberate configuration - pinning actions to a full commit SHA rather than a mutable tag, using OIDC instead of static cloud credentials, and applying least-privilege permissions are all things you need to actively do, not defaults you get automatically
+
+**Choose this when:** your code already lives on GitHub and you don't have a specific reason to look elsewhere - it's the least-friction option for the largest share of .NET teams in 2026.
+
+## Azure DevOps
+
+Azure DevOps (Azure Pipelines specifically, for CI/CD) remains the deepest, most natural fit for teams heavily invested in the Microsoft ecosystem - Windows-based builds, Azure deployment targets, and enterprise governance requirements all get first-class treatment here in ways that feel more native than bolting the same capability onto a GitHub-hosted pipeline.
+
+**Strengths:**
+
+- Genuinely the cheapest option for Windows-heavy build workloads in cost comparisons - a real, measurable advantage if your .NET builds specifically need Windows runners rather than Linux
+- Deep, natural integration with the rest of the Azure ecosystem - deploying to Azure App Service, Azure Container Apps, or AKS is more streamlined here than assembling the equivalent from third-party actions elsewhere
+- Strong governance and approval workflows out of the box, well suited to enterprise compliance requirements without needing an upgraded tier the way some competitors require
+- Works with repositories hosted on GitHub as well as Azure Repos, so it's not strictly limited to Microsoft-hosted source control
+
+**Weaknesses:**
+
+- Less central to the broader industry conversation than GitHub Actions or Jenkins - smaller community, fewer third-party integrations and examples relative to the two most dominant platforms
+- The most natural fit specifically for Microsoft-stack-heavy teams; teams without existing Azure or Microsoft ecosystem investment get comparatively less differentiated value
+- Its own YAML pipeline syntax, while capable, is a distinct thing to learn if your team is more familiar with GitHub Actions' or GitLab's conventions
+
+**Choose this when:** your team is deep in the Microsoft/Azure ecosystem, needs Windows-heavy build infrastructure at the lowest cost, or requires strong built-in enterprise governance without upgrading to a premium tier elsewhere.
+
+## GitLab CI
+
+GitLab CI/CD is part of GitLab's broader all-in-one DevOps platform - source control, CI/CD, security scanning (SAST, DAST, dependency scanning), and project planning all under one product, which is the core of its pitch relative to assembling equivalent capability from several separate tools.
+
+**Strengths:**
+
+- The most complete single-platform experience in this comparison - repos, pipelines, security scanning, and project management without stitching together separate tools
+- Built-in security scanning (SAST, DAST, dependency scanning) is genuinely differentiated versus needing separate third-party tooling layered onto GitHub Actions or Azure DevOps
+- Strong self-managed option for teams wanting GitLab's full feature set with complete infrastructure control, not just the SaaS offering
+- Increasingly cited as having more mature AI-assisted CI features compared to some competitors, worth checking current state given how quickly this specific area moves
+
+**Weaknesses:**
+
+- The tightest, most natural fit is specifically for teams already using GitLab for source control - less compelling as a CI/CD-only choice if your code lives elsewhere
+- Smaller .NET-specific community and fewer readily available examples compared to GitHub Actions, though core functionality is solid
+- Choosing GitLab CI often implies a broader platform commitment (repos, planning, security) rather than a narrow CI/CD-only decision, which is a bigger adoption decision than picking a CI tool alone
+
+**Choose this when:** you want one consolidated platform for source control, CI/CD, and security scanning rather than assembling several point solutions, and you're either already on GitLab or open to moving your broader toolchain there.
+
+## TeamCity
+
+TeamCity, from JetBrains, is positioned specifically for teams wanting enterprise-grade build orchestration with deep self-hosted control - less of a lightweight, YAML-first tool and more a purpose-built build server with a strong reputation among teams that have outgrown simpler CI tools.
+
+**Strengths:**
+
+- Enterprise-grade build orchestration with genuinely sophisticated build chain and dependency management, well suited to complex, multi-project .NET solutions with intricate build ordering requirements
+- Strong self-hosted control, appealing to teams with strict infrastructure or compliance requirements that a pure SaaS CI platform can't satisfy
+- A mature, actively maintained product with deep .NET/MSBuild integration, reflecting JetBrains' broader investment in the .NET developer tooling space (the same company behind Rider and ReSharper)
+- Repo-agnostic - works well regardless of where your source control actually lives, unlike GitHub Actions or GitLab CI's tighter coupling to their respective platforms
+
+**Weaknesses:**
+
+- License-based cost model, a real and different consideration from GitHub Actions' or GitLab's free-tier-plus-usage pricing
+- Smaller mindshare and community than GitHub Actions, Jenkins, or GitLab CI specifically, meaning fewer publicly available examples for uncommon scenarios
+- The self-hosted control that's a strength for compliance-focused teams is also real infrastructure responsibility, the same trade-off Jenkins carries
+
+**Choose this when:** you have genuinely complex, multi-project build orchestration needs, want strong self-hosted control for compliance reasons, and are comfortable with a licensed product rather than a free, usage-based one.
+
+## Jenkins
+
+Jenkins remains the most deployed CI/CD server globally and the most customizable option in this comparison by a wide margin - it's infrastructure you own and configure entirely yourself, which is both its greatest strength and its most significant ongoing cost.
+
+**Strengths:**
+
+- Unmatched flexibility for teams willing to invest in configuring and maintaining it - if a CI/CD workflow can be imagined, Jenkins can almost certainly be configured to do it, via its vast plugin ecosystem
+- Groovy-based Jenkinsfiles are more expressive than YAML-based alternatives for genuinely complex build logic, a real advantage for teams with sophisticated pipeline requirements
+- Completely repo-agnostic and infrastructure-agnostic - no coupling to any specific source control platform or cloud provider
+- Remains extremely common in long-lived enterprise environments, with Jenkins pipelines a well-worn, well-understood pattern across the industry
+
+**Weaknesses:**
+
+- The software itself is free, but infrastructure and maintenance are a real, ongoing cost - estimates put a 20-person team's self-hosted Jenkins cost at $800-2,500/month including compute, storage, and engineer maintenance time
+- Cloud-native alternatives win the large majority of new projects specifically because of this operational overhead - Jenkins' strongest fit today is organizations with strict infrastructure control requirements and an operations team to support it, not new, simple projects
+- Setup and plugin management require more upfront and ongoing effort than any cloud-hosted alternative in this comparison
+
+**Choose this when:** you need maximum customization and infrastructure control, have (or are willing to build) the operational capacity to maintain it well, and your organization's constraints specifically call for self-hosted CI infrastructure rather than a managed platform.
+
+## How to Decide
+
+A few heuristics that cover most real-world decisions:
+
+**Code already lives on GitHub, no specific reason to look elsewhere?** GitHub Actions is the least-friction default, and the migration tooling makes it a reasonable landing point even if you're consolidating from another platform.
+
+**Deep in the Microsoft/Azure ecosystem, Windows-heavy builds, or need strong built-in enterprise governance?** Azure DevOps offers the most natural fit and is often the cheapest option specifically for Windows workloads.
+
+**Want one consolidated platform for repos, CI, and security scanning rather than several separate tools?** GitLab CI is built around exactly that pitch, at the cost of a broader platform commitment.
+
+**Genuinely complex, multi-project build orchestration, with a preference for self-hosted control?** TeamCity's build chain management and JetBrains' .NET tooling investment make it a strong specialist choice.
+
+**Need maximum customization and have the operational capacity to maintain infrastructure yourself?** Jenkins remains unmatched in flexibility - just be honest about the real, ongoing infrastructure cost that comes with it.
+
+The research is consistent on one point worth internalizing: pilot two options against a real service rather than picking from a spec sheet alone - one Git-native tool matching your repo host, and one enterprise or self-hosted option if governance is a genuine priority. The right answer depends more on your actual constraints than on any platform's raw feature count.
+
+## Frequently Asked Questions
+
+### Is GitHub Actions the best CI/CD platform for .NET in 2026?
+
+For teams already hosting code on GitHub, it's the natural, lowest-friction default and leads organizational adoption industry-wide. It's not universally "the best" - teams with Windows-heavy builds and Microsoft ecosystem investment may find Azure DevOps cheaper and more natural, and teams needing maximum self-hosted control may prefer Jenkins or TeamCity.
+
+### Should I migrate from Jenkins to GitHub Actions?
+
+Consider it if Jenkins' infrastructure and maintenance cost has become a genuine burden relative to the customization you're actually using - the official GitHub Actions Importer CLI supports this migration, with Jenkins pipelines reportedly converting at 70-90% accuracy. If your team has the operational capacity and genuinely needs Jenkins' flexibility, migration isn't automatically the right call just because it's possible.
+
+### What's the actual cost difference between these platforms?
+
+It varies significantly by workload. GitHub Actions and GitLab CI's free tiers are strong for startup-scale usage (under roughly 3,000 minutes/month). Azure DevOps is typically the cheapest per-minute option for Windows-heavy workloads specifically. Jenkins has no software licensing cost but real infrastructure and maintenance expense - estimated at $800-2,500/month for a 20-person team once compute, storage, and engineer time are accounted for. TeamCity uses license-based pricing, a different model from the usage-based platforms.
+
+### Is Jenkins still worth learning or adopting in 2026?
+
+Yes, particularly for organizations with strict infrastructure control requirements and existing operational capacity to support it - it remains the most deployed CI server globally and continues active development. For new, simpler projects without those specific constraints, cloud-native alternatives win the majority of adoption specifically because they avoid Jenkins' operational overhead.
+
+### What security practices matter most for GitHub Actions specifically?
+
+Pin all third-party actions to a full commit SHA rather than a mutable tag or branch (a moving tag can be silently repointed to different, potentially malicious code), use OIDC for cloud authentication instead of long-lived static credentials, and apply least-privilege permissions to workflow tokens rather than broad default access. These aren't automatic defaults - they require deliberate configuration.
+
+### Can I use Azure DevOps if my code is hosted on GitHub, not Azure Repos?
+
+Yes - Azure Pipelines works with GitHub-hosted repositories as well as Azure Repos, so you're not required to move your source control to adopt Azure DevOps' CI/CD capabilities specifically. That said, the tightest integration experience is still with Azure Repos.
+
+### How do I decide between GitLab CI and assembling separate tools (GitHub Actions plus a separate security scanner)?
+
+It comes down to whether platform consolidation itself is valuable to your team, versus preferring best-of-breed tools for each individual function. GitLab CI's pitch is specifically reducing the number of separate tools and integrations you maintain; if you're satisfied with GitHub Actions plus point solutions for security scanning and project management, there's less incentive to consolidate onto GitLab purely for its CI/CD capability.

--- a/src/posts/2028-03-07-getting-started-with-github-actions-dotnet.md
+++ b/src/posts/2028-03-07-getting-started-with-github-actions-dotnet.md
@@ -1,0 +1,201 @@
+---
+author: Steve Kaschimer
+date: 2028-03-07
+image: /images/posts/2028-03-07-hero.webp
+image_alt: "A small pipeline glyph fused directly into a repo-shaped outline with no visible gap, a locked shield badge tucked at the seam representing SHA pinning and OIDC."
+image_prompt: "A dark-mode technical editorial illustration on a near-black background with electric teal, amber, and off-white accents. Composition centers on a thin pipeline glyph fused seamlessly into a repository-shaped outline, no visible boundary between them, implying zero friction between code host and build. A small amber shield badge sits right at the seam, marking a deliberate security checkpoint (SHA pinning, OIDC) layered onto the otherwise frictionless connection. Mood is native, fast, and quietly disciplined. Avoid: vendor logos, brand colors, circuit-board textures, gears, or generic checkmark clip art as the dominant motif."
+layout: post.njk
+site_title: Tech Notes
+summary: "A working GitHub Actions build-and-test workflow takes about ten lines, which is exactly why the real setup work lives elsewhere. A setup guide for caching NuGet correctly, pinning actions to a commit SHA, and using OIDC instead of long-lived cloud credentials."
+tags: ["dotnet", "ci-cd", "devops", "tooling"]
+title: "Getting Started with GitHub Actions for .NET"
+---
+
+GitHub Actions' YAML syntax is simple enough that a working .NET build-and-test workflow takes about ten lines, which is exactly why the real setup work lives elsewhere: caching NuGet packages correctly, pinning actions to a commit SHA rather than a mutable tag, and using OIDC instead of long-lived cloud credentials for deployment. None of these are hard, but none of them are the default either - a workflow that "just builds" and one that's actually fast, secure, and production-ready look almost identical until you know what to add.
+
+This guide covers setting up a GitHub Actions workflow for .NET, bootstrapping caching and matrix builds for real project needs, the core CI and CD patterns including OIDC-based Azure deployment, and the security practices that matter specifically for GitHub Actions. By the end you'll have a pipeline that's fast on every run, not just the first one, and secure by deliberate configuration rather than by luck.
+
+If you're deciding between CI/CD platforms first, [a comparison of the top CI/CD platforms for .NET](/posts/2028-02-29-top-5-cicd-platforms-dotnet-compared/) covers where GitHub Actions fits relative to Azure DevOps, GitLab CI, TeamCity, and Jenkins.
+
+## What You'll Need
+
+- A GitHub repository containing your .NET solution
+- No local installation required - workflows run on GitHub's infrastructure (or self-hosted runners you configure separately)
+
+## Your First Workflow
+
+```yaml
+# .github/workflows/ci.yml
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  build-and-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '8.0.x'
+
+      - run: dotnet restore
+      - run: dotnet build --no-restore -c Release
+      - run: dotnet test --no-build -c Release
+```
+
+This is a complete, working CI pipeline - it triggers on pushes and pull requests to `main`, restores, builds, and tests. Everything from here is about making it fast, secure, and production-ready.
+
+## Bootstrapping the Ideal Environment
+
+### Cache NuGet packages
+
+```yaml
+- uses: actions/setup-dotnet@v4
+  with:
+    dotnet-version: '8.0.x'
+    cache: true
+    cache-dependency-path: '**/packages.lock.json'
+```
+
+Without caching, every run re-downloads every NuGet package from scratch - a real, avoidable time cost on every single build. `cache-dependency-path` pointing at your lock files means the cache correctly invalidates when dependencies actually change, rather than serving stale packages.
+
+### Matrix builds for multiple target frameworks or OSes
+
+```yaml
+jobs:
+  build-and-test:
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+        dotnet-version: ['8.0.x', '9.0.x']
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: ${{ matrix.dotnet-version }}
+      - run: dotnet test
+```
+
+A matrix runs the same job across every combination of the defined dimensions - useful for confirming your application works correctly across multiple .NET versions or operating systems without duplicating the workflow definition for each.
+
+### Pin actions to a full commit SHA, not a mutable tag
+
+```yaml
+# Instead of this:
+- uses: actions/checkout@v4
+
+# Do this, for anything security-sensitive:
+- uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+```
+
+A tag like `@v4` can be silently repointed to different code by the action's maintainer - pinning to a full SHA guarantees you're running exactly the code you reviewed. This matters most for third-party actions with write access to secrets or deployment credentials; official GitHub-maintained actions are lower risk but pinning remains best practice broadly.
+
+### Use OIDC instead of static credentials for cloud deployment
+
+```yaml
+permissions:
+  id-token: write
+  contents: read
+
+steps:
+  - uses: actions/checkout@v4
+  - uses: azure/login@v2
+    with:
+      client-id: ${{ secrets.AZURE_CLIENT_ID }}
+      tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+      subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+```
+
+This authenticates to Azure using OpenID Connect - a short-lived token issued per workflow run - rather than a long-lived service principal secret stored as a static credential. No secret to rotate, no static credential that could leak and remain valid indefinitely.
+
+### Apply least-privilege permissions
+
+```yaml
+permissions:
+  contents: read
+  pull-requests: write # only if the workflow needs to comment on PRs
+```
+
+Setting `permissions` explicitly at the workflow or job level restricts what the automatically-provided `GITHUB_TOKEN` can actually do - default permissions are broader than most workflows need, and scoping them down limits the blast radius if a workflow is ever compromised.
+
+## Core Workflow
+
+- **Separate CI (build/test on every push and PR) from CD (deploy on merge to main or a tag).** Use `on: push: branches: [main]` for CD triggers specifically, keeping deployment from firing on every feature branch push.
+- **Use environments with required reviewers for production deployments**, adding a manual approval gate before anything deploys to a sensitive target.
+- **Publish test results and code coverage as workflow artifacts or PR annotations**, so failures are visible directly in the pull request rather than requiring someone to dig through raw logs.
+
+```yaml
+deploy:
+  needs: build-and-test
+  runs-on: ubuntu-latest
+  environment: production
+  steps:
+    - run: echo "Deploying to production"
+```
+
+## Verifying Your Setup
+
+1. **Caching is actually reducing build time** - compare a cached run's duration against an uncached one; a meaningful difference confirms the cache is working
+2. **Matrix builds cover the combinations you actually need** - confirm all defined OS/version combinations run and report results independently
+3. **OIDC authentication succeeds without a static secret** - confirm cloud deployment steps authenticate correctly using only the configured `id-token: write` permission and federated credential setup
+4. **Pinned actions still resolve correctly** - confirm SHA-pinned actions run without error, and periodically review whether newer versions need to be adopted (SHA pinning means you control updates explicitly, not automatically)
+
+## Best Practices
+
+**Pin third-party actions to a full commit SHA, especially anything with access to secrets.** This is a real, actively recommended security practice, not excessive caution - a compromised or malicious action update is a genuine supply-chain risk.
+
+**Use OIDC for cloud authentication instead of long-lived static credentials wherever the target platform supports it.** Azure, AWS, and GCP all support OIDC federation with GitHub Actions - there's little reason to still be storing static cloud credentials as repository secrets.
+
+**Cache NuGet packages (and any other slow, deterministic dependency restore) by default.** The time savings compound across every single workflow run, for a small amount of one-time configuration.
+
+**Scope `GITHUB_TOKEN` permissions explicitly at the workflow or job level.** Default permissions are broader than most workflows need - least privilege here meaningfully reduces the impact of a compromised workflow or action.
+
+**Use required reviewers on GitHub Environments for production deployments.** This adds a genuine, enforced human gate before anything reaches a sensitive target, without adding friction to the CI portion of the pipeline.
+
+## Comparison with Azure DevOps
+
+| | GitHub Actions | Azure DevOps |
+| --- | --- | --- |
+| Repo coupling | Tightest with GitHub | Tightest with Azure Repos, works with GitHub too |
+| Windows build cost | Standard GitHub-hosted pricing | Often cheapest for Windows-heavy workloads |
+| Azure deployment integration | Strong via OIDC and azure/login | Deepest, most native |
+| Governance for complex enterprise needs | Requires GitHub Enterprise | Strong out of the box |
+
+If you're already committed to GitHub Actions but deploying heavily to Azure, the OIDC-based `azure/login` pattern above gets you most of Azure DevOps' native deployment convenience without switching platforms.
+
+## Frequently Asked Questions
+
+### Why should I pin actions to a commit SHA instead of a version tag?
+
+A version tag like `@v4` can be repointed by the action's maintainer to different code at any time - either accidentally or, in a supply-chain attack scenario, maliciously. Pinning to a full commit SHA guarantees the exact code you reviewed is what actually runs, which matters most for any action with access to secrets or deployment credentials.
+
+### What's OIDC, and why is it better than storing cloud credentials as secrets?
+
+OIDC (OpenID Connect) lets your workflow authenticate to a cloud provider using a short-lived, per-run token instead of a long-lived static credential stored as a repository secret. There's no secret to rotate or accidentally leak that would remain valid indefinitely - the federated trust relationship is configured once, and tokens are issued fresh for each workflow run.
+
+### How do I speed up slow GitHub Actions builds for .NET?
+
+Enable NuGet caching via `actions/setup-dotnet`'s built-in `cache: true` option, use `--no-restore` and `--no-build` flags on subsequent steps to avoid redundant work, and consider self-hosted runners for genuinely heavy workloads where standard GitHub-hosted runner performance is a real bottleneck.
+
+### What's the difference between CI and CD in a GitHub Actions workflow?
+
+CI (continuous integration) typically runs on every push and pull request - build, test, lint. CD (continuous deployment/delivery) typically triggers on merges to a specific branch or tag creation, and actually deploys the application. Keeping these as distinct jobs or workflows, gated by different triggers, prevents deployment from firing on every feature-branch push.
+
+### How do I require manual approval before a production deployment?
+
+Use GitHub Environments with required reviewers configured on the "production" environment - a job targeting that environment will pause and wait for an approved reviewer before proceeding, giving you an enforced human gate without needing a separate approval tool.
+
+### Can I run GitHub Actions workflows on my own infrastructure instead of GitHub-hosted runners?
+
+Yes - self-hosted runners let you run workflows on infrastructure you control, useful for specific hardware needs, cost optimization at scale, or network access requirements that GitHub-hosted runners can't satisfy. Setup involves registering your own runner with the repository or organization.
+
+### What's the most common mistake in a first GitHub Actions setup for .NET?
+
+Not caching NuGet packages, leaving every run to redundantly re-download the same dependencies. The second common mistake is storing static cloud credentials as secrets instead of using OIDC, and not pinning third-party actions to a SHA, both of which are genuine, actively-discussed security gaps rather than theoretical concerns.

--- a/src/posts/2028-03-14-getting-started-with-azure-devops-dotnet.md
+++ b/src/posts/2028-03-14-getting-started-with-azure-devops-dotnet.md
@@ -1,0 +1,184 @@
+---
+author: Steve Kaschimer
+date: 2028-03-14
+image: /images/posts/2028-03-14-hero.webp
+image_alt: "A pipeline glyph fused directly into a repo-shaped outline, matching a sibling tool's shape, but with a small Azure-cloud accent shape sitting beside it marking a deeper native connection."
+image_prompt: "A dark-mode technical editorial illustration on a near-black background with electric teal, amber, and off-white accents. Composition centers on a thin pipeline glyph fused seamlessly into a repository-shaped outline, echoing a sibling tool's composition, but with a small solid amber cloud-shaped accent positioned just beside the seam, implying a deeper, more native connection specifically to a cloud deployment target. Mood is native, deep, and enterprise-ready. Avoid: vendor logos, brand colors, circuit-board textures, gears, or generic cloud clip art as the dominant motif."
+layout: post.njk
+site_title: Tech Notes
+summary: "Azure Pipelines' YAML feels familiar if you know GitHub Actions, but the vocabulary is genuinely different underneath, and the payoff is real specifically where Azure is the deployment target. A setup guide for the Cache@2 task, multi-stage pipelines, and workload identity federation."
+tags: ["dotnet", "ci-cd", "cloud", "devops", "tooling"]
+title: "Getting Started with Azure DevOps for .NET"
+---
+
+Azure DevOps' YAML pipelines feel familiar if you already know GitHub Actions - steps, stages, triggers - but the vocabulary and structure are genuinely different underneath, and the payoff for learning them is real specifically where Azure is your deployment target: native Azure service connections, deep App Service/Container Apps/AKS deployment tasks, and governance features that don't require an enterprise upgrade tier the way some competitors do.
+
+This guide covers setting up an Azure Pipelines YAML pipeline for .NET, bootstrapping caching and multi-stage build/deploy structure, the core patterns for Azure-native deployment, and the best practices that take advantage of what Azure DevOps specifically does well. By the end you'll have a pipeline that's fast, secure, and deeply integrated with Azure if that's your deployment target.
+
+If you're deciding between CI/CD platforms first, [a comparison of the top CI/CD platforms for .NET](/posts/2028-02-29-top-5-cicd-platforms-dotnet-compared/) covers where Azure DevOps fits relative to GitHub Actions, GitLab CI, TeamCity, and Jenkins.
+
+## What You'll Need
+
+- An Azure DevOps organization and project
+- A repository - Azure Repos, or a connected GitHub repository (Azure Pipelines works with both)
+
+## Your First Pipeline
+
+```yaml
+# azure-pipelines.yml
+trigger:
+  branches:
+    include:
+      - main
+
+pool:
+  vmImage: 'ubuntu-latest'
+
+steps:
+  - task: UseDotNet@2
+    inputs:
+      version: '8.0.x'
+
+  - script: dotnet restore
+  - script: dotnet build --configuration Release --no-restore
+  - script: dotnet test --configuration Release --no-build
+```
+
+This is a working CI pipeline, structurally similar in spirit to a GitHub Actions workflow - a `trigger` instead of `on`, `steps` with `task`/`script` entries instead of `uses`/`run`, but the same underlying idea: restore, build, test on every push to `main`.
+
+## Bootstrapping the Ideal Environment
+
+### Cache NuGet packages
+
+```yaml
+steps:
+  - task: Cache@2
+    inputs:
+      key: 'nuget | "$(Agent.OS)" | **/packages.lock.json'
+      restoreKeys: |
+        nuget | "$(Agent.OS)"
+      path: $(NUGET_PACKAGES)
+    displayName: Cache NuGet packages
+
+  - script: dotnet restore
+```
+
+The `Cache@2` task is Azure Pipelines' equivalent of `actions/setup-dotnet`'s built-in caching - keying off your lock files means the cache correctly invalidates when dependencies actually change.
+
+### Multi-stage pipelines for build and deploy
+
+```yaml
+stages:
+  - stage: Build
+    jobs:
+      - job: BuildAndTest
+        pool:
+          vmImage: 'ubuntu-latest'
+        steps:
+          - task: UseDotNet@2
+            inputs:
+              version: '8.0.x'
+          - script: dotnet restore
+          - script: dotnet build --configuration Release --no-restore
+          - script: dotnet test --configuration Release --no-build
+          - script: dotnet publish -c Release -o $(Build.ArtifactStagingDirectory)
+          - publish: $(Build.ArtifactStagingDirectory)
+            artifact: drop
+
+  - stage: Deploy
+    dependsOn: Build
+    jobs:
+      - deployment: DeployToAzure
+        environment: production
+        pool:
+          vmImage: 'ubuntu-latest'
+        strategy:
+          runOnce:
+            deploy:
+              steps:
+                - download: current
+                  artifact: drop
+                - task: AzureWebApp@1
+                  inputs:
+                    azureSubscription: 'my-service-connection'
+                    appType: webApp
+                    appName: 'myapp-api'
+                    package: '$(Pipeline.Workspace)/drop/**/*.zip'
+```
+
+Stages give you the same CI/CD separation GitHub Actions achieves with separate jobs and `environment` gates - `dependsOn: Build` ensures deployment only runs after a successful build, and the `environment: production` reference enables the same kind of approval gating.
+
+### Set up an Azure service connection instead of static credentials
+
+In Azure DevOps: **Project Settings → Service connections → New service connection → Azure Resource Manager**, using workload identity federation rather than a service principal with a stored secret. This is Azure DevOps' equivalent of GitHub Actions' OIDC pattern - short-lived, federated authentication rather than a long-lived static credential.
+
+### Configure approval gates on environments
+
+**Pipelines → Environments → production → Approvals and checks**: add required approvers before a deployment to that environment can proceed - the same manual gate concept as GitHub Actions' environment protection rules, configured through Azure DevOps' UI instead of YAML.
+
+## Core Workflow
+
+- **Use multi-stage YAML pipelines to keep build and deploy logically separated**, the same discipline that applies to any CI/CD platform in this series.
+- **Use service connections with workload identity federation rather than stored service principal secrets**, for the same security reasons OIDC matters in GitHub Actions.
+- **Take advantage of native Azure deployment tasks** (`AzureWebApp@1`, `AzureContainerApps@1`, and similar) rather than shelling out to raw Azure CLI commands for common deployment targets - they handle a lot of the underlying complexity for you.
+
+## Verifying Your Setup
+
+1. **Caching reduces build time on subsequent runs** - compare cached vs. uncached run duration
+2. **Multi-stage pipelines correctly gate deployment on a successful build** - confirm `dependsOn` prevents deployment from running if the build stage fails
+3. **Service connections authenticate without a stored secret** - confirm workload identity federation is configured and deployment tasks authenticate successfully
+4. **Approval gates actually pause deployment** - confirm a deployment to a gated environment waits for approval rather than proceeding automatically
+
+## Best Practices
+
+**Use workload identity federation for Azure service connections instead of service principal secrets.** This is Azure DevOps' equivalent of GitHub Actions' OIDC recommendation - short-lived, federated credentials instead of long-lived static secrets.
+
+**Cache NuGet packages via the `Cache@2` task.** The same time-saving benefit as GitHub Actions' built-in caching, just requiring an explicit task rather than a flag on `setup-dotnet`.
+
+**Use native Azure deployment tasks for common targets (App Service, Container Apps, AKS).** They encapsulate meaningful complexity that you'd otherwise be reimplementing via raw Azure CLI scripting.
+
+**Configure environment approval gates for production deployments.** The same enforced human checkpoint concept as GitHub Actions' required reviewers, worth setting up before anything deploys to a sensitive target.
+
+**If your builds are Windows-heavy, confirm you're taking advantage of Azure DevOps' typically lower per-minute cost for Windows runners** compared to alternatives - this is a real, measurable cost difference worth factoring into platform decisions.
+
+## Comparison with GitHub Actions
+
+| | Azure DevOps | GitHub Actions |
+| --- | --- | --- |
+| YAML structure | `trigger`/`stages`/`jobs`/`steps` with `task`/`script` | `on`/`jobs`/`steps` with `uses`/`run` |
+| Azure deployment | Deepest, native tasks for most Azure services | Strong via OIDC + `azure/login`, less native |
+| Windows build cost | Often cheapest | Standard GitHub-hosted pricing |
+| Credential federation | Workload identity federation via service connections | OIDC |
+| Repo requirement | Azure Repos or GitHub | GitHub specifically |
+
+If you're weighing a move from GitHub Actions specifically because of Azure deployment depth or Windows build cost, both are genuine, measurable reasons - the trade-off is adopting Azure DevOps' distinct YAML vocabulary and, if you stay on GitHub for source control, running CI/CD on a different platform than your repo host.
+
+## Frequently Asked Questions
+
+### Can I use Azure DevOps if my code is on GitHub, not Azure Repos?
+
+Yes - Azure Pipelines connects to GitHub repositories directly, so you don't need to migrate source control to use Azure DevOps for CI/CD. The integration is solid, though slightly less seamless than using Azure Repos natively.
+
+### What's the Azure DevOps equivalent of GitHub Actions' OIDC?
+
+Workload identity federation, configured through a service connection in **Project Settings → Service connections**. It provides the same benefit - short-lived, federated authentication instead of a long-lived static service principal secret - just through Azure DevOps' own configuration flow rather than YAML-based OIDC claims.
+
+### How do multi-stage pipelines work compared to GitHub Actions' job dependencies?
+
+Azure DevOps' `stages` with `dependsOn` serve the same purpose as GitHub Actions' `needs` between jobs - ensuring one stage only runs after another completes successfully. The YAML structure differs, but the underlying dependency-gating concept is the same.
+
+### Is Azure DevOps actually cheaper than GitHub Actions?
+
+For Windows-heavy build workloads specifically, yes, typically - cost comparisons consistently show Azure DevOps as the cheaper option per build minute for Windows runners. For Linux-based builds, the cost difference is less pronounced, and the right comparison depends on your actual workload mix.
+
+### Do I need Azure DevOps if I'm not deploying to Azure?
+
+Not particularly - its strongest differentiation is specifically Azure-native deployment integration and Windows build cost. If you're not deploying to Azure and don't have Windows-heavy build needs, GitHub Actions (if your code is on GitHub) or another platform may be a more natural fit without a compelling reason to add Azure DevOps into the mix.
+
+### How do I set up an approval gate before a production deployment?
+
+Configure it under **Pipelines → Environments → [your environment] → Approvals and checks**, adding required approvers. A deployment job referencing that environment will pause and wait for approval before proceeding, the same enforced human checkpoint GitHub Actions provides via environment protection rules.
+
+### What's the most common mistake in a first Azure DevOps setup for .NET?
+
+Using a service principal with a stored secret for Azure service connections instead of workload identity federation, missing the same security benefit OIDC provides in GitHub Actions. The second common mistake is not using the `Cache@2` task for NuGet packages, leaving builds slower than necessary on every run.

--- a/src/posts/2028-03-21-getting-started-with-gitlab-ci-dotnet.md
+++ b/src/posts/2028-03-21-getting-started-with-gitlab-ci-dotnet.md
@@ -1,0 +1,174 @@
+---
+author: Steve Kaschimer
+date: 2028-03-21
+image: /images/posts/2028-03-21-hero.webp
+image_alt: "An all-in-one platform glyph combining a pipeline, a shield, and a repo icon in one continuous shape with no seams, implying source control, CI, and security scanning as a single product."
+image_prompt: "A dark-mode technical editorial illustration on a near-black background with electric teal, amber, and off-white accents. Composition centers on a single continuous shape that smoothly combines a pipeline outline, a small shield, and a repository icon, with no visible seams or connecting lines between the three, implying all three are genuinely one platform rather than separately joined tools. Mood is consolidated, complete, and unified. Avoid: vendor logos, brand colors, circuit-board textures, gears, or generic checkmark clip art as the dominant motif."
+layout: post.njk
+site_title: Tech Notes
+summary: "GitLab CI's single-file, single-platform philosophy means your .gitlab-ci.yml sits inside the same product that hosts the repo, runs security scans, and tracks issues. A setup guide for stages/rules, cache keys, and the built-in dependency and container scanning templates."
+tags: ["dotnet", "ci-cd", "devops", "security", "tooling"]
+title: "Getting Started with GitLab CI for .NET"
+---
+
+GitLab CI's single-file, single-platform philosophy means your `.gitlab-ci.yml` isn't just a build pipeline - it's sitting inside the same product that hosts your repo, runs your security scans, and tracks your issues. That consolidation is the whole pitch, and it changes the setup calculus a little: the interesting parts of a GitLab CI setup for .NET aren't just build/test/deploy, but wiring up the built-in dependency and container scanning that GitHub Actions or Azure DevOps would need a separate tool for.
+
+This guide covers setting up a GitLab CI pipeline for .NET, bootstrapping caching and multi-stage pipelines, the core patterns for build/test/deploy plus GitLab's built-in security scanning, and the best practices that take advantage of the consolidated platform rather than treating GitLab CI as a standalone build tool. By the end you'll have a pipeline that builds, tests, and scans your .NET application in one coherent configuration.
+
+If you're deciding between CI/CD platforms first, [a comparison of the top CI/CD platforms for .NET](/posts/2028-02-29-top-5-cicd-platforms-dotnet-compared/) covers where GitLab CI fits relative to GitHub Actions, Azure DevOps, TeamCity, and Jenkins.
+
+## What You'll Need
+
+- A GitLab repository (GitLab.com or self-managed)
+- No local installation required - pipelines run on GitLab's shared runners or your own configured runners
+
+## Your First Pipeline
+
+```yaml
+# .gitlab-ci.yml
+image: mcr.microsoft.com/dotnet/sdk:8.0
+
+stages:
+  - build
+  - test
+
+build:
+  stage: build
+  script:
+    - dotnet restore
+    - dotnet build --configuration Release --no-restore
+
+test:
+  stage: test
+  script:
+    - dotnet test --configuration Release
+```
+
+GitLab CI's structure centers on `stages` (the pipeline's phases) and jobs assigned to each stage - conceptually similar to GitHub Actions' jobs and Azure DevOps' stages, expressed through GitLab's own YAML vocabulary. The `image` directive specifies the container the job runs in, using the official .NET SDK image directly.
+
+## Bootstrapping the Ideal Environment
+
+### Cache NuGet packages
+
+```yaml
+variables:
+  NUGET_PACKAGES: '$CI_PROJECT_DIR/.nuget/packages'
+
+cache:
+  key:
+    files:
+      - '**/packages.lock.json'
+  paths:
+    - .nuget/packages
+
+build:
+  stage: build
+  script:
+    - dotnet restore
+    - dotnet build --configuration Release --no-restore
+```
+
+Keying the cache off your lock files means it correctly invalidates when dependencies change - the same principle as GitHub Actions' `cache-dependency-path` or Azure DevOps' `Cache@2` key, expressed through GitLab's cache configuration.
+
+### Multi-stage pipeline with deploy
+
+```yaml
+stages:
+  - build
+  - test
+  - deploy
+
+deploy_production:
+  stage: deploy
+  image: mcr.microsoft.com/dotnet/sdk:8.0
+  script:
+    - dotnet publish -c Release -o publish
+    - echo "Deploying to production"
+  environment:
+    name: production
+  rules:
+    - if: '$CI_COMMIT_BRANCH == "main"'
+```
+
+`rules` controls when a job runs - here, deployment only triggers on pushes to `main`, the same conditional-trigger concept as GitHub Actions' branch filters or Azure DevOps' trigger configuration. `environment` enables GitLab's environment tracking and, combined with protected environment settings, approval gating.
+
+### Enable built-in dependency and container scanning
+
+```yaml
+include:
+  - template: Security/Dependency-Scanning.gitlab-ci.yml
+  - template: Security/Container-Scanning.gitlab-ci.yml
+```
+
+This is the concrete payoff of GitLab's consolidated platform - including these templates adds dependency vulnerability scanning and container image scanning directly into your pipeline, without integrating a separate third-party tool the way you would on GitHub Actions or Azure DevOps.
+
+### Configure protected environments for deployment approval
+
+**Settings → CI/CD → Protected environments**: restrict who can deploy to a given environment and optionally require approval before a deployment job runs - GitLab's equivalent of GitHub Actions' required reviewers or Azure DevOps' environment approval checks.
+
+## Core Workflow
+
+- **Use `rules` to control exactly when jobs run**, keeping deploy jobs scoped to the right branch or tag rather than running on every pipeline trigger.
+- **Include GitLab's security scanning templates rather than integrating separate third-party scanners**, taking advantage of the platform consolidation that's GitLab CI's core differentiator.
+- **Use `cache` keyed to your dependency lock files** for the same NuGet restore time savings every platform in this comparison benefits from.
+
+## Verifying Your Setup
+
+1. **Caching reduces restore time on subsequent runs** - compare cached vs. uncached pipeline duration
+2. **Deploy jobs only trigger on the intended branch/tag** - confirm `rules` correctly scope deployment
+3. **Security scanning templates run and report findings** - confirm dependency and container scanning jobs appear in the pipeline and produce results in the Security dashboard
+4. **Protected environment approval gates work correctly** - confirm a deployment to a protected environment requires approval before proceeding
+
+## Best Practices
+
+**Take advantage of GitLab's built-in security scanning rather than reaching for a separate tool.** This is the platform's clearest differentiator versus GitHub Actions or Azure DevOps - underusing it means paying for consolidation without getting its actual benefit.
+
+**Use `rules` deliberately to scope jobs to the right triggers.** The same discipline that applies to any CI/CD platform - don't let deploy jobs run on every push by accident.
+
+**Cache dependencies keyed to lock files, not a static key.** A static cache key risks serving stale dependencies after a real dependency change; keying off the lock file content ensures correct invalidation.
+
+**Use protected environments and required approvals for production deployments.** The same enforced human checkpoint concept every platform in this comparison supports, configured through GitLab's environment protection settings.
+
+**If you're evaluating GitLab CI specifically, evaluate the broader platform consolidation, not just the CI/CD syntax.** Its real value proposition is repos, CI, and security scanning together - adopting it purely for CI/CD syntax preferences undersells (and under-delivers on) what it's actually built for.
+
+## Comparison with GitHub Actions
+
+| | GitLab CI | GitHub Actions |
+| --- | --- | --- |
+| Platform scope | Repos, CI/CD, security scanning, planning, all-in-one | CI/CD tightly coupled to GitHub repos |
+| Built-in security scanning | Yes, via included templates | Requires separate tools/actions |
+| YAML structure | `stages`/jobs with `rules` | `on`/`jobs` with `uses`/`run` |
+| Repo requirement | GitLab | GitHub |
+| Community/.NET examples | Smaller than GitHub Actions | Larger, broader marketplace |
+
+If you're specifically drawn to GitLab CI's built-in security scanning, that's a genuine, concrete reason to consider it over stitching a scanner into GitHub Actions - but it comes with the broader platform commitment of moving source control to GitLab, not just a CI/CD syntax change.
+
+## Frequently Asked Questions
+
+### Do I need to host my code on GitLab to use GitLab CI?
+
+For the tightest, most native experience, yes - GitLab CI is built around GitLab-hosted repositories, unlike Azure DevOps which comfortably supports GitHub-hosted repos as well. This is a meaningfully bigger platform decision than choosing a CI/CD tool alone.
+
+### What's GitLab CI's biggest advantage over GitHub Actions specifically?
+
+Built-in security scanning (dependency scanning, container scanning, SAST/DAST) included directly via template files, without integrating a separate third-party tool. This is a genuine, concrete differentiator, not just a stylistic difference in YAML syntax.
+
+### How do I control which branch a deployment job runs on?
+
+Use `rules` with a condition like `if: '$CI_COMMIT_BRANCH == "main"'`, GitLab CI's mechanism for conditionally including a job in a given pipeline run - functionally similar to GitHub Actions' branch filters on triggers.
+
+### How does caching work in GitLab CI compared to GitHub Actions?
+
+Both key a cache off file contents to ensure correct invalidation - GitLab CI's `cache: key: files:` pointing at your lock file, GitHub Actions' `cache-dependency-path` doing the equivalent. The underlying goal (avoid re-downloading unchanged dependencies) and mechanism (content-based cache keys) are the same across platforms.
+
+### Can I require approval before a production deployment in GitLab CI?
+
+Yes, via Protected Environments (**Settings → CI/CD → Protected environments**), which can restrict who can deploy and require approval before a deployment job proceeds - the same enforced human checkpoint concept as GitHub Actions' required reviewers or Azure DevOps' approval checks.
+
+### Is GitLab CI harder to learn if I already know GitHub Actions?
+
+The core concepts (stages/jobs, conditional triggers, caching, environments) map closely between the two, so the learning curve is moderate rather than steep - mostly a matter of adjusting to GitLab's specific YAML vocabulary (`rules` instead of trigger filters, `stages` instead of GitHub's implicit job ordering via `needs`).
+
+### What's the most common mistake in a first GitLab CI setup for .NET?
+
+Not taking advantage of the built-in security scanning templates, missing the platform's clearest differentiator and effectively using GitLab CI as if it were a standalone build tool. The second common mistake is using a static cache key instead of one tied to lock file contents, risking stale cached dependencies after a real change.

--- a/src/posts/2028-03-28-getting-started-with-jenkins-dotnet.md
+++ b/src/posts/2028-03-28-getting-started-with-jenkins-dotnet.md
@@ -1,0 +1,239 @@
+---
+author: Steve Kaschimer
+date: 2028-03-28
+image: /images/posts/2028-03-28-hero.webp
+image_alt: "A standalone server-rack glyph with a pipeline running independently beside it, not fused or connected to any repository outline, emphasizing infrastructure owned entirely separately."
+image_prompt: "A dark-mode technical editorial illustration on a near-black background with electric teal, amber, and off-white accents. Composition centers on a small server-rack glyph on the left, rendered as three stacked rectangles, with a thin pipeline outline running beside it but deliberately not touching or merging with any repository shape, emphasizing infrastructure owned and operated entirely independently. A small wrench-free maintenance-clock icon sits near the base, implying ongoing operational responsibility. Mood is self-hosted, capable, and deliberately unmanaged. Avoid: vendor logos, brand colors, circuit-board textures, gears, or generic checkmark clip art as the dominant motif."
+layout: post.njk
+site_title: Tech Notes
+summary: "Jenkins asks more of you before your first pipeline even runs than any other CI/CD platform - provisioning the server, installing plugins, configuring agents. A setup guide for Declarative Pipeline syntax, Docker agents, and the real ongoing infrastructure cost behind the free software."
+tags: ["dotnet", "ci-cd", "devops", "platform-engineering", "tooling"]
+title: "Getting Started with Jenkins for .NET"
+---
+
+Jenkins asks more of you before your first pipeline even runs than any other platform in this comparison - you're provisioning the server, installing plugins, and configuring agents yourself, work that GitHub Actions or GitLab CI hands you for free the moment you push a YAML file. That upfront cost is exactly the trade this guide is honest about: Jenkins' Groovy-based Jenkinsfiles are genuinely more expressive for complex build logic than any YAML alternative, but that expressiveness sits on top of infrastructure you now own and maintain.
+
+This guide covers installing Jenkins and configuring it for .NET builds, bootstrapping a Jenkinsfile with the plugins and agent setup that matter, the core declarative pipeline patterns, and the best practices for keeping a self-hosted Jenkins instance from becoming its own maintenance burden. By the end you'll have a working .NET pipeline and a clear-eyed understanding of the operational commitment behind it.
+
+If you're deciding between CI/CD platforms first, [a comparison of the top CI/CD platforms for .NET](/posts/2028-02-29-top-5-cicd-platforms-dotnet-compared/) covers where Jenkins fits relative to GitHub Actions, Azure DevOps, GitLab CI, and TeamCity.
+
+## What You'll Need
+
+- A server (VM, container, or physical machine) to host Jenkins - this is genuinely your infrastructure to provision and maintain
+- Java (Jenkins' runtime dependency)
+- Docker, if you plan to run builds in containers rather than directly on the Jenkins host or dedicated agents
+
+## Installing Jenkins
+
+```bash
+# Debian/Ubuntu example
+curl -fsSL https://pkg.jenkins.io/debian-stable/jenkins.io-2023.key | sudo tee \
+  /usr/share/keyrings/jenkins-keyring.asc > /dev/null
+echo "deb [signed-by=/usr/share/keyrings/jenkins-keyring.asc]" \
+  https://pkg.jenkins.io/debian-stable binary/ | sudo tee \
+  /etc/apt/sources.list.d/jenkins.list > /dev/null
+
+sudo apt-get update
+sudo apt-get install jenkins
+```
+
+Or, for a faster evaluation setup, run Jenkins in Docker:
+
+```bash
+docker run -d -p 8080:8080 -p 50000:50000 -v jenkins_home:/var/jenkins_home jenkins/jenkins:lts
+```
+
+Complete the setup wizard at `http://localhost:8080`, install suggested plugins, and create an admin user.
+
+## Installing .NET Support
+
+Install the **.NET SDK** on the Jenkins agent(s) that will run builds - either directly on the host, or by using a Docker-based agent with the .NET SDK image:
+
+```bash
+# Direct install on a Jenkins agent (Linux example)
+wget https://dot.net/v1/dotnet-install.sh
+chmod +x dotnet-install.sh
+./dotnet-install.sh --channel 8.0
+```
+
+## Your First Jenkinsfile
+
+```groovy
+// Jenkinsfile
+pipeline {
+    agent any
+
+    stages {
+        stage('Restore') {
+            steps {
+                sh 'dotnet restore'
+            }
+        }
+        stage('Build') {
+            steps {
+                sh 'dotnet build --configuration Release --no-restore'
+            }
+        }
+        stage('Test') {
+            steps {
+                sh 'dotnet test --configuration Release --no-build'
+            }
+        }
+    }
+}
+```
+
+This is Jenkins' Declarative Pipeline syntax - `pipeline`, `stages`, `steps` - committed as a `Jenkinsfile` in your repository, the same "pipeline as code" principle GitHub Actions' YAML or GitLab's `.gitlab-ci.yml` follow, just expressed in Groovy.
+
+## Bootstrapping the Ideal Environment
+
+### Use a Docker agent for consistent, isolated build environments
+
+```groovy
+pipeline {
+    agent {
+        docker { image 'mcr.microsoft.com/dotnet/sdk:8.0' }
+    }
+
+    stages {
+        stage('Build') {
+            steps {
+                sh 'dotnet restore'
+                sh 'dotnet build --configuration Release'
+            }
+        }
+    }
+}
+```
+
+Running builds in a Docker agent using the official .NET SDK image avoids the "works on my Jenkins host but not elsewhere" class of problem that comes from builds depending on whatever happens to be installed directly on a specific agent.
+
+### Cache NuGet packages across builds
+
+```groovy
+pipeline {
+    agent any
+    environment {
+        NUGET_PACKAGES = "${WORKSPACE}/.nuget/packages"
+    }
+    stages {
+        stage('Restore') {
+            steps {
+                sh 'dotnet restore'
+            }
+        }
+    }
+}
+```
+
+Jenkins doesn't have a first-class, declarative cache mechanism the way GitHub Actions or GitLab CI do - caching typically relies on persistent workspace directories or agent-level persistence, similar in spirit to TeamCity's approach, requiring more manual configuration to get right.
+
+### Multi-stage pipeline with a manual approval gate
+
+```groovy
+pipeline {
+    agent any
+    stages {
+        stage('Build and Test') {
+            steps {
+                sh 'dotnet restore'
+                sh 'dotnet build --configuration Release --no-restore'
+                sh 'dotnet test --configuration Release --no-build'
+            }
+        }
+        stage('Approval') {
+            steps {
+                input message: 'Deploy to production?'
+            }
+        }
+        stage('Deploy') {
+            steps {
+                sh 'echo Deploying to production'
+            }
+        }
+    }
+}
+```
+
+The `input` step pauses the pipeline and waits for a human to approve before continuing - Jenkins' built-in equivalent of GitHub Actions' required reviewers or Azure DevOps' environment approval gates.
+
+### Use credentials binding instead of hardcoded secrets
+
+```groovy
+stage('Deploy') {
+    steps {
+        withCredentials([string(credentialsId: 'azure-client-secret', variable: 'AZURE_SECRET')]) {
+            sh 'echo Deploying with credential'
+        }
+    }
+}
+```
+
+Jenkins' Credentials plugin stores secrets encrypted and injects them into the pipeline only for the steps that need them, rather than being hardcoded in the Jenkinsfile or exposed in logs.
+
+## Core Workflow
+
+- **Use Docker agents for build consistency**, avoiding dependence on whatever happens to be installed on a specific long-lived Jenkins agent.
+- **Commit the Jenkinsfile to your repository**, the same pipeline-as-code principle every platform in this comparison follows.
+- **Use `input` steps for manual approval gates**, and Jenkins' Credentials plugin for any secrets a pipeline needs, rather than hardcoding sensitive values.
+
+## Verifying Your Setup
+
+1. **Builds run consistently regardless of which agent picks them up** - confirm Docker-based agents produce identical results to direct-install agents, or standardize on one approach
+2. **Credentials are properly injected and not exposed in logs** - confirm `withCredentials` correctly masks sensitive values in build output
+3. **Approval gates actually pause the pipeline** - confirm an `input` step waits for manual action before proceeding to deployment
+4. **The Jenkins instance itself is being maintained** - confirm plugin updates, security patches, and agent health are part of an ongoing maintenance routine, not a one-time setup task
+
+## Best Practices
+
+**Budget real, ongoing time for Jenkins maintenance, not just initial setup.** Plugin updates, security patches, and agent management are continuous responsibilities - this is the actual cost behind Jenkins' "free" software, and it's worth planning for explicitly rather than discovering later.
+
+**Use Docker-based agents for build consistency.** This avoids configuration drift between agents and makes your build environment reproducible and portable, closer to the consistency GitHub Actions or GitLab CI provide by default through their managed runner images.
+
+**Use the Credentials plugin for all secrets, never hardcoded values in a Jenkinsfile.** This is table stakes for any CI/CD platform, and Jenkins' credential binding mechanism handles it correctly once configured.
+
+**Take full advantage of Groovy's expressiveness for genuinely complex pipeline logic**, since this is Jenkins' real differentiator over YAML-based alternatives - conditional logic, shared libraries, and dynamic pipeline generation are all more natural here than in a purely declarative YAML format.
+
+**Consider whether Jenkins' operational overhead is actually justified for your team's situation before committing.** It remains the right choice for organizations with strict infrastructure control requirements and existing operational capacity - be honest about whether that describes your team before choosing it purely for its flexibility.
+
+## Comparison with GitHub Actions
+
+| | Jenkins | GitHub Actions |
+| --- | --- | --- |
+| Hosting | Self-hosted, your infrastructure | Cloud (GitHub-hosted or self-hosted runners) |
+| Configuration language | Groovy (Jenkinsfile) | YAML |
+| Expressiveness for complex logic | Higher - Groovy is a full language | Lower - YAML with limited expressions/conditionals |
+| Setup and maintenance cost | Real, ongoing (server, plugins, agents) | Minimal - managed by GitHub |
+| Migration tooling | N/A | Official Importer CLI supports migrating from Jenkins (~70-90% accuracy) |
+
+If you're currently on Jenkins and evaluating whether to migrate, GitHub's Actions Importer is a real, practical starting point - but the reverse decision (choosing Jenkins fresh) should be driven by a genuine need for its flexibility and self-hosted control, not familiarity alone.
+
+## Frequently Asked Questions
+
+### Is Jenkins actually free?
+
+The software itself is free and open source, but infrastructure and maintenance are a real, ongoing cost - server hosting, plugin updates, security patching, and agent management all require time and money. Estimates put this at $800-2,500/month for a 20-person team once compute, storage, and engineer maintenance time are factored in.
+
+### How do I cache NuGet packages in Jenkins?
+
+Jenkins doesn't have a first-class declarative caching mechanism like GitHub Actions' `cache-dependency-path` or GitLab's `cache` block - the common approach is persisting a packages directory within the workspace or relying on agent-level file system persistence across builds, which requires more manual setup to get right.
+
+### Should I use Docker agents or install .NET directly on Jenkins agents?
+
+Docker agents are generally the better choice for build consistency - they avoid dependence on whatever happens to be installed on a specific long-lived agent, and they're portable in the same way container-based builds are portable across the other platforms in this comparison.
+
+### How do I add a manual approval step before deployment in Jenkins?
+
+Use the `input` step within a pipeline stage, which pauses execution and waits for a human to approve (or reject) before the pipeline continues - Jenkins' built-in mechanism for the same kind of approval gate GitHub Actions provides through required reviewers on environments.
+
+### Can I migrate from Jenkins to GitHub Actions if the maintenance burden becomes too much?
+
+Yes - GitHub's official Actions Importer CLI specifically supports migrating from Jenkins, with reported conversion accuracy in the 70-90% range for typical pipelines. It's a genuine, practical path if Jenkins' operational overhead has become disproportionate to the customization you're actually using.
+
+### Why would I choose Jenkins over a YAML-based CI tool for a new .NET project?
+
+Primarily for genuinely complex pipeline logic that Groovy expresses more naturally than YAML, or for organizational requirements around self-hosted infrastructure control that a managed platform can't satisfy. For most new, simpler projects, the operational overhead isn't justified relative to what a managed platform like GitHub Actions provides out of the box.
+
+### What's the most common mistake in a first Jenkins setup for .NET?
+
+Underestimating the ongoing maintenance commitment - treating Jenkins as a one-time setup rather than infrastructure requiring continuous plugin updates, security patches, and agent management. The second common mistake is running builds directly on inconsistent, long-lived agents instead of using Docker agents for reproducible, portable build environments.

--- a/src/posts/2028-04-04-getting-started-with-teamcity-dotnet.md
+++ b/src/posts/2028-04-04-getting-started-with-teamcity-dotnet.md
@@ -1,0 +1,199 @@
+---
+author: Steve Kaschimer
+date: 2028-04-04
+image: /images/posts/2028-04-04-hero.webp
+image_alt: "A build-chain glyph shown as several small connected nodes branching and rejoining, with two independent branches merging into a single dependent node representing parallel builds gating a downstream stage."
+image_prompt: "A dark-mode technical editorial illustration on a near-black background with electric teal, amber, and off-white accents. Composition centers on a small network of connected nodes: two independent branches on the left running in parallel, each a short chain of two nodes, converging into a single downstream node on the right that only lights up once both branches complete. Mood is orchestrated, precise, and enterprise-grade. Avoid: vendor logos, brand colors, circuit-board textures, gears, or generic checkmark clip art as the dominant motif."
+layout: post.njk
+site_title: Tech Notes
+summary: "TeamCity's build configuration UI is a genuinely good way to learn the concepts, but the moment there's more than one project, Kotlin DSL is the real setup decision. A setup guide for version-controlled pipeline configuration and genuine multi-project build chains."
+tags: ["dotnet", "ci-cd", "devops", "tooling"]
+title: "Getting Started with TeamCity for .NET"
+---
+
+TeamCity's build configuration UI is where most people start, and it's a genuinely good way to learn the concepts - but the moment you have more than one project, the thing that actually matters is Kotlin DSL: version-controlled, code-based pipeline definitions instead of UI-configured settings that live only in TeamCity's own database. That's the real setup decision this guide centers on, since it's what determines whether your TeamCity configuration is reviewable, diffable, and portable, or a black box only reproducible by clicking through the same UI steps again.
+
+This guide covers setting up a TeamCity build configuration for .NET using both the UI and Kotlin DSL, bootstrapping build chains for multi-project solutions, the core patterns for dependency management between builds, and the best practices that take advantage of what TeamCity specifically does well - sophisticated build orchestration - without treating it like a simpler YAML-based CI tool. By the end you'll have version-controlled pipeline configuration and a real build chain, not just a single linear job.
+
+If you're deciding between CI/CD platforms first, [a comparison of the top CI/CD platforms for .NET](/posts/2028-02-29-top-5-cicd-platforms-dotnet-compared/) covers where TeamCity fits relative to GitHub Actions, Azure DevOps, GitLab CI, and Jenkins.
+
+## What You'll Need
+
+- A TeamCity server (cloud or self-hosted) and at least one build agent
+- A repository TeamCity can access (GitHub, GitLab, Azure Repos, or any Git-compatible host - TeamCity is repo-agnostic)
+
+## Your First Build Configuration (via UI)
+
+In the TeamCity UI: **Create Project → connect your repository → Create build configuration**, then add build steps:
+
+1. **.NET Restore**: `dotnet restore`
+2. **.NET Build**: `dotnet build --configuration Release --no-restore`
+3. **.NET Test**: `dotnet test --configuration Release --no-build`
+
+TeamCity auto-detects common project structures and can suggest build steps automatically when connecting a .NET repository, though reviewing and adjusting the detected steps is worth doing rather than accepting them blindly.
+
+## Bootstrapping the Ideal Environment
+
+### Switch to Kotlin DSL for version-controlled configuration
+
+```kotlin
+// .teamcity/settings.kts
+import jetbrains.buildServer.configs.kotlin.*
+import jetbrains.buildServer.configs.kotlin.buildSteps.script
+
+version = "2024.03"
+
+project {
+    buildType(BuildAndTest)
+}
+
+object BuildAndTest : BuildType({
+    name = "Build and Test"
+
+    steps {
+        script {
+            name = "Restore"
+            scriptContent = "dotnet restore"
+        }
+        script {
+            name = "Build"
+            scriptContent = "dotnet build --configuration Release --no-restore"
+        }
+        script {
+            name = "Test"
+            scriptContent = "dotnet test --configuration Release --no-build"
+        }
+    }
+
+    triggers {
+        vcs {}
+    }
+})
+```
+
+This is the equivalent of GitHub Actions' `.github/workflows/*.yml` or GitLab's `.gitlab-ci.yml` - your build configuration as code, committed alongside your application, reviewable in pull requests, and reproducible without manually reconstructing UI settings. TeamCity can generate this DSL from an existing UI-configured build as a starting point, which is a practical way to migrate from UI-first to DSL-first configuration.
+
+### Cache NuGet packages
+
+```kotlin
+steps {
+    script {
+        name = "Restore"
+        scriptContent = "dotnet restore --packages %teamcity.build.checkoutDir%/.nuget"
+    }
+}
+
+requirements {
+    // Ensure builds land on agents with a warm NuGet cache when possible
+}
+```
+
+TeamCity's caching approach differs from GitHub Actions' or GitLab's explicit cache actions - it more commonly relies on agent-level persistence (the same build agent retaining its NuGet cache directory across runs) combined with directing `dotnet restore` at a consistent local packages directory.
+
+### Build a build chain for multi-project solutions
+
+```kotlin
+project {
+    buildType(BuildCore)
+    buildType(BuildApi)
+    buildType(RunIntegrationTests)
+
+    buildType(RunIntegrationTests) {
+        dependencies {
+            snapshot(BuildCore) {}
+            snapshot(BuildApi) {}
+        }
+    }
+}
+```
+
+This is TeamCity's signature strength - a genuine build chain where `RunIntegrationTests` depends on both `BuildCore` and `BuildApi` completing successfully, letting TeamCity parallelize independent builds and only proceed to dependent stages once prerequisites are satisfied. This kind of dependency graph is more explicit and sophisticated here than the linear or simply-nested job dependencies in GitHub Actions or GitLab CI.
+
+### Configure deployment with approval
+
+```kotlin
+object DeployProduction : BuildType({
+    name = "Deploy to Production"
+
+    steps {
+        script {
+            scriptContent = "echo Deploying to production"
+        }
+    }
+
+    dependencies {
+        snapshot(BuildAndTest) {}
+    }
+
+    // Manual trigger only, rather than automatic VCS trigger
+})
+```
+
+Omitting a `triggers { vcs {} }` block means this build configuration only runs when manually triggered - TeamCity's equivalent of an approval gate, since a human has to explicitly initiate the deployment run rather than it firing automatically.
+
+## Core Workflow
+
+- **Use Kotlin DSL for anything beyond a single, simple project.** The version-control and review benefits compound as your configuration grows - UI-only configuration becomes a real liability at scale.
+- **Model genuine build dependencies as a build chain**, taking advantage of TeamCity's parallelization and dependency-ordering strength rather than flattening everything into one linear sequence.
+- **Use manual triggers (omitting automatic VCS triggers) for deployment configurations** that need a human decision point before running.
+
+## Verifying Your Setup
+
+1. **Kotlin DSL configuration matches what's actually running** - confirm changes to `.teamcity/settings.kts` correctly update the build configuration when TeamCity syncs
+2. **Build chains execute in the correct order and parallelize where possible** - confirm dependent builds wait for their prerequisites, and independent builds run concurrently
+3. **NuGet restore is taking advantage of agent-level caching** - compare build times across consecutive runs on the same agent
+4. **Manual-trigger deployment configurations don't run automatically** - confirm a deployment configuration without a VCS trigger only executes when explicitly started
+
+## Best Practices
+
+**Move to Kotlin DSL early, even for a single project.** The migration cost only grows the longer configuration lives purely in the UI - TeamCity can generate DSL from existing UI configuration, making this a reasonable first step rather than a from-scratch effort.
+
+**Model real build dependencies as an explicit build chain**, not a single flattened sequence of steps. This is TeamCity's core differentiator - underusing it means paying for capability you're not benefiting from.
+
+**Use manual triggers deliberately for anything requiring a human decision point**, the same principle as required reviewers in GitHub Actions or approval gates in Azure DevOps, expressed through TeamCity's trigger configuration instead.
+
+**Take advantage of agent requirements and pools if you have varied build needs** (Windows vs. Linux, different hardware profiles) - this is part of what self-hosted control buys you that a purely cloud-hosted platform doesn't offer as flexibly.
+
+**Review generated Kotlin DSL from UI-configured builds before committing it**, since auto-generated DSL can be more verbose than a hand-written equivalent - clean it up for long-term maintainability rather than committing the raw generated output unexamined.
+
+## Comparison with GitHub Actions
+
+| | TeamCity | GitHub Actions |
+| --- | --- | --- |
+| Configuration | Kotlin DSL (code) or UI | YAML |
+| Build orchestration | Sophisticated build chains, explicit dependency graphs | Job dependencies via `needs`, less elaborate |
+| Hosting | Self-hosted or cloud | Cloud (GitHub-hosted or self-hosted runners) |
+| Repo coupling | Repo-agnostic | Tightest with GitHub |
+| Cost model | License-based | Free tier + usage-based |
+
+TeamCity's build chain sophistication is worth the switch specifically for complex, multi-project .NET solutions with real dependency ordering needs - for a simple, single-project pipeline, GitHub Actions' YAML is typically less overhead to set up and maintain.
+
+## Frequently Asked Questions
+
+### Should I configure TeamCity through the UI or Kotlin DSL?
+
+Kotlin DSL, for anything beyond a quick single-project evaluation. UI configuration lives only in TeamCity's own database, isn't reviewable in a pull request, and isn't reproducible without manually clicking through the same steps again - DSL gives you version-controlled, code-based configuration comparable to what GitHub Actions or GitLab CI provide by default through YAML.
+
+### What's a build chain, and why does TeamCity emphasize it more than other platforms?
+
+A build chain is an explicit dependency graph between separate build configurations - one build (or several, run in parallel) completing successfully before a dependent build starts. TeamCity's snapshot dependencies make this a first-class, sophisticated feature, well suited to complex multi-project .NET solutions where the build ordering genuinely matters, more so than the simpler linear or lightly-nested job dependencies most YAML-based CI tools offer.
+
+### How does TeamCity handle NuGet package caching?
+
+Typically through agent-level persistence - the same build agent retaining its local NuGet packages directory across consecutive runs, combined with directing `dotnet restore` at a consistent local path. This differs from GitHub Actions' or GitLab's explicit, per-run cache actions, relying instead on the self-hosted (or persistent cloud) agent's own file system state.
+
+### Can I migrate an existing UI-configured TeamCity project to Kotlin DSL?
+
+Yes - TeamCity can generate Kotlin DSL from an existing UI-configured build configuration, giving you a starting point to review, clean up, and commit to version control rather than writing the DSL entirely from scratch.
+
+### Is TeamCity worth it if I only have one simple .NET project?
+
+Probably not the first choice - its strengths (build chains, sophisticated dependency management, self-hosted control) matter most for complex, multi-project solutions. A single simple project is usually served just as well, with less setup overhead, by GitHub Actions or another YAML-based CI tool.
+
+### How do I add an approval gate before a TeamCity deployment?
+
+Omit an automatic VCS trigger from the deployment build configuration, so it only runs when manually started - this is TeamCity's approach to requiring a human decision point, functionally similar to GitHub Actions' required reviewers or Azure DevOps' approval checks, though implemented differently.
+
+### What's the most common mistake in a first TeamCity setup for .NET?
+
+Configuring everything through the UI without migrating to Kotlin DSL, leaving build configuration unreviewable and hard to reproduce as the project grows. The second common mistake is not modeling genuine build dependencies as an actual build chain, missing TeamCity's core differentiating strength and using it as if it were a simpler, linear CI tool.


### PR DESCRIPTION
## Summary

- Schedules and drafts the CI/CD Platforms for .NET Tuesday track: a comparison anchor post plus five getting-started guides, running weekly Tuesdays 2028-02-29 through 2028-04-04, picking up the cadence directly after the .NET Architecture Quality Tools track
- Moves the series from `editorial-plan.md`'s Backlog into a dated `## 📅 Tuesday Track - CI/CD Platforms for .NET (February-April 2028)` section, all entries `Status: draft` with `File:` paths, and updates the Backlog intro count from four to three remaining series

### Posts added

- **Anchor:** The Top 5 CI/CD Platforms for .NET Compared: Which One Should You Choose? (2028-02-29) - GitHub Actions, Azure DevOps, GitLab CI, TeamCity, and Jenkins compared on hosting model, repo coupling, governance, and cost, resolving on repo host and control appetite rather than a feature matrix
- Getting Started with GitHub Actions for .NET (2028-03-07)
- Getting Started with Azure DevOps for .NET (2028-03-14)
- Getting Started with GitLab CI for .NET (2028-03-21)
- Getting Started with Jenkins for .NET (2028-03-28)
- Getting Started with TeamCity for .NET (2028-04-04)

Each setup guide cross-links back to the anchor post, mirroring the structure of the prior .NET ORMs/API Styles/Validation Approaches/Mapping Libraries/Caching Solutions/Message Brokers/Background Job Libraries/Mocking Libraries/Architecture Quality Tools/Testing/Logging/Architecture tracks.

## Test plan

- [x] `npm run deploy` builds cleanly, all 6 posts render (including the leap-day-scheduled 2028-02-29 anchor post)
- [x] `node scripts/a11y-check.js` (axe-core + Playwright) - zero violations across home/post/about/privacy/terms/404 in light and dark mode
- [x] Verified all 5 setup-guide cross-links resolve to the anchor post's output URL


---
_Generated by [Claude Code](https://claude.ai/code/session_01WKyNF7L5qzrfct8cec6A32)_