### PR TITLE
Add .NET Deployment Options Tuesday track (April-May 2028)

### DIFF
--- a/editorial-plan.md
+++ b/editorial-plan.md
@@ -1358,17 +1358,69 @@ Six posts on where a .NET team actually runs its builds and deployments, picking
 
 ---
 
-## 📅 Backlog - Unscheduled Series
+## 📅 Tuesday Track - .NET Deployment Options (April-May 2028)
 
-Three six-post series remain unscheduled, drawn from the drafts in `docs/article-ideas/`. They continue the Tuesday cadence once the CI/CD Platforms for .NET series ends on 2028-04-04, and they're listed here in priority order. They're deliberately undated - that horizon is too far out to put honest dates against - so each series gets one entry rather than six speculative ones, and entries are expanded into individual dated posts when a series moves onto the calendar.
+Six posts on how a .NET application actually reaches production, picking up the Tuesday cadence directly from the CI/CD Platforms track. A comparison post anchors the track and each of the five follow-ups is a complete setup for one deployment path.
 
-### .NET Deployment Options (6 posts)
-- **Status:** `idea`
-- **Source:** `docs/article-ideas/top-5-dotnet-deployment-options-compared.md` + 5 getting-started drafts
-- **Series:** Top 5 comparison, then Azure Container Apps, AWS ECS/Fargate, Docker + Kubernetes, IIS, .NET Aspire deploy workflow
+### The Top 5 Ways to Deploy .NET Apps Compared: Which One Should You Choose?
+- **Status:** `draft`
+- **Scheduled:** 2028-04-11
+- **Source:** `docs/article-ideas/top-5-dotnet-deployment-options-compared.md`
+- **File:** `src/posts/2028-04-11-top-5-dotnet-deployment-options-compared.md`
 - **Pitch:** Four of these five paths are container-based, so "do we use containers" isn't the real question. The differentiator is how much orchestration and operational burden you keep versus hand to a managed platform - a team running Kubernetes for a service taking 500 requests a day is spending engineering time on something that isn't the problem.
 - **Angle:** Compares the five on operational overhead, portability, and cloud coupling, carrying forward the Microservices post's argument that infrastructure should be sized to the control you actually need rather than to what sounds most modern. That's why IIS stays in the comparison as a valid answer for Windows and on-premises environments instead of a legacy footnote. Treats .NET Aspire as a target-agnostic tooling layer that generates manifests for whichever of the others you pick, not as a competing runtime.
 - **Tags:** `dotnet`, `deployment`, `containers`, `platform-engineering`, `devops`
+
+### Getting Started with Azure Container Apps for .NET Deployment
+- **Status:** `draft`
+- **Scheduled:** 2028-04-18
+- **Source:** `docs/article-ideas/getting-started-with-azure-container-apps.md`
+- **File:** `src/posts/2028-04-18-getting-started-with-azure-container-apps.md`
+- **Pitch:** Azure Container Apps' whole pitch is containerized, cloud-native deployment without ever touching a Kubernetes manifest or provisioning a cluster - and for a genuinely large share of .NET applications, that trade is exactly right.
+- **Angle:** Covers `--min-replicas 0` scale-to-zero, secret references over plain environment variables, HTTP-concurrency and KEDA-backed autoscaling rules, and `azd` as the integrated workflow once a deployment involves more than one service. Direct about ACA's real edges upfront - no DaemonSets, no privileged containers, no GPU node selection - so the choice is deliberate, not a mid-project discovery, and names the well-defined migration path to AKS if those limits are hit later.
+- **Tags:** `dotnet`, `deployment`, `cloud`, `containers`, `devops`
+
+### Getting Started with AWS ECS/Fargate for .NET Deployment
+- **Status:** `draft`
+- **Scheduled:** 2028-04-25
+- **Source:** `docs/article-ideas/getting-started-with-aws-ecs-fargate.md`
+- **File:** `src/posts/2028-04-25-getting-started-with-aws-ecs-fargate.md`
+- **Pitch:** ECS paired with Fargate solves the same problem Azure Container Apps solves - run containers without managing a cluster - but asks one decision Azure's platform doesn't: EC2-backed ECS or Fargate.
+- **Angle:** Covers task definitions with Secrets Manager references, pairing an ECS service with an Application Load Balancer target group for health-checked routing, registering a new task definition revision per deployment rather than editing in place, and starting with Fargate by default unless there's a specific reason to manage EC2 compute directly. Honest that ECS's scale-to-zero story needs more manual work than ACA's native support, and that .NET-specific tooling is comparatively thinner than Azure's.
+- **Tags:** `dotnet`, `deployment`, `cloud`, `containers`, `devops`
+
+### Getting Started with Docker + Kubernetes for .NET Deployment
+- **Status:** `draft`
+- **Scheduled:** 2028-05-02
+- **Source:** `docs/article-ideas/getting-started-with-docker-kubernetes-dotnet.md`
+- **File:** `src/posts/2028-05-02-getting-started-with-docker-kubernetes-dotnet.md`
+- **Pitch:** Containerizing a .NET application is the easy part. Running that image well in Kubernetes is where the real work lives, and it's also where .NET-specific details - Kestrel binding, graceful shutdown - matter more than generic Kubernetes advice accounts for.
+- **Angle:** Covers a two-stage Dockerfile, Kestrel bound directly to a non-privileged port with TLS terminating at the ingress (genuinely simpler than IIS out-of-process hosting), liveness/readiness health checks, and `IHostApplicationLifetime`-based graceful shutdown as the single most commonly mishandled piece of a first .NET-on-Kubernetes deployment. Names resource requests/limits as non-optional, not tuning, and covers the clean migration path to and from Azure Container Apps since only the orchestration layer changes.
+- **Tags:** `dotnet`, `deployment`, `containers`, `devops`, `architecture`
+
+### Getting Started with IIS for .NET Deployment
+- **Status:** `draft`
+- **Scheduled:** 2028-05-09
+- **Source:** `docs/article-ideas/getting-started-with-iis-dotnet.md`
+- **File:** `src/posts/2028-05-09-getting-started-with-iis-dotnet.md`
+- **Pitch:** IIS deployments have one failure mode that shows up more than any other in this series: a completely correct application returning a 500 error the moment it hits the server, because the .NET Core Hosting Bundle wasn't installed on the Windows Server itself.
+- **Angle:** Covers the Hosting Bundle as a separate install from any SDK, the out-of-process hosting model (IIS as reverse proxy in front of Kestrel) that `dotnet publish` configures automatically via `web.config`, setting `managedRuntimeVersion` to empty for "No Managed Code," and temporarily enabling `stdoutLogEnabled` for first-deployment troubleshooting. Frames IIS as a legitimate answer for existing Windows Server infrastructure and Active Directory integration, not a legacy fallback.
+- **Tags:** `dotnet`, `deployment`, `platform-engineering`, `devops`
+
+### Getting Started with .NET Aspire's Deploy Workflow
+- **Status:** `draft`
+- **Scheduled:** 2028-05-16
+- **Source:** `docs/article-ideas/getting-started-with-aspire-deploy-workflow.md`
+- **File:** `src/posts/2028-05-16-getting-started-with-aspire-deploy-workflow.md`
+- **Pitch:** Aspire's local development story is well known. Less widely known is that Aspire 9.2+ ships a genuine deployment workflow - `aspire publish` and `aspire deploy` - that generates real deployment artifacts from the exact same AppHost model used for local development.
+- **Angle:** Covers `aspire publish` for reviewing generated artifacts before ever applying them, `azd up` as the full Azure provision-and-deploy path with the deepest first-class Aspire integration, targeting Kubernetes instead via the extensible publisher model, and making deployment customizations from the AppHost itself (`PublishAsAzureContainerApp`) rather than hand-editing generated Bicep that drifts on the next publish. Direct throughout that this is a consistency layer over an actual target, not a target itself - the operational realities from the ACA, ECS, and Kubernetes posts in this same track still apply underneath it.
+- **Tags:** `dotnet`, `deployment`, `cloud`, `tooling`, `architecture`
+
+---
+
+## 📅 Backlog - Unscheduled Series
+
+Two six-post series remain unscheduled, drawn from the drafts in `docs/article-ideas/`. They continue the Tuesday cadence once the .NET Deployment Options series ends on 2028-05-16, and they're listed here in priority order. They're deliberately undated - that horizon is too far out to put honest dates against - so each series gets one entry rather than six speculative ones, and entries are expanded into individual dated posts when a series moves onto the calendar.
 
 ### Auth & Identity for .NET (6 posts)
 - **Status:** `idea`

--- a/src/posts/2028-04-11-top-5-dotnet-deployment-options-compared.md
+++ b/src/posts/2028-04-11-top-5-dotnet-deployment-options-compared.md
@@ -1,0 +1,168 @@
+---
+author: Steve Kaschimer
+date: 2028-04-11
+image: /images/posts/2028-04-11-hero.webp
+image_alt: "Five columns of abstract deployment glyphs positioned along a horizontal axis running from self-managed infrastructure on the left to fully hands-off managed platforms on the right."
+image_prompt: "A dark-mode technical editorial illustration on a near-black background with electric teal, amber, and off-white accents. Composition is five vertical columns of equal width separated by thin hairline rules, each column topped by a distinct abstract glyph rendered in flat geometry: a dense interconnected node cluster with a small steering-wheel accent implying full manual control, a lighter single container glyph fading gently at the edges implying scale-to-zero, a similar container glyph with a small toggle beside it implying a compute-model choice, a target-agnostic funnel glyph feeding into three small differently-shaped output icons, and a traditional server-tower glyph standing apart from the others with no cloud element attached. Beneath the glyphs, a shared horizontal axis labeled in monospaced type runs from 'self-managed' on the left to 'fully managed' on the right, with a small glowing teal dot positioned at a different point under each column. Mood is comparative, engineering-first, and non-partisan. Avoid: vendor logos, brand colors, circuit-board textures, gears, or generic cloud clip art used as the dominant motif."
+layout: post.njk
+site_title: Tech Notes
+summary: "Four of these five paths are container-based, so 'do we use containers' isn't the real question. The differentiator is how much orchestration and operational burden you keep versus hand to a managed platform. A practical breakdown of five ways .NET applications actually reach production."
+tags: ["dotnet", "deployment", "containers", "platform-engineering", "devops"]
+title: "The Top 5 Ways to Deploy .NET Apps Compared: Which One Should You Choose?"
+---
+
+Deployment decisions in .NET used to mean picking a Windows Server and installing IIS. That's still a real, valid option - but it's now one of at least five genuinely different paths, and the honest starting point for this comparison is the same one that came up in the Microservices architecture article: the right amount of deployment infrastructure depends entirely on how much operational control you actually need, not on which option sounds most modern. A team running Kubernetes for a service that gets 500 requests a day is spending real engineering time on infrastructure that isn't the actual problem.
+
+This guide compares five ways .NET applications get deployed to production in 2026: Docker + Kubernetes (self-managed orchestration), Azure Container Apps, AWS ECS/Fargate, .NET Aspire's cloud-native deploy workflow, and traditional IIS. The first four are all container-based at their core - the real differentiator between them is how much of the orchestration and operational burden you're taking on yourself versus handing to a managed platform, not whether containers are involved at all. This series continues with dedicated getting-started walkthroughs for each deployment path.
+
+## Quick Comparison
+
+| | Docker + Kubernetes | Azure Container Apps | AWS ECS/Fargate | .NET Aspire (deploy workflow) | IIS |
+| --- | --- | --- | --- | --- | --- |
+| **Category** | Self-managed container orchestration | Serverless containers, managed | Managed container orchestration (AWS) | Dev-to-cloud tooling layer, target-agnostic | Traditional Windows web server |
+| **Operational overhead** | High - you manage the cluster | Low - no cluster to manage | Low-moderate, depending on Fargate vs. EC2 | Low, since it generates manifests for your chosen target | Low, but Windows Server maintenance is its own burden |
+| **Portability** | Highest - runs anywhere Kubernetes runs | Lower - Azure-specific | Lower - AWS-specific | High - can target ACA, AKS, Kubernetes manifests, or Docker Compose | None - Windows-specific |
+| **Best for** | Multi-tenant platforms, complex stateful workloads, teams needing full control | Azure-first teams wanting cloud-native without cluster management | AWS-first teams wanting managed container orchestration | Teams wanting a consistent dev-to-cloud experience regardless of final target | Legacy Windows Server environments, on-premises hosting |
+
+## Docker + Kubernetes
+
+Running .NET applications as containers orchestrated by Kubernetes - whether self-hosted, or via a managed offering like Azure Kubernetes Service (AKS) or AWS EKS - remains the most powerful and most portable option in this comparison, and also the one with the steepest real operational cost.
+
+**Strengths:**
+
+- The highest portability of any option here - Kubernetes manifests, Helm charts, and container images are genuinely vendor-neutral, running identically on AKS, EKS, GKE, or on-premises
+- Full control over networking, scaling policies, node configuration, and advanced patterns (DaemonSets, sidecar proxies, custom ingress controllers) that managed serverless container platforms don't expose
+- The right choice for genuinely complex requirements - multi-tenant platforms, GPU workloads, stateful services needing fine-grained storage control
+- A massive, mature ecosystem of tooling (Prometheus, Grafana, service meshes, operators) that works across any Kubernetes distribution without vendor lock-in
+
+**Weaknesses:**
+
+- Real, ongoing operational overhead - cluster maintenance, upgrades, and troubleshooting are genuine engineering time, not a one-time setup cost
+- Significant overkill for smaller workloads - a team spending a meaningful share of its time on cluster maintenance for a low-traffic service is spending that time on infrastructure, not the actual business problem
+- Getting graceful shutdown, health checks, and resource limits configured correctly for .NET workloads specifically is a common source of production issues if not done deliberately
+- The steepest learning curve of any option in this comparison, even before considering .NET-specific configuration
+
+**Choose this when:** your requirements genuinely need Kubernetes' control surface - multi-tenant complexity, stateful workloads, specific node/hardware requirements - and you have (or are willing to build) the operational capacity to run it well.
+
+## Azure Container Apps
+
+Azure Container Apps (ACA) is Microsoft's serverless container platform - you deploy a container image, and Azure handles scaling, networking, and the underlying infrastructure without you managing a cluster at all. It's specifically positioned as the answer for teams who want cloud-native deployment without Kubernetes' operational weight.
+
+**Strengths:**
+
+- Genuinely serverless - no cluster to provision, patch, or maintain, which eliminates the largest operational cost of the Kubernetes path entirely
+- Deep integration with .NET Aspire's deployment tooling, making it the most natural target for Aspire-based multi-service applications specifically within the Azure ecosystem
+- Scales automatically based on demand, including scaling to zero for genuinely idle services - a real cost advantage for workloads with variable or low traffic
+- A well-defined migration path to AKS if you eventually do need Kubernetes' full control surface - the container images themselves don't change, only how they're orchestrated
+
+**Weaknesses:**
+
+- Real limitations compared to full Kubernetes: no DaemonSets, no privileged containers, no GPU node pool selection, and less granular networking control (no custom ingress controllers or advanced network policies)
+- Primarily designed for stateless workloads - persistent storage options are less flexible than AKS, even with Dapr's state management support layered in
+- Azure-specific, meaning genuine platform lock-in - migrating away means adopting a different deployment model entirely, not a configuration change
+
+**Choose this when:** you're Azure-first, want cloud-native deployment without cluster management overhead, and your workload doesn't need Kubernetes' most advanced capabilities - which describes a large share of real .NET applications.
+
+## AWS ECS/Fargate
+
+Amazon ECS (Elastic Container Service), typically paired with Fargate for serverless compute, is AWS's answer to managed container orchestration - conceptually similar to Azure Container Apps' value proposition, but within the AWS ecosystem and with its own distinct operational model.
+
+**Strengths:**
+
+- Removes cluster management the same way ACA does when paired with Fargate, letting AWS handle the underlying compute without you provisioning or patching servers
+- Deep integration with the rest of AWS's ecosystem - IAM, VPC networking, CloudWatch, and Application Load Balancer all integrate natively
+- A reasonable middle ground between EC2-based ECS (more control, more management) and Fargate (fully serverless), letting teams choose their own point on that trade-off
+- Well-documented and mature, with a long production track record across a huge range of workload types
+
+**Weaknesses:**
+
+- AWS-specific, the same category of lock-in Azure Container Apps carries for Azure - a genuine platform commitment, not a portable choice
+- .NET-specific tooling and documentation is comparatively thinner than the Azure-native options, reflecting AWS's broader, less .NET-centric ecosystem focus
+- Choosing between ECS-on-EC2 and ECS-on-Fargate adds a real decision point that Azure Container Apps' simpler model doesn't require
+
+**Choose this when:** you're AWS-first and want managed container orchestration without Kubernetes' operational weight - the natural choice for teams already invested in AWS's broader ecosystem.
+
+## .NET Aspire (Deploy Workflow)
+
+.NET Aspire's local development story - covered in this series' Microservices architecture guide - is well known. Less widely understood is that Aspire 9.2+ also includes a genuine deployment workflow (`aspire publish` and `aspire deploy`) that generates deployment artifacts for multiple targets from the same application model, making it less a deployment target itself and more a consistent layer on top of wherever you're actually deploying.
+
+**Strengths:**
+
+- Generates Docker Compose files, Kubernetes manifests, Bicep templates, or custom publisher output from the same underlying Aspire application model - one source of truth, multiple possible deployment targets
+- For Azure specifically, `azd` (Azure Developer CLI) has first-class Aspire support, handling the entire workflow from provisioning through deployment in one coherent path
+- Meaningfully reduces the friction between local development and cloud deployment that used to be a genuine pain point for multi-service .NET applications
+- The extensible publisher model means teams aren't locked into Aspire's default output format if they need something more customized
+
+**Weaknesses:**
+
+- This isn't a deployment target in the same sense as the other four options - it's a workflow layer, meaning you still need to understand and choose an actual target (ACA, AKS, a Kubernetes cluster) underneath it
+- Most mature and well-documented specifically for Azure via `azd` - other targets are supported but with less first-class tooling investment behind them
+- Adds a real conceptual layer for teams not already using Aspire for local development, which may not be worth adopting purely for its deployment tooling alone
+
+**Choose this when:** you're already using .NET Aspire for local multi-service development and want that same consistent model to carry through to deployment, particularly if Azure Container Apps or AKS is your actual target.
+
+## IIS
+
+Internet Information Services remains a completely legitimate deployment option for .NET applications running on Windows Server - either as the reverse proxy in front of Kestrel (out-of-process hosting) or, less commonly today, hosting the application directly in-process.
+
+**Strengths:**
+
+- The natural fit for organizations already running Windows Server infrastructure, with mature, well-understood operational tooling built up over decades
+- No containerization or orchestration learning curve required - for teams without that expertise already, IIS can be the lower-friction starting point
+- Deep integration with Windows-specific authentication (Windows Authentication, Active Directory) that's more natural here than in a containerized, cloud-native deployment
+- Still fully supported and actively used in real production enterprise environments, not a legacy-only option
+
+**Weaknesses:**
+
+- No cloud-native portability at all - an IIS deployment is tied to Windows Server, full stop, with none of the "runs anywhere" flexibility containers provide
+- Scaling is manual and comparatively slow - adding capacity means provisioning another Windows Server and configuring a load balancer, nothing like the automatic, on-demand scaling containerized options offer
+- A common, easy-to-miss deployment issue: the .NET Core Hosting Bundle needs to be installed on the Windows Server separately from the application itself, and forgetting it is a frequent cause of confusing 500 errors on first deploy
+- Increasingly the outlier choice for new projects, as the broader .NET ecosystem's tooling and documentation investment shifts toward containerized, cloud-native deployment
+
+**Choose this when:** you're deploying into an existing Windows Server environment, need deep Windows-specific integration (Active Directory, Windows Authentication), or your organization's operational expertise and infrastructure are already built around IIS.
+
+## How to Decide
+
+A few heuristics that cover most real-world decisions:
+
+**Requirements are genuinely complex - multi-tenant, stateful, specific hardware needs?** Kubernetes' control surface is worth its operational cost specifically for this class of problem, not as a default starting point.
+
+**Azure-first, want cloud-native deployment without managing a cluster?** Azure Container Apps is purpose-built for exactly this, with a well-defined upgrade path to AKS if you outgrow it later.
+
+**AWS-first, want the equivalent managed container experience?** ECS with Fargate is the natural analog, deeply integrated with the rest of AWS's ecosystem.
+
+**Already using .NET Aspire for local development?** Its deploy workflow (`aspire publish`/`aspire deploy`) carries that same model through to production, particularly smoothly for Azure via `azd`.
+
+**Deploying into existing Windows Server infrastructure, or need deep Windows-specific integration?** IIS remains a completely legitimate, well-supported choice - not a legacy fallback, but the right fit for a real class of environments.
+
+The single most common mistake across all five options isn't picking the wrong one outright - it's reaching for more infrastructure than the actual workload needs. A low-traffic internal tool doesn't need Kubernetes; a genuinely complex, multi-tenant platform will eventually outgrow Azure Container Apps' limitations. Match the operational commitment to the actual problem, and be honest about which one you're solving.
+
+## Frequently Asked Questions
+
+### Should I default to Kubernetes for a new .NET project?
+
+Usually not, unless you have a concrete, specific reason - multi-tenant complexity, stateful workloads needing fine control, or hardware requirements a serverless container platform doesn't support. For most new projects, a managed serverless container platform (Azure Container Apps or AWS ECS/Fargate) delivers most of the containerized benefits with meaningfully less operational overhead.
+
+### What's the actual difference between Azure Container Apps and AKS?
+
+Azure Container Apps is serverless - no cluster to manage, with real limitations (no DaemonSets, limited node configuration, less networking control) in exchange for that simplicity. AKS is full Kubernetes, giving you the complete control surface at the cost of managing the cluster yourself. The migration path between them is well-defined since your container images don't change, only the orchestration layer around them.
+
+### Is .NET Aspire's deploy workflow a replacement for choosing an actual deployment target?
+
+No - it's a tooling layer on top of whatever target you choose, generating Docker Compose files, Kubernetes manifests, or Bicep templates from the same application model. You still need to decide where those artifacts actually get deployed; Aspire just makes that transition from local development smoother and more consistent, particularly for Azure via `azd`.
+
+### Is IIS still a reasonable choice for new .NET projects in 2026?
+
+For most new, cloud-native projects, container-based options are now the more common default. IIS remains completely reasonable specifically for organizations already running Windows Server infrastructure or needing deep Windows-specific integration (Active Directory, Windows Authentication) - it's not obsolete, just no longer the default assumption the way it once was.
+
+### What's the most common mistake when deploying ASP.NET Core to IIS?
+
+Forgetting to install the .NET Core Hosting Bundle on the Windows Server separately from deploying the application itself - this is a frequently reported cause of confusing 500 Internal Server Errors on a first deployment, since the application code is correct but the server lacks the runtime component needed to host it.
+
+### Should I choose AWS ECS or Azure Container Apps if I'm not committed to a cloud platform yet?
+
+Let your broader cloud platform decision drive this rather than the reverse - both offer a comparable value proposition (managed containers without cluster management), so the more important question is which cloud ecosystem the rest of your infrastructure, team expertise, and existing services are already built around.
+
+### Does choosing a serverless container platform (ACA or ECS/Fargate) lock me into that cloud forever?
+
+It's real lock-in in the sense that migrating away means adopting a different deployment and orchestration model, not a configuration change - but your actual container images remain portable. If you build with portable patterns (avoiding cloud-specific SDKs baked directly into application code, for instance), migrating the orchestration layer later is a real but bounded project, not a full rewrite.

--- a/src/posts/2028-04-18-getting-started-with-azure-container-apps.md
+++ b/src/posts/2028-04-18-getting-started-with-azure-container-apps.md
@@ -1,0 +1,186 @@
+---
+author: Steve Kaschimer
+date: 2028-04-18
+image: /images/posts/2028-04-18-hero.webp
+image_alt: "A light container glyph fading gently at its edges against the dark background, implying a workload that scales down to nothing when idle rather than a container that's always running."
+image_prompt: "A dark-mode technical editorial illustration on a near-black background with electric teal, amber, and off-white accents. Composition centers on a single container glyph rendered as a simple rounded rectangle outline, its edges deliberately fading into the background at the top and bottom corners, implying a workload that scales down to zero when idle rather than something permanently running. A small amber dot sits just outside the container's edge, isolated, implying a referenced secret rather than an embedded value. Mood is serverless, elastic, and quietly efficient. Avoid: vendor logos, brand colors, circuit-board textures, gears, or generic cloud clip art as the dominant motif."
+layout: post.njk
+site_title: Tech Notes
+summary: "Azure Container Apps' pitch is containerized deployment without ever touching a Kubernetes manifest - the part worth understanding upfront is where that simplicity has real edges. A setup guide for scale-to-zero, KEDA-backed autoscaling rules, and secretref: configuration."
+tags: ["dotnet", "deployment", "azure", "containers", "devops"]
+title: "Getting Started with Azure Container Apps for .NET Deployment"
+---
+
+Azure Container Apps' whole pitch is that you get containerized, cloud-native deployment without ever touching a Kubernetes manifest or provisioning a cluster - and for a genuinely large share of .NET applications, that trade is exactly right. The part worth understanding before committing is where its simplicity has real edges: no DaemonSets, no privileged containers, no GPU node selection. Knowing those limits upfront means you're choosing ACA deliberately, not discovering its ceiling mid-project.
+
+This guide covers deploying a .NET application to Azure Container Apps, bootstrapping scaling and configuration correctly, the core deployment workflow via the Azure CLI or `azd`, and the best practices that take advantage of what ACA does well without running into its known limitations unexpectedly. By the end you'll have a serverless container deployment that scales automatically, including down to zero for idle workloads.
+
+If you're deciding between deployment options first, [a comparison of the top ways to deploy .NET apps](/posts/2028-04-11-top-5-dotnet-deployment-options-compared/) covers where Azure Container Apps fits relative to Docker + Kubernetes, AWS ECS/Fargate, .NET Aspire's deploy workflow, and IIS.
+
+## What You'll Need
+
+- An Azure subscription
+- Azure CLI installed, or the Azure Developer CLI (`azd`) for a more opinionated, integrated workflow
+- A containerized .NET application (see this series' [Docker + Kubernetes guide](/posts/2028-05-02-getting-started-with-docker-kubernetes-dotnet/) for containerization basics)
+
+## Installing the Tooling
+
+```bash
+# Azure CLI
+curl -L https://aka.ms/InstallAzureCLIDeb | sudo bash  # Linux example; see docs for macOS/Windows
+
+az login
+az extension add --name containerapp
+```
+
+## Deploying to Azure Container Apps
+
+### Create the environment and container app
+
+```bash
+az group create --name myapp-rg --location eastus
+
+az containerapp env create \
+  --name myapp-env \
+  --resource-group myapp-rg \
+  --location eastus
+
+az containerapp create \
+  --name myapp-api \
+  --resource-group myapp-rg \
+  --environment myapp-env \
+  --image myregistry.azurecr.io/myapp-api:latest \
+  --target-port 8080 \
+  --ingress external \
+  --min-replicas 0 \
+  --max-replicas 10
+```
+
+`--min-replicas 0` is what enables scale-to-zero - genuinely idle services cost nothing in compute, a real advantage over always-on options for workloads with variable or low traffic.
+
+## Bootstrapping the Ideal Environment
+
+### Configure autoscaling rules
+
+```bash
+az containerapp update \
+  --name myapp-api \
+  --resource-group myapp-rg \
+  --scale-rule-name http-scaling \
+  --scale-rule-type http \
+  --scale-rule-http-concurrency 50
+```
+
+This scales based on concurrent HTTP requests per replica - ACA also supports scaling rules based on CPU, memory, or custom metrics (via KEDA under the hood), letting you match scaling behavior to your actual workload characteristics.
+
+### Configure secrets and environment variables
+
+```bash
+az containerapp secret set \
+  --name myapp-api \
+  --resource-group myapp-rg \
+  --secrets "db-connection-string=Server=...;"
+
+az containerapp update \
+  --name myapp-api \
+  --resource-group myapp-rg \
+  --set-env-vars "ConnectionStrings__Default=secretref:db-connection-string"
+```
+
+Referencing secrets rather than embedding connection strings directly in environment variables keeps sensitive configuration out of plain-text app settings - worth doing from the start rather than retrofitting later.
+
+### Set up health probes
+
+```csharp
+builder.Services.AddHealthChecks()
+    .AddCheck("self", () => HealthCheckResult.Healthy());
+
+var app = builder.Build();
+app.MapHealthChecks("/health");
+```
+
+```bash
+az containerapp update \
+  --name myapp-api \
+  --resource-group myapp-rg \
+  --readiness-probe-path /health \
+  --liveness-probe-path /health
+```
+
+The same health check concepts from Kubernetes apply here - ACA uses them to determine whether a replica is ready for traffic and whether it needs to be restarted.
+
+### Deploying via azd for a more integrated workflow
+
+```bash
+azd init
+azd up
+```
+
+`azd` handles provisioning the resource group, container registry, and Container App environment together, and has particularly strong support for .NET Aspire-based applications if you're using Aspire for local development - worth using over raw Azure CLI commands once your setup involves more than a single service.
+
+## Core Workflow
+
+- **Deploy new revisions rather than modifying a running one in place.** ACA's revision model lets you roll out a new version, verify it, and shift traffic gradually - or roll back instantly if something's wrong.
+- **Configure scaling rules matched to your actual traffic pattern**, not a one-size-fits-all default - HTTP concurrency, CPU, and custom metrics are all available depending on what actually drives your workload's load.
+- **Use `azd` for multi-service or Aspire-based applications**, and raw Azure CLI or Bicep for simpler, single-service scenarios where the extra tooling isn't needed.
+
+## Verifying Your Setup
+
+1. **The application scales to zero when idle, and back up under load** - confirm this behavior matches your `--min-replicas`/`--max-replicas` configuration
+2. **Secrets are referenced, not embedded directly** - confirm sensitive configuration uses `secretref:` rather than plain environment variable values
+3. **Health probes correctly reflect application state** - confirm ACA restarts or avoids routing traffic to unhealthy replicas appropriately
+4. **Revisions roll out and can be rolled back** - confirm a new deployment creates a new revision, and that reverting to a previous one works cleanly
+
+## Best Practices
+
+**Understand ACA's real limitations before committing to it for a complex workload.** No DaemonSets, no privileged containers, limited networking control - if your requirements need these, Kubernetes (AKS) is the more honest choice, not something to discover mid-project.
+
+**Use scale-to-zero deliberately for genuinely variable or low-traffic services.** It's a real cost advantage, but confirm your application's cold-start time is acceptable for your use case, since scaling from zero isn't instantaneous.
+
+**Reference secrets rather than embedding sensitive values directly in environment variables.** This is a small amount of extra setup for a meaningful security improvement.
+
+**Use `azd` for anything beyond a single simple service, especially Aspire-based applications.** It meaningfully reduces the amount of manual Azure CLI orchestration needed for multi-resource deployments.
+
+**Know the migration path to AKS exists, and don't treat ACA as a permanent ceiling.** If you outgrow ACA's limitations, your container images carry over directly - only the orchestration layer changes.
+
+## Comparison with AWS ECS/Fargate
+
+| | Azure Container Apps | AWS ECS/Fargate |
+| --- | --- | --- |
+| Cloud | Azure | AWS |
+| Scale-to-zero | Yes, natively | Requires more manual configuration |
+| .NET-specific tooling | Deep, especially via Aspire/azd | Solid, less .NET-centric |
+| Ecosystem integration | Azure Monitor, Key Vault, Application Insights | CloudWatch, Secrets Manager, IAM |
+| Best fit | Azure-first teams | AWS-first teams |
+
+Both offer a comparable serverless-container value proposition - the deciding factor is almost always which cloud ecosystem the rest of your infrastructure and team expertise are already built around, not a meaningful capability gap between them.
+
+## Frequently Asked Questions
+
+### Does Azure Container Apps support scaling to zero?
+
+Yes - setting `--min-replicas 0` allows a genuinely idle service to scale down to zero running instances, meaning no compute cost while there's no traffic. Confirm your application's cold-start time from zero is acceptable for your use case, since there's a real latency cost to the first request after scaling up from zero.
+
+### What can't Azure Container Apps do that Kubernetes (AKS) can?
+
+No DaemonSets, no privileged containers, no GPU node pool selection, and less granular networking control (no custom ingress controllers or advanced network policies). These are real, deliberate limitations of ACA's simpler, serverless model - if your workload needs any of them, AKS is the more appropriate choice.
+
+### How do I keep sensitive configuration like connection strings secure in Azure Container Apps?
+
+Use `az containerapp secret set` to store sensitive values as secrets, then reference them in environment variables via `secretref:secret-name` rather than embedding the actual value directly. This keeps secrets out of plain-text app configuration.
+
+### What's the difference between using raw Azure CLI commands and azd?
+
+Raw Azure CLI commands give you granular, step-by-step control over each resource. `azd` (Azure Developer CLI) provides a more integrated, opinionated workflow that provisions multiple related resources together, with particularly strong support for .NET Aspire applications - worth using once your deployment involves more than a single simple service.
+
+### How does autoscaling work in Azure Container Apps?
+
+Via configurable scaling rules based on HTTP concurrency, CPU/memory usage, or custom metrics (powered by KEDA underneath), each with a minimum and maximum replica count you define. Match the scaling rule type to what actually drives load in your specific application rather than defaulting to one without considering your traffic pattern.
+
+### Can I migrate from Azure Container Apps to AKS later if I outgrow it?
+
+Yes, and the migration path is well-defined - your container images don't change, only the orchestration and deployment configuration around them. This is a real, practical advantage of choosing a container-based deployment strategy from the start, regardless of which specific platform you begin with.
+
+### What's the most common mistake when adopting Azure Container Apps?
+
+Not understanding its real limitations (no DaemonSets, limited networking control, primarily stateless workloads) before committing, and discovering them mid-project rather than as an informed, upfront decision. The second common mistake is embedding secrets directly in environment variables instead of using ACA's secret reference mechanism.

--- a/src/posts/2028-04-25-getting-started-with-aws-ecs-fargate.md
+++ b/src/posts/2028-04-25-getting-started-with-aws-ecs-fargate.md
@@ -1,0 +1,178 @@
+---
+author: Steve Kaschimer
+date: 2028-04-25
+image: /images/posts/2028-04-25-hero.webp
+image_alt: "A container glyph paired with a small toggle switch beside it, implying a deliberate choice between two compute models rather than a single fixed option."
+image_prompt: "A dark-mode technical editorial illustration on a near-black background with electric teal, amber, and off-white accents. Composition centers on a single container glyph rendered as a rounded rectangle outline, with a small toggle-switch shape positioned just beside it, one side lit teal and the other side lit amber, implying a deliberate choice between two underlying compute models. A thin routing line connects the container to a small load-balancer glyph off to the side. Mood is deliberate, ecosystem-integrated, and precise. Avoid: vendor logos, brand colors, circuit-board textures, gears, or generic cloud clip art as the dominant motif."
+layout: post.njk
+site_title: Tech Notes
+summary: "ECS paired with Fargate asks you to make one decision Azure's platform doesn't: EC2-backed ECS or Fargate. A setup guide for task definitions, Secrets Manager references, and pairing an ECS service with an Application Load Balancer."
+tags: ["dotnet", "deployment", "aws", "containers", "devops"]
+title: "Getting Started with AWS ECS/Fargate for .NET Deployment"
+---
+
+ECS paired with Fargate is AWS's answer to the same problem Azure Container Apps solves - run containers without managing a cluster - but it asks you to make one decision Azure's platform doesn't: EC2-backed ECS or Fargate. That choice determines whether you're managing the underlying compute yourself or handing it entirely to AWS, and it's worth making deliberately rather than defaulting to whichever example you copied first.
+
+This guide covers deploying a .NET application to ECS with Fargate, bootstrapping the task definition and service configuration that matter for .NET workloads specifically, the core deployment workflow, and the best practices for taking advantage of AWS's ecosystem integration without adding unnecessary operational complexity. By the end you'll have a serverless container deployment integrated with the rest of your AWS infrastructure.
+
+If you're deciding between deployment options first, [a comparison of the top ways to deploy .NET apps](/posts/2028-04-11-top-5-dotnet-deployment-options-compared/) covers where AWS ECS/Fargate fits relative to Docker + Kubernetes, Azure Container Apps, .NET Aspire's deploy workflow, and IIS.
+
+## What You'll Need
+
+- An AWS account
+- AWS CLI installed and configured with appropriate credentials
+- A containerized .NET application pushed to a container registry (Amazon ECR is the natural choice)
+
+## Pushing Your Image to ECR
+
+```bash
+aws ecr create-repository --repository-name myapp-api
+
+aws ecr get-login-password --region us-east-1 | \
+  docker login --username AWS --password-stdin <account-id>.dkr.ecr.us-east-1.amazonaws.com
+
+docker tag myapp-api:latest <account-id>.dkr.ecr.us-east-1.amazonaws.com/myapp-api:latest
+docker push <account-id>.dkr.ecr.us-east-1.amazonaws.com/myapp-api:latest
+```
+
+## Bootstrapping the Ideal Environment
+
+### Define a task definition
+
+```json
+{
+  "family": "myapp-api",
+  "networkMode": "awsvpc",
+  "requiresCompatibilities": ["FARGATE"],
+  "cpu": "512",
+  "memory": "1024",
+  "containerDefinitions": [
+    {
+      "name": "myapp-api",
+      "image": "<account-id>.dkr.ecr.us-east-1.amazonaws.com/myapp-api:latest",
+      "portMappings": [{ "containerPort": 8080, "protocol": "tcp" }],
+      "logConfiguration": {
+        "logDriver": "awslogs",
+        "options": {
+          "awslogs-group": "/ecs/myapp-api",
+          "awslogs-region": "us-east-1",
+          "awslogs-stream-prefix": "ecs"
+        }
+      },
+      "secrets": [
+        {
+          "name": "ConnectionStrings__Default",
+          "valueFrom": "arn:aws:secretsmanager:us-east-1:<account-id>:secret:db-connection-string"
+        }
+      ]
+    }
+  ]
+}
+```
+
+Referencing AWS Secrets Manager via `secrets` rather than embedding connection strings directly keeps sensitive configuration out of the task definition itself - the same discipline that applies across every deployment option in this series.
+
+```bash
+aws ecs register-task-definition --cli-input-json file://task-definition.json
+```
+
+### Configure health checks in your .NET app
+
+```csharp
+builder.Services.AddHealthChecks();
+var app = builder.Build();
+app.MapHealthChecks("/health");
+```
+
+### Create the ECS service
+
+```bash
+aws ecs create-service \
+  --cluster myapp-cluster \
+  --service-name myapp-api-service \
+  --task-definition myapp-api \
+  --desired-count 2 \
+  --launch-type FARGATE \
+  --network-configuration "awsvpcConfiguration={subnets=[subnet-xxx],securityGroups=[sg-xxx],assignPublicIp=ENABLED}" \
+  --load-balancers "targetGroupArn=<target-group-arn>,containerName=myapp-api,containerPort=8080"
+```
+
+Pairing the ECS service with an Application Load Balancer target group is the standard pattern for routing external traffic - the load balancer also performs health checks against your `/health` endpoint to determine which tasks are ready to receive traffic.
+
+### Choosing between Fargate and EC2-backed ECS
+
+Fargate removes server management entirely - you specify CPU and memory for your task, and AWS handles the underlying compute. EC2-backed ECS gives you more control (and potentially lower cost at scale) at the price of managing the underlying EC2 instances yourself. Start with Fargate unless you have a specific, informed reason to manage the compute layer directly.
+
+## Core Workflow
+
+- **Register a new task definition revision for each deployment**, rather than modifying one in place - this preserves a clean history and makes rollback straightforward.
+- **Update the service to use the new task definition revision**, letting ECS handle the rolling deployment and health-check-gated traffic shift automatically.
+- **Use CloudWatch Logs (configured via the task definition's `logConfiguration`) for centralized log aggregation**, rather than relying on ephemeral container logs for anything beyond local debugging.
+
+```bash
+aws ecs update-service \
+  --cluster myapp-cluster \
+  --service myapp-api-service \
+  --task-definition myapp-api:2
+```
+
+## Verifying Your Setup
+
+1. **The service registers healthy targets with the load balancer** - confirm the target group shows healthy targets, not just running tasks
+2. **Secrets are referenced via Secrets Manager, not embedded in the task definition** - confirm sensitive values use `valueFrom`, not plain `environment` entries
+3. **Logs flow to CloudWatch correctly** - confirm application logs are visible in the configured log group
+4. **Rolling deployments complete without downtime** - confirm a new task definition revision deploys with the load balancer correctly shifting traffic to healthy new tasks before old ones terminate
+
+## Best Practices
+
+**Start with Fargate unless you have a specific reason to manage EC2 instances directly.** The operational simplicity is worth the (often modest) cost premium for most workloads, especially early on.
+
+**Reference AWS Secrets Manager for sensitive configuration**, not plain environment variables in the task definition. This is a small amount of extra setup for a meaningful security improvement, consistent with every other deployment option in this series.
+
+**Configure CloudWatch Logs from the start.** Container logs disappear when a task stops - centralized logging is not optional for any real production troubleshooting.
+
+**Pair ECS services with an Application Load Balancer and configure health checks correctly.** Without them, ECS has no reliable way to know whether a task is actually ready to serve traffic.
+
+**Register new task definition revisions per deployment rather than editing existing ones.** This preserves a clean audit trail and makes rollback to a known-good revision straightforward.
+
+## Comparison with Azure Container Apps
+
+| | AWS ECS/Fargate | Azure Container Apps |
+| --- | --- | --- |
+| Cloud | AWS | Azure |
+| Compute model choice | Fargate (serverless) or EC2-backed | Serverless only |
+| Ecosystem integration | IAM, VPC, CloudWatch, Secrets Manager | Azure Monitor, Key Vault, Application Insights |
+| .NET-specific tooling | Solid, less .NET-centric than Azure's offerings | Deep, especially via Aspire/azd |
+| Scale-to-zero | Requires more manual configuration | Native |
+
+Both deliver a comparable managed-container experience - the deciding factor is almost always which cloud ecosystem the rest of your infrastructure and team expertise already live in, not a meaningful capability gap between the two platforms.
+
+## Frequently Asked Questions
+
+### Should I use Fargate or EC2-backed ECS?
+
+Start with Fargate unless you have a specific, informed reason to manage the underlying compute yourself - it removes server management entirely, letting you specify CPU/memory per task rather than provisioning and patching EC2 instances. EC2-backed ECS offers more control and potentially lower cost at scale, at the cost of that added operational responsibility.
+
+### How do I keep secrets like database connection strings secure in ECS?
+
+Reference AWS Secrets Manager (or Systems Manager Parameter Store) via the `secrets` array in your task definition, using `valueFrom` to point at the secret's ARN, rather than embedding the actual value in the task definition's `environment` section.
+
+### Does ECS support scaling to zero like Azure Container Apps?
+
+Not as natively - ECS services typically maintain a minimum desired count above zero. Achieving scale-to-zero-like behavior requires more manual configuration (such as scheduled scaling or custom automation), whereas Azure Container Apps supports it as a first-class, simpler configuration option.
+
+### How does ECS know when a task is healthy and ready for traffic?
+
+Through health checks configured on the Application Load Balancer's target group, which ECS uses to determine whether a task should receive traffic. Configure your .NET application's `/health` endpoint and point the target group's health check at it.
+
+### What's the difference between updating a service and registering a new task definition?
+
+You always register a new task definition revision to reflect a code or configuration change, then update the service to point at that new revision - ECS handles the rolling deployment. Editing an existing task definition in place isn't how ECS is designed to work; revisions are immutable once registered.
+
+### Is AWS ECS as well-documented for .NET specifically as Azure's options?
+
+Generally less so - AWS's documentation and tooling investment is broader and less .NET-centric than Azure's, which makes sense given Azure's tighter integration with the Microsoft ecosystem. ECS itself is mature and well-documented in general, just with somewhat thinner .NET-specific guidance compared to Azure Container Apps or App Service.
+
+### What's the most common mistake in a first ECS/Fargate deployment?
+
+Not configuring CloudWatch Logs from the start, leading to a frustrating debugging experience once a task fails and its ephemeral logs are gone. The second common mistake is embedding secrets directly in the task definition instead of referencing Secrets Manager, leaving sensitive values in plain text within deployment configuration.

--- a/src/posts/2028-05-02-getting-started-with-docker-kubernetes-dotnet.md
+++ b/src/posts/2028-05-02-getting-started-with-docker-kubernetes-dotnet.md
@@ -1,0 +1,207 @@
+---
+author: Steve Kaschimer
+date: 2028-05-02
+image: /images/posts/2028-05-02-hero.webp
+image_alt: "A dense cluster of interconnected nodes with a small steering-wheel accent at its center, implying full manual control over orchestration rather than a managed platform doing it for you."
+image_prompt: "A dark-mode technical editorial illustration on a near-black background with electric teal, amber, and off-white accents. Composition centers on a dense cluster of small interconnected nodes rendered as circles joined by thin lines, with a small steering-wheel glyph positioned at the cluster's center, implying full manual control over orchestration. A subtle amber pulse travels along one of the connecting lines toward an outer node, implying a rolling update in progress. Mood is capable, hands-on, and portable. Avoid: vendor logos, brand colors, circuit-board textures, gears, or generic cloud clip art as the dominant motif."
+layout: post.njk
+site_title: Tech Notes
+summary: "Containerizing a .NET application is the easy part - running that image well in Kubernetes is where the real work lives, and where .NET-specific details matter more than generic advice accounts for. A setup guide for Kestrel binding, graceful shutdown, and liveness/readiness probes."
+tags: ["dotnet", "deployment", "kubernetes", "containers", "devops"]
+title: "Getting Started with Docker + Kubernetes for .NET Deployment"
+---
+
+Containerizing a .NET application is the easy part - a Dockerfile, a build command, and you have an image. Running that image well in Kubernetes is where most of the real work lives, and it's also where .NET-specific details matter more than generic Kubernetes advice accounts for: how Kestrel should bind inside a pod, why graceful shutdown needs deliberate handling, and why the hosting model inside a container is actually simpler than what IIS or a VM would require, not more complex.
+
+This guide covers containerizing a .NET application correctly, bootstrapping Kubernetes manifests with the settings that matter for .NET workloads specifically, the core deployment workflow, and the best practices that prevent the most common production issues teams hit running .NET in Kubernetes for the first time. By the end you'll have a deployment that scales correctly and shuts down cleanly.
+
+If you're deciding between deployment options first, [a comparison of the top ways to deploy .NET apps](/posts/2028-04-11-top-5-dotnet-deployment-options-compared/) covers where Docker + Kubernetes fits relative to Azure Container Apps, AWS ECS/Fargate, .NET Aspire's deploy workflow, and IIS.
+
+## What You'll Need
+
+- Docker installed locally
+- A Kubernetes cluster - local (minikube, kind, Docker Desktop's built-in Kubernetes) for development, a managed offering (AKS, EKS, GKE) for production
+- `kubectl` configured against your target cluster
+
+## Containerizing Your Application
+
+```dockerfile
+# Dockerfile
+FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
+WORKDIR /src
+COPY *.csproj .
+RUN dotnet restore
+COPY . .
+RUN dotnet publish -c Release -o /app/publish
+
+FROM mcr.microsoft.com/dotnet/aspnet:8.0 AS final
+WORKDIR /app
+COPY --from=build /app/publish .
+EXPOSE 8080
+ENTRYPOINT ["dotnet", "MyApp.Api.dll"]
+```
+
+The two-stage build (SDK image for building, the smaller ASP.NET runtime image for the final container) is standard practice - it keeps the deployed image significantly smaller than shipping the full SDK.
+
+```bash
+docker build -t myapp-api:latest .
+docker run -p 8080:8080 myapp-api:latest
+```
+
+## Bootstrapping the Ideal Environment
+
+### Configure Kestrel for the container/Kubernetes context
+
+Inside a Kubernetes pod, your app typically only needs Kestrel bound to a non-privileged port - no IIS, no in-process hosting complexity:
+
+```csharp
+// Program.cs
+var builder = WebApplication.CreateBuilder(args);
+builder.WebHost.UseKestrel(options => options.ListenAnyIP(8080));
+```
+
+TLS terminates at the cluster's ingress layer, not inside your pod - this is the simplest hosting model in this entire deployment series, genuinely less to configure than IIS out-of-process hosting requires.
+
+### Add health check endpoints
+
+```csharp
+builder.Services.AddHealthChecks()
+    .AddCheck("self", () => HealthCheckResult.Healthy())
+    .AddDbContextCheck<AppDbContext>();
+
+var app = builder.Build();
+app.MapHealthChecks("/health/live");
+app.MapHealthChecks("/health/ready");
+```
+
+Kubernetes uses these to determine whether your pod is alive (liveness) and ready to receive traffic (readiness) - without them, Kubernetes has no way to know your application is actually healthy versus just running.
+
+### Write the Kubernetes deployment manifest
+
+```yaml
+# deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: myapp-api
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: myapp-api
+  template:
+    metadata:
+      labels:
+        app: myapp-api
+    spec:
+      containers:
+        - name: myapp-api
+          image: myregistry.azurecr.io/myapp-api:latest
+          ports:
+            - containerPort: 8080
+          livenessProbe:
+            httpGet:
+              path: /health/live
+              port: 8080
+            initialDelaySeconds: 10
+          readinessProbe:
+            httpGet:
+              path: /health/ready
+              port: 8080
+          resources:
+            requests:
+              cpu: "250m"
+              memory: "256Mi"
+            limits:
+              cpu: "500m"
+              memory: "512Mi"
+```
+
+Setting `resources.requests` and `resources.limits` explicitly is not optional in any real production deployment - without them, a single misbehaving pod can consume disproportionate cluster resources and destabilize other workloads.
+
+### Handle graceful shutdown
+
+```csharp
+var app = builder.Build();
+
+var lifetime = app.Services.GetRequiredService<IHostApplicationLifetime>();
+lifetime.ApplicationStopping.Register(() =>
+{
+    // Allow in-flight requests to complete before the pod terminates
+});
+
+app.Run();
+```
+
+Kubernetes sends a `SIGTERM` to your pod before terminating it, and .NET's `IHostApplicationLifetime` gives you a hook to respond - this is consistently the thing teams get wrong first in Kubernetes deployments: not configuring graceful shutdown correctly, resulting in dropped requests during rolling deploys or scale-down events.
+
+## Core Workflow
+
+- **Build and push images through your CI pipeline**, tagging with a meaningful version (commit SHA, semantic version) rather than only `latest`, which makes rollback and debugging much harder.
+- **Apply manifests via `kubectl apply -f` or a templating tool (Helm, Kustomize)** for anything beyond a trivial single-service deployment.
+- **Use rolling updates (Kubernetes' default deployment strategy) and confirm readiness probes are configured correctly**, so traffic only routes to pods that are actually ready.
+
+```bash
+kubectl apply -f deployment.yaml
+kubectl rollout status deployment/myapp-api
+```
+
+## Verifying Your Setup
+
+1. **Health checks respond correctly** - confirm `/health/live` and `/health/ready` return expected results, and that Kubernetes correctly reflects pod readiness
+2. **Graceful shutdown actually works** - confirm in-flight requests complete during a rolling update rather than being abruptly dropped
+3. **Resource limits are appropriately sized** - monitor actual CPU/memory usage against configured requests/limits and adjust if they're consistently under- or over-provisioned
+4. **Rolling updates deploy without downtime** - confirm a new version rolls out with zero dropped requests, assuming readiness probes and graceful shutdown are both correctly configured
+
+## Best Practices
+
+**Always configure both liveness and readiness probes, and understand the difference.** Liveness determines if a pod should be restarted; readiness determines if it should receive traffic - conflating the two or omitting either is a common source of subtle production issues.
+
+**Set resource requests and limits explicitly for every container.** This isn't optional tuning - it's the mechanism that prevents one workload from destabilizing the rest of the cluster.
+
+**Implement graceful shutdown deliberately, don't assume it's automatic.** This is consistently the single most commonly mishandled aspect of running .NET in Kubernetes, according to teams who've been through it.
+
+**Use a two-stage Dockerfile to keep production images minimal.** Shipping the full SDK image in production is unnecessary bloat - the ASP.NET runtime image is what should actually run in your cluster.
+
+**Forward logs to centralized observability (Azure Monitor, Application Insights, or an open-source equivalent) rather than relying on `kubectl logs` for anything beyond local debugging.** Container logs are ephemeral by nature; production troubleshooting needs persistent, searchable log aggregation.
+
+## Comparison with Azure Container Apps
+
+| | Docker + Kubernetes | Azure Container Apps |
+| --- | --- | --- |
+| Operational overhead | High - you manage the cluster | Low - no cluster to manage |
+| Control | Full - networking, node config, advanced patterns | Limited - no DaemonSets, no privileged containers |
+| Portability | Highest - runs on any Kubernetes distribution | Azure-specific |
+| Best fit | Complex, multi-tenant, or stateful workloads | Azure-first teams wanting cloud-native without cluster ops |
+
+Kubernetes is the right choice specifically when you need its control surface - the same container images can migrate to Azure Container Apps or back without a rewrite, just a different orchestration layer around them.
+
+## Frequently Asked Questions
+
+### Do I need IIS inside my container?
+
+No - Kestrel bound directly to a non-privileged port (typically 8080) is the correct hosting model inside a Kubernetes pod. TLS terminates at the cluster's ingress, not inside your container, making this genuinely simpler than IIS-based hosting models.
+
+### Why is my rolling deployment dropping requests?
+
+The most common cause is missing or incorrectly configured graceful shutdown - Kubernetes sends `SIGTERM` before terminating a pod, and without handling it via `IHostApplicationLifetime`, in-flight requests can be abruptly cut off. Confirm readiness probes are also configured correctly, so traffic isn't routed to a pod that isn't actually ready yet.
+
+### What's the difference between a liveness probe and a readiness probe?
+
+A liveness probe determines whether Kubernetes should restart a pod (it's checking "is this process still functioning"). A readiness probe determines whether the pod should receive traffic (it's checking "is this instance ready to serve requests right now"). A pod can be alive but not ready - for instance, during startup while it's still connecting to a database.
+
+### How do I decide resource requests and limits for a .NET container?
+
+Start with reasonable estimates based on your application's typical memory and CPU usage, then monitor actual usage in a realistic environment and adjust. Setting limits too low causes throttling or out-of-memory kills; setting them too high wastes cluster capacity that could serve other workloads.
+
+### Should I run Kubernetes myself or use a managed offering like AKS or EKS?
+
+For production, a managed offering is almost always the right call - self-hosting the Kubernetes control plane itself is a substantial additional operational burden on top of everything else in this guide. AKS, EKS, and similar managed services handle the control plane for you, leaving you to manage just your workloads.
+
+### Can I migrate from Kubernetes to Azure Container Apps later, or vice versa?
+
+Yes, relatively cleanly - your container images themselves don't change, only the orchestration and deployment configuration around them. This is one of the real advantages of the container-based approach across this entire comparison: the portability exists at the image level, regardless of which orchestrator you're using.
+
+### What's the most common mistake in a first Kubernetes deployment for .NET?
+
+Not configuring graceful shutdown, leading to dropped requests during routine rolling deployments and scale-down events. The second most common mistake is omitting resource requests/limits entirely, which risks one misbehaving pod destabilizing the rest of the cluster.

--- a/src/posts/2028-05-09-getting-started-with-iis-dotnet.md
+++ b/src/posts/2028-05-09-getting-started-with-iis-dotnet.md
@@ -1,0 +1,157 @@
+---
+author: Steve Kaschimer
+date: 2028-05-09
+image: /images/posts/2028-05-09-hero.webp
+image_alt: "A traditional server-tower glyph standing apart from any cloud or container shape, with no connecting lines to the rest of the composition, emphasizing infrastructure that lives entirely on its own."
+image_prompt: "A dark-mode technical editorial illustration on a near-black background with electric teal, amber, and off-white accents. Composition centers on a single traditional server-tower glyph rendered as a tall rectangle with three horizontal drive-bay lines, standing deliberately apart from any cloud, container, or network shape, with no connecting lines to anything else in the frame. A small amber warning-triangle glyph sits faintly in the background, implying a missing prerequisite waiting to be discovered. Mood is established, self-contained, and slightly cautionary. Avoid: vendor logos, brand colors, circuit-board textures, gears, or generic checkmark clip art as the dominant motif."
+layout: post.njk
+site_title: Tech Notes
+summary: "A completely correct application that returns a 500 error the moment it hits the server, because the .NET Core Hosting Bundle wasn't installed on the Windows Server itself - IIS's most common failure mode. A setup guide for out-of-process hosting, application pool configuration, and stdout logging for troubleshooting."
+tags: ["dotnet", "deployment", "iis", "windows", "devops"]
+title: "Getting Started with IIS for .NET Deployment"
+---
+
+IIS deployments have one failure mode that shows up more often than any other in this series: a completely correct application that returns a 500 error the moment it hits the server, because a single prerequisite - the .NET Core Hosting Bundle - wasn't installed on the Windows Server itself. It's a five-minute fix once you know to look for it, and a genuinely confusing debugging session if you don't. Getting the handful of Windows-Server-specific setup steps right up front is most of what separates a smooth IIS deployment from a frustrating one.
+
+This guide covers deploying an ASP.NET Core application to IIS, bootstrapping the server prerequisites and application pool configuration correctly, the core out-of-process hosting model IIS uses for modern .NET, and the best practices that prevent the most common first-deployment failures. By the end you'll have a working IIS deployment and a clear understanding of what's actually happening between IIS and your application underneath it.
+
+If you're deciding between deployment options first, [a comparison of the top ways to deploy .NET apps](/posts/2028-04-11-top-5-dotnet-deployment-options-compared/) covers where IIS fits relative to Docker + Kubernetes, Azure Container Apps, AWS ECS/Fargate, and .NET Aspire's deploy workflow.
+
+## What You'll Need
+
+- A Windows Server (or Windows with IIS enabled for development/testing) with IIS installed
+- Administrator access to the server
+
+## Installing Prerequisites
+
+### Enable IIS with the necessary features
+
+```powershell
+Install-WindowsFeature -Name Web-Server, Web-Asp-Net45, Web-Net-Ext45, Web-ISAPI-Ext, Web-ISAPI-Filter
+```
+
+### Install the .NET Core Hosting Bundle - the step most commonly missed
+
+Download and install the ASP.NET Core Hosting Bundle from Microsoft's .NET download page directly on the Windows Server. This is a separate installer from the SDK or runtime you might already have for development - it specifically registers the ASP.NET Core Module (ANCM) with IIS, which is what allows IIS to act as a reverse proxy in front of Kestrel.
+
+```powershell
+# After installing, restart IIS to ensure it picks up the new module
+net stop was /y
+net start w3svc
+```
+
+Skipping this step is the single most common cause of a 500 Internal Server Error immediately after a first IIS deployment - the application code is correct, but IIS has no way to actually host it without this component installed.
+
+## Bootstrapping the Ideal Environment
+
+### Publish your application
+
+```bash
+dotnet publish -c Release -o C:\inetpub\wwwroot\myapp
+```
+
+### Understand the out-of-process hosting model
+
+IIS acts as a reverse proxy in front of Kestrel - your ASP.NET Core application runs as a separate process, and IIS forwards requests to it over the loopback adapter. This is the standard, recommended hosting model for modern ASP.NET Core on IIS:
+
+```xml
+<!-- web.config, generated automatically by dotnet publish -->
+<configuration>
+  <system.webServer>
+    <handlers>
+      <add name="aspNetCore" path="*" verb="*" modules="AspNetCoreModuleV2" resourceType="Unspecified" />
+    </handlers>
+    <aspNetCore processPath="dotnet" arguments=".\MyApp.dll" stdoutLogEnabled="false" hostingModel="outofprocess" />
+  </system.webServer>
+</configuration>
+```
+
+`dotnet publish` generates this `web.config` automatically - you generally shouldn't need to hand-write it, but understanding what it configures is useful for troubleshooting.
+
+### Create the application pool and site in IIS
+
+```powershell
+Import-Module WebAdministration
+
+New-WebAppPool -Name "MyAppPool"
+Set-ItemProperty IIS:\AppPools\MyAppPool -Name managedRuntimeVersion -Value ""
+
+New-Website -Name "MyApp" -PhysicalPath "C:\inetpub\wwwroot\myapp" -ApplicationPool "MyAppPool" -Port 80
+```
+
+Setting `managedRuntimeVersion` to an empty string is important - ASP.NET Core doesn't use the traditional .NET Framework CLR that IIS's application pools were originally designed around, so the "No Managed Code" setting is correct here.
+
+### Enable logging for troubleshooting
+
+```xml
+<aspNetCore processPath="dotnet" arguments=".\MyApp.dll" stdoutLogEnabled="true" stdoutLogFile=".\logs\stdout" hostingModel="outofprocess" />
+```
+
+Enable `stdoutLogEnabled` temporarily during initial deployment troubleshooting - it captures startup errors that would otherwise only be visible as a generic 500 error in the browser, then disable it again once the deployment is confirmed working, since it adds overhead you don't want running continuously in production.
+
+## Core Workflow
+
+- **Publish a fresh build for every deployment**, and stop the application pool before overwriting files to avoid file-lock conflicts with the running process.
+- **Check `stdoutLogEnabled` output first when troubleshooting a failed deployment**, before assuming the application code itself is broken - most first-deployment failures are environmental (missing Hosting Bundle, incorrect application pool settings), not code issues.
+- **Use IIS's built-in request tracing and Failed Request Tracing (FREB) for deeper diagnostics** when stdout logging alone doesn't reveal the issue.
+
+## Verifying Your Setup
+
+1. **The Hosting Bundle is installed and IIS was restarted afterward** - confirm the ASP.NET Core Module is registered (`%windir%\System32\inetsrv\config\applicationHost.config` should reference `AspNetCoreModuleV2`)
+2. **The application pool is set to "No Managed Code"** - confirm `managedRuntimeVersion` is empty for the app pool
+3. **The site responds correctly** - confirm a request to the configured port returns your application's expected response, not a 500 error
+4. **Stdout logging captures useful diagnostics if something's wrong** - confirm enabling it surfaces actionable startup error details rather than a generic failure
+
+## Best Practices
+
+**Always install the .NET Core Hosting Bundle on the Windows Server, separately from any SDK you used for development.** This is the most consistently reported first-deployment failure across ASP.NET Core + IIS setups - validate this prerequisite before assuming anything else is wrong.
+
+**Set the application pool's `managedRuntimeVersion` to empty ("No Managed Code").** ASP.NET Core doesn't use the CLR that IIS application pools traditionally manage - this setting reflects that correctly.
+
+**Enable stdout logging temporarily during initial troubleshooting, and disable it once the deployment is confirmed working.** It's genuinely useful for diagnosing startup failures, and genuinely unnecessary overhead to leave running indefinitely in production.
+
+**Stop the application pool before overwriting deployed files.** Attempting to overwrite files for a running process can fail or leave the deployment in an inconsistent state - stop, deploy, restart.
+
+**Use Windows Authentication or Active Directory integration where it's actually needed, rather than by default.** This is one of IIS's genuine strengths over cloud-native deployment options, but only worth the added configuration complexity where your application genuinely requires that integration.
+
+## Comparison with Docker + Kubernetes
+
+| | IIS | Docker + Kubernetes |
+| --- | --- | --- |
+| Platform | Windows Server only | Runs anywhere Kubernetes runs |
+| Scaling | Manual - provision another server | Automatic, on-demand |
+| Windows-specific integration | Deep (Active Directory, Windows Auth) | Requires additional configuration |
+| Setup complexity | Lower for teams already on Windows Server | Higher, but more portable |
+| Best fit | Existing Windows Server infrastructure | Cloud-native, portable deployments |
+
+IIS remains the right choice specifically for organizations already invested in Windows Server infrastructure and needing its specific integration points - for new, cloud-native projects without that constraint, container-based options generally offer more operational flexibility.
+
+## Frequently Asked Questions
+
+### Why does my application return a 500 error immediately after deploying to IIS?
+
+The most common cause by far is a missing .NET Core Hosting Bundle installation on the Windows Server - this is a separate installer from any SDK or runtime used during development, and without it, IIS has no way to actually host an ASP.NET Core application. Install it directly on the server and restart IIS.
+
+### What's the difference between in-process and out-of-process hosting?
+
+Out-of-process hosting (the current recommended default) runs your application as a separate process, with IIS acting as a reverse proxy forwarding requests to Kestrel over the loopback adapter. In-process hosting runs the application inside the IIS worker process itself, which can offer a modest performance benefit but is less commonly used today - `dotnet publish`'s generated `web.config` defaults to out-of-process unless configured otherwise.
+
+### Why do I need to set managedRuntimeVersion to empty for my application pool?
+
+ASP.NET Core doesn't use the traditional .NET Framework CLR that IIS application pools were originally built around - setting `managedRuntimeVersion` to an empty string tells IIS "No Managed Code," which is the correct setting for hosting ASP.NET Core applications through the ASP.NET Core Module.
+
+### How do I troubleshoot a deployment that isn't working correctly?
+
+Enable `stdoutLogEnabled` in your `web.config` temporarily - it captures startup errors and diagnostic output that would otherwise only appear as a generic 500 error in the browser. Check the resulting log file for the actual underlying error, then disable stdout logging again once the issue is resolved.
+
+### Can I run multiple ASP.NET Core applications on the same IIS server?
+
+Yes - create a separate application pool and site (or application under an existing site) for each, giving each application process isolation from the others. This is standard practice for hosting multiple applications on shared Windows Server infrastructure.
+
+### Does IIS support HTTPS and modern TLS configuration?
+
+Yes, fully - IIS has mature, well-established tooling for certificate binding and TLS configuration, including integration with tools like Let's Encrypt via community modules for automated certificate management.
+
+### What's the most common mistake in a first IIS deployment?
+
+Forgetting to install the .NET Core Hosting Bundle on the Windows Server, resulting in a confusing 500 error despite correct application code. The second common mistake is leaving `managedRuntimeVersion` at its default (rather than empty), which can cause IIS to attempt to load an incorrect runtime context for the application pool.

--- a/src/posts/2028-05-16-getting-started-with-aspire-deploy-workflow.md
+++ b/src/posts/2028-05-16-getting-started-with-aspire-deploy-workflow.md
@@ -1,0 +1,153 @@
+---
+author: Steve Kaschimer
+date: 2028-05-16
+image: /images/posts/2028-05-16-hero.webp
+image_alt: "A funnel glyph narrowing from a single application model at the top into three distinct small output shapes at the bottom, implying one source model generating multiple different deployment targets."
+image_prompt: "A dark-mode technical editorial illustration on a near-black background with electric teal, amber, and off-white accents. Composition centers on a single funnel glyph, wide at the top and narrowing downward, feeding into three small distinctly-shaped output icons arranged side by side beneath it: a cloud outline, a stacked-node cluster outline, and a simple box outline, implying one source application model generating several different deployment targets. Mood is consistent, generative, and target-agnostic. Avoid: vendor logos, brand colors, circuit-board textures, gears, or generic checkmark clip art as the dominant motif."
+layout: post.njk
+site_title: Tech Notes
+summary: "Aspire's local development story is well covered elsewhere - less widely known is that Aspire 9.2+ ships a real deployment workflow on top of the same application model. A setup guide for aspire publish, aspire deploy, azd up, and customizing generated output from the AppHost."
+tags: ["dotnet", "deployment", "aspire", "azure", "devops"]
+title: "Getting Started with .NET Aspire's Deploy Workflow"
+---
+
+Aspire's local development story - the AppHost, service discovery, the dashboard - is well covered elsewhere in this series. What's less widely known is that Aspire 9.2 and later ships a genuine deployment workflow on top of that same application model: `aspire publish` and `aspire deploy` commands that generate real deployment artifacts - Docker Compose files, Kubernetes manifests, Bicep templates - from the exact same AppHost definition you've already been using for local development. This guide is about that second half, the part that gets less attention than the local dev experience but closes a real gap between "works on my machine" and "deployed to production."
+
+This guide covers using Aspire's publish and deploy commands, bootstrapping the configuration that determines which target your application deploys to, the core workflow for both Azure (via `azd`) and other targets, and the best practices for treating Aspire's deploy tooling as what it actually is - a consistency layer, not a deployment platform of its own. By the end you'll have a deployment pipeline that stays in sync with your local development model instead of drifting from it.
+
+If you're deciding between deployment options first, [a comparison of the top ways to deploy .NET apps](/posts/2028-04-11-top-5-dotnet-deployment-options-compared/) covers where Aspire's deploy workflow fits relative to Docker + Kubernetes, Azure Container Apps, AWS ECS/Fargate, and IIS directly.
+
+## What You'll Need
+
+- .NET 8 SDK or later, with Aspire 9.2 or later
+- An existing Aspire AppHost project
+- For Azure targets: the Azure Developer CLI (`azd`)
+
+## Installing azd (for Azure Targets)
+
+```bash
+curl -fsSL https://aka.ms/install-azd.sh | bash  # Linux/macOS
+winget install microsoft.azd  # Windows
+```
+
+## Understanding the Two Commands
+
+`aspire publish` generates deployment artifacts (Bicep, Kubernetes manifests, Docker Compose files) from your AppHost without actually deploying anything - useful for reviewing what would be deployed, or for handing artifacts to a separate deployment pipeline. `aspire deploy` goes further, generating and actually applying those artifacts to your chosen target.
+
+## Bootstrapping the Ideal Environment
+
+### Deploying to Azure via azd
+
+```bash
+cd MyApp.AppHost
+azd init
+```
+
+`azd init` detects your Aspire AppHost and scaffolds the necessary Azure configuration (`azure.yaml`, Bicep templates under `infra/`) automatically, based on what your AppHost defines - services, databases, and their relationships all carry over from the same model you use locally.
+
+```bash
+azd up
+```
+
+This single command provisions the necessary Azure resources (a Container Apps environment, any databases your AppHost references, networking) and deploys your services - the entire workflow from provisioning through deployment in one coherent path, which is `azd`'s specific value over assembling the same steps manually via Azure CLI.
+
+### Reviewing generated artifacts before deploying
+
+```bash
+aspire publish --output-path ./deploy-artifacts
+```
+
+This generates the deployment manifests without applying them, letting you review exactly what would be provisioned and deployed - worth doing at least once for a new application, so you understand what Aspire's tooling is actually generating on your behalf rather than treating it as an opaque black box.
+
+### Targeting Kubernetes instead of Azure Container Apps
+
+```bash
+aspire publish --publisher kubernetes --output-path ./k8s-manifests
+```
+
+Aspire's publisher model is extensible - Kubernetes manifests generated this way can then be applied with `kubectl` the same way any hand-written manifest would be, giving you Aspire's consistent local-to-cloud model without being tied to Azure specifically.
+
+### Customizing the generated output for non-default scenarios
+
+```csharp
+// In your AppHost's Program.cs
+var builder = DistributedApplication.CreateBuilder(args);
+
+var api = builder.AddProject<Projects.MyApp_Api>("api")
+    .WithHttpEndpoint(port: 8080)
+    .PublishAsAzureContainerApp((infra, app) =>
+    {
+        app.Template.Scale.MinReplicas = 1; // override default scale-to-zero behavior
+    });
+
+builder.Build().Run();
+```
+
+`PublishAsAzureContainerApp` (and equivalents for other targets) lets you customize the generated deployment configuration directly from the AppHost, keeping deployment-specific overrides in the same source-controlled model as everything else rather than hand-editing generated Bicep after the fact.
+
+## Core Workflow
+
+- **Use `aspire publish` to review generated artifacts before your first real deployment**, understanding what's actually being provisioned rather than trusting it blindly.
+- **Use `azd up` for the full Azure provision-and-deploy workflow**, and `aspire deploy` with a different publisher for non-Azure targets.
+- **Customize generated output from the AppHost itself** (via `PublishAsAzureContainerApp` and similar APIs) rather than hand-editing generated Bicep or manifests, which would drift out of sync on the next publish.
+
+## Verifying Your Setup
+
+1. **`azd init` correctly detects your AppHost's services and dependencies** - confirm the generated `azure.yaml` and Bicep templates reflect your actual application topology
+2. **`azd up` successfully provisions and deploys** - confirm all services and their dependencies (databases, caches) come up correctly in the target environment
+3. **Customizations via the AppHost persist across re-publishes** - confirm scale settings or other overrides configured in code survive a fresh `aspire publish`/`azd up` cycle
+4. **Non-Azure targets generate correctly, if used** - confirm `aspire publish --publisher kubernetes` (or your chosen alternative) produces manifests that apply cleanly
+
+## Best Practices
+
+**Review generated artifacts with `aspire publish` before your first production deployment.** Understanding what's actually being provisioned is worth the time, rather than trusting `azd up` to do the right thing without ever inspecting its output.
+
+**Make deployment-specific customizations in the AppHost itself**, using the publisher-specific configuration APIs, rather than hand-editing generated Bicep or Kubernetes manifests after the fact. Hand-edited output drifts out of sync the next time you publish.
+
+**Use `azd` specifically for Azure deployments**, since it has the deepest, most first-class Aspire integration of any target. For other clouds or platforms, `aspire publish` with the appropriate publisher gives you the artifacts, but the surrounding provisioning workflow is more manual.
+
+**Don't adopt Aspire's deploy workflow purely for its own sake if you're not already using Aspire for local development.** Its value is specifically in keeping local development and cloud deployment models consistent - if you're not using Aspire locally, there's less reason to adopt just its deployment tooling.
+
+**Remember this is a tooling layer, not a deployment target.** You still need to understand and choose the actual target underneath - Azure Container Apps, AKS, or another Kubernetes cluster - the same operational considerations documented in this series' guides for those specific platforms still apply.
+
+## Comparison with Manual Azure Container Apps Deployment
+
+| | Aspire Deploy Workflow (azd) | Manual Azure Container Apps (Azure CLI) |
+| --- | --- | --- |
+| Source of truth | The AppHost application model | Individual Azure CLI commands or Bicep files |
+| Multi-service coordination | Automatic, derived from AppHost | Manual, orchestrated yourself |
+| Local/cloud consistency | High - same model for both | Requires separate maintenance of each |
+| Flexibility | Extensible via publishers, but Azure-first | Full manual control |
+| Best fit | Teams already using Aspire locally | Teams wanting granular, manual control |
+
+The Aspire deploy workflow's real value is consistency between what you run locally and what gets deployed - for a single, simple service, manual Azure CLI deployment is perfectly reasonable and arguably simpler; the gap widens in Aspire's favor as service count grows.
+
+## Frequently Asked Questions
+
+### What's the difference between aspire publish and aspire deploy?
+
+`aspire publish` generates deployment artifacts (Bicep, Kubernetes manifests, Docker Compose) without applying them - useful for review or handing off to a separate pipeline. `aspire deploy` (or `azd up` for Azure specifically) generates and actually applies those artifacts, completing the deployment.
+
+### Do I need to use Azure to benefit from Aspire's deploy workflow?
+
+No - while `azd` has the deepest, most first-class integration and is Azure-specific, Aspire's publisher model is extensible to other targets, including generating Kubernetes manifests or Docker Compose files usable with any Kubernetes cluster or Docker environment.
+
+### How do I customize the deployment configuration Aspire generates?
+
+Use target-specific configuration APIs directly in your AppHost's `Program.cs`, such as `PublishAsAzureContainerApp(...)` for Azure Container Apps targets, rather than hand-editing the generated Bicep or manifests afterward. Customizations made in the AppHost persist across future publishes; hand-edited generated files don't.
+
+### Is Aspire's deploy workflow a replacement for understanding Azure Container Apps or Kubernetes?
+
+No - it's a consistency and automation layer on top of whichever target you choose, not a replacement for understanding that target's actual operational characteristics. The concepts covered in this series' Azure Container Apps and Docker + Kubernetes guides still apply to whatever Aspire ultimately deploys to.
+
+### Should I adopt Aspire's deploy workflow if I'm not using Aspire for local development?
+
+Probably not as your primary motivation - its value is specifically in keeping local development and cloud deployment models consistent. If you're not already using Aspire locally, adopting it purely for deployment tooling is less compelling than a more direct deployment path to your chosen target.
+
+### What happens if I need a deployment target Aspire doesn't have a built-in publisher for?
+
+Aspire's publisher model is extensible, meaning custom publishers can be built for targets without first-class support. This is more involved than using an existing publisher, but it means you're not fundamentally locked out of a target just because Aspire doesn't ship default support for it.
+
+### What's the most common mistake when using Aspire's deploy workflow?
+
+Hand-editing generated Bicep or Kubernetes manifests directly instead of making customizations through the AppHost's configuration APIs, causing those changes to be lost or drift out of sync on the next publish. The second common mistake is treating the deploy workflow as a full deployment platform rather than understanding it's a tooling layer sitting on top of an actual target you still need to operationally understand.


### PR DESCRIPTION
## Summary

- Schedules and drafts the .NET Deployment Options Tuesday track (April-May 2028), continuing the weekly Tuesday cadence from the CI/CD Platforms for .NET track
- Six posts: an anchor comparison post (`Top 5 Ways to Deploy .NET Apps Compared`) plus getting-started guides for Azure Container Apps, AWS ECS/Fargate, Docker + Kubernetes, IIS, and .NET Aspire's 9.2+ deploy workflow
- `editorial-plan.md` updated: series moved from Backlog into a new dated section, all 6 entries marked `Status: draft`

## Test plan

- [x] `npm run deploy` builds all posts (including this track's 6 new files) without error
- [x] `node scripts/a11y-check.js` (axe-core, WCAG 2.1 A/AA, light + dark) reports zero violations across home/post/about/privacy/terms/404
- [x] Verified each getting-started post cross-links back to the anchor comparison post
- [x] Verified each post's built `_site/posts/.../index.html` exists
- [x] `editorial-plan.md` CRLF line endings preserved (verified via `file` and byte-count check)


---
_Generated by [Claude Code](https://claude.ai/code/session_01WKyNF7L5qzrfct8cec6A32)_