### PR TITLE
Add Auth & Identity for .NET Tuesday track (May-June 2028)

### DIFF
--- a/editorial-plan.md
+++ b/editorial-plan.md
@@ -1418,17 +1418,69 @@ Six posts on how a .NET application actually reaches production, picking up the 
 
 ---
 
+## 📅 Tuesday Track - Auth & Identity for .NET (May-June 2028)
+
+Six posts on how .NET applications handle authentication and identity, picking up the Tuesday cadence directly from the .NET Deployment Options track. A comparison post anchors the track and each of the five follow-ups is a complete setup for one auth/identity solution.
+
+### The Top 5 Auth & Identity Solutions for .NET Compared: Which One Should You Choose?
+- **Status:** `draft`
+- **Scheduled:** 2028-05-23
+- **Source:** `docs/article-ideas/top-5-auth-identity-solutions-dotnet-compared.md`
+- **File:** `src/posts/2028-05-23-top-5-auth-identity-solutions-dotnet-compared.md`
+- **Pitch:** Duende IdentityServer - the direct successor to the free, widely-loved IdentityServer4 - now requires a commercial license for production use above a revenue threshold, the same commercial-shift pattern the mapping and mocking tracks both hit.
+- **Angle:** Compares the five across three genuinely different categories - an embedded user-management library, self-hosted protocol servers you operate yourself, and fully managed identity platforms you configure rather than run - framing the decision as how much of the identity stack you want to own, not a feature checklist. Names OpenIddict as the free, .NET-native alternative that rose directly out of Duende's licensing change, and closes on the common pattern of pairing ASP.NET Core Identity with a protocol framework rather than treating the five as strictly mutually exclusive.
+- **Tags:** `dotnet`, `security`, `identity`, `oidc`, `architecture`
+
+### Getting Started with ASP.NET Core Identity
+- **Status:** `draft`
+- **Scheduled:** 2028-05-30
+- **Source:** `docs/article-ideas/getting-started-with-aspnet-core-identity.md`
+- **File:** `src/posts/2028-05-30-getting-started-with-aspnet-core-identity.md`
+- **Pitch:** Scaffolding gets a working login page in minutes, which is exactly why it's easy to stop there and miss the configuration that actually matters: password and lockout policies tuned to real risk tolerance, email confirmation wired to a real sender, and knowing when Identity alone has been outgrown.
+- **Angle:** Covers tuning password/lockout policy away from generic scaffolded defaults, replacing the default `IEmailSender` stub (which silently does nothing) with a real provider, adding `AddRoles<IdentityRole>()` for role-based authorization, and claims-based policies for anything more granular than a fixed role list. Direct that the moment SSO, external API tokens, or third-party federation are needed, that's the signal to pair Identity with a protocol framework rather than stretch it further.
+- **Tags:** `dotnet`, `security`, `identity`, `aspnet-core`
+
+### Getting Started with Microsoft Entra External ID for .NET
+- **Status:** `draft`
+- **Scheduled:** 2028-06-06
+- **Source:** `docs/article-ideas/getting-started-with-entra-external-id.md`
+- **File:** `src/posts/2028-06-06-getting-started-with-entra-external-id.md`
+- **Pitch:** The newest name in this track's comparison - Microsoft's current, officially recommended replacement for Azure AD B2C - which means double-checking any setup step against Microsoft's own docs before production, since this is an actively evolving product rather than a long-settled one.
+- **Angle:** Covers tenant and app registration, `Microsoft.Identity.Web` as the same first-party library that's underpinned Azure AD and Azure AD B2C integration for years, admin-center-configured user flows for sign-up/sign-in behavior, and the still-maturing pattern for unifying consumer and B2B sign-in in one application. Honest that this is genuinely newer than Azure AD B2C with a smaller body of battle-tested guidance, and points to Microsoft's official migration path for existing B2C applications.
+- **Tags:** `dotnet`, `security`, `identity`, `azure`, `oidc`
+
+### Getting Started with Duende IdentityServer
+- **Status:** `draft`
+- **Scheduled:** 2028-06-13
+- **Source:** `docs/article-ideas/getting-started-with-duende-identityserver.md`
+- **File:** `src/posts/2028-06-13-getting-started-with-duende-identityserver.md`
+- **Pitch:** The first real decision happens before writing any code: is the organization actually under the community edition's revenue threshold, or does it need a commercial license - worth resolving explicitly rather than building an identity provider around an unconfirmed licensing assumption.
+- **Angle:** Covers clients and scopes as the foundational configuration vocabulary, pairing with ASP.NET Core Identity for the actual user store (Duende supplies no UI or user management of its own), deliberate token lifetime configuration, and the real, often-underestimated engineering cost of building login, registration, consent, and password-reset flows Duende doesn't ship turnkey. Recommends seriously evaluating OpenIddict or Keycloak before committing to a paid license unless there's a specific technical requirement only Duende meets.
+- **Tags:** `dotnet`, `security`, `identity`, `oidc`, `architecture`
+
+### Getting Started with Keycloak for .NET
+- **Status:** `draft`
+- **Scheduled:** 2028-06-20
+- **Source:** `docs/article-ideas/getting-started-with-keycloak-dotnet.md`
+- **File:** `src/posts/2028-06-20-getting-started-with-keycloak-dotnet.md`
+- **Pitch:** Free and standards-compliant enough that the .NET side is genuinely simple - the same generic `Microsoft.AspNetCore.Authentication.OpenIdConnect` middleware works with no Keycloak-specific SDK - while the real work lives in realms, clients, and operating a Java-based service as infrastructure regardless of how cleanly .NET talks to it.
+- **Angle:** Covers realms as Keycloak's top-level isolation boundary, standard OIDC middleware pointed at a realm-specific issuer URL, the `realm_access.roles` claim nesting that's a common source of silently-never-matching authorization policies, and never running `start-dev` mode in production. Frames Keycloak as the community's clear recommendation over a paid Duende license for cost-constrained teams with real infrastructure capacity, at the cost of operating a Java-based service.
+- **Tags:** `dotnet`, `security`, `identity`, `oidc`, `devops`
+
+### Getting Started with Auth0 for .NET
+- **Status:** `draft`
+- **Scheduled:** 2028-06-27
+- **Source:** `docs/article-ideas/getting-started-with-auth0-dotnet.md`
+- **File:** `src/posts/2028-06-27-getting-started-with-auth0-dotnet.md`
+- **Pitch:** The value proposition shows up in the first ten minutes - register an application, install one SDK package, working login without hand-writing an OAuth flow or standing up infrastructure - but the setup work that actually matters happens after that quick win.
+- **Angle:** Covers the `Auth0.AspNetCore.Authentication` SDK for web apps versus JWT Bearer authentication for APIs as two distinct integration patterns, `Audience` mismatches as the most common "token is valid but access is denied" cause, namespaced custom claims via Auth0 Actions since roles aren't included in tokens by default, and clearing both the local and Auth0 session on logout. Closes on monitoring usage-based pricing against tier boundaries as user base grows, rather than being surprised by cost later.
+- **Tags:** `dotnet`, `security`, `identity`, `oidc`, `tooling`
+
+---
+
 ## 📅 Backlog - Unscheduled Series
 
-Two six-post series remain unscheduled, drawn from the drafts in `docs/article-ideas/`. They continue the Tuesday cadence once the .NET Deployment Options series ends on 2028-05-16, and they're listed here in priority order. They're deliberately undated - that horizon is too far out to put honest dates against - so each series gets one entry rather than six speculative ones, and entries are expanded into individual dated posts when a series moves onto the calendar.
-
-### Auth & Identity for .NET (6 posts)
-- **Status:** `idea`
-- **Source:** `docs/article-ideas/top-5-auth-identity-solutions-dotnet-compared.md` + 5 getting-started drafts
-- **Series:** Top 5 comparison, then ASP.NET Core Identity, Microsoft Entra External ID, Duende IdentityServer, Keycloak, Auth0
-- **Pitch:** Duende IdentityServer - the direct successor to the free, widely-loved IdentityServer4 - now requires a commercial license for production use above a revenue threshold. That single change reshaped how .NET teams think about self-hosted identity, and this series runs into the same commercial-shift pattern the mapping and mocking series both hit.
-- **Angle:** Compares the five across three genuinely different categories: an embedded user-management library, self-hosted protocol servers you operate yourself, and fully managed identity platforms you configure rather than run. The decision isn't a feature checklist, it's how much of the identity stack you want to own - including uptime, scaling, and security patching, which is where self-hosting costs are usually underestimated. Names OpenIddict as the free, .NET-native alternative that rose directly out of Duende's licensing change, even though it isn't one of the five deep dives.
-- **Tags:** `dotnet`, `security`, `identity`, `oidc`, `architecture`
+One six-post series remains unscheduled, drawn from the drafts in `docs/article-ideas/`. It continues the Tuesday cadence once the Auth & Identity for .NET series ends on 2028-06-27. It's deliberately undated - that horizon is too far out to put honest dates against - so the series gets one entry rather than six speculative ones, expanded into individual dated posts when it moves onto the calendar.
 
 ### .NET IDEs & Editors (6 posts)
 - **Status:** `idea`

--- a/src/posts/2028-05-23-top-5-auth-identity-solutions-dotnet-compared.md
+++ b/src/posts/2028-05-23-top-5-auth-identity-solutions-dotnet-compared.md
@@ -1,0 +1,170 @@
+---
+author: Steve Kaschimer
+date: 2028-05-23
+image: /images/posts/2028-05-23-hero.webp
+image_alt: "Five columns of abstract identity glyphs positioned along a horizontal axis running from a single embedded library on the left to fully managed, hands-off identity platforms on the right."
+image_prompt: "A dark-mode technical editorial illustration on a near-black background with electric teal, amber, and off-white accents. Composition is five vertical columns of equal width separated by thin hairline rules, each column topped by a distinct abstract glyph rendered in flat geometry: a small padlock nested directly inside a rounded application-window outline implying an embedded library, a padlock connected by a thin line to a small building-shaped server icon implying a self-hosted framework you build around, a padlock floating cleanly inside a cloud outline implying a fully managed vendor platform, a padlock beside a small stacked-brick icon implying an open-source self-hosted server, and a padlock inside a cloud outline bearing a small four-pane window accent implying a Microsoft-ecosystem managed platform. Beneath the glyphs, a shared horizontal axis labeled in monospaced type runs from 'embedded library' on the left to 'fully managed' on the right, with a small glowing teal dot positioned at a different point under each column. Mood is comparative, security-conscious, and non-partisan. Avoid: vendor logos, brand colors, circuit-board textures, gears, or generic lock clip art as the dominant motif."
+layout: post.njk
+site_title: Tech Notes
+summary: "Duende IdentityServer - the direct successor to the free, widely-loved IdentityServer4 - now requires a commercial license for production use above a revenue threshold, the same commercial-shift pattern the mapping and mocking tracks both hit. A practical breakdown of five ways .NET applications handle authentication and identity."
+tags: ["dotnet", "security", "identity", "oidc", "architecture"]
+title: "The Top 5 Auth & Identity Solutions for .NET Compared: Which One Should You Choose?"
+---
+
+Authentication decisions in .NET have gone through the same pattern this whole series keeps running into: a widely-used free tool goes commercial, and the ecosystem scrambles to figure out what's next. Duende IdentityServer - the direct successor to the beloved, free IdentityServer4 - now requires a commercial license for production use above a revenue threshold. That single change reshaped how .NET teams think about self-hosted identity, and it's directly responsible for OpenIddict's rise as the free, .NET-native alternative worth knowing about even though it isn't one of this article's five named entries.
+
+This guide compares five ways .NET applications handle authentication and identity: ASP.NET Core Identity, Duende IdentityServer, Auth0, Keycloak, and Microsoft Entra External ID. They split into genuinely different categories worth understanding before comparing feature lists - ASP.NET Core Identity is a user-management library you embed directly in your app, Duende and Keycloak are protocol frameworks/servers you self-host, and Auth0 and Entra External ID are fully managed identity platforms you configure rather than operate. Picking between them is less about which has more checkboxes and more about how much of the identity stack you want to own. This series continues with dedicated getting-started walkthroughs for each solution.
+
+## Quick Comparison
+
+| | ASP.NET Core Identity | Duende IdentityServer | Auth0 | Keycloak | Microsoft Entra External ID |
+| --- | --- | --- | --- | --- | --- |
+| **Category** | Embedded user-management library | Self-hosted OIDC/OAuth framework | Managed identity platform | Self-hosted, full-featured IdP | Managed CIAM platform (Microsoft) |
+| **Hosting** | In-process with your app | You host it | Fully managed by Auth0 | You host it | Fully managed by Microsoft |
+| **Cost model** | Free | Free under a revenue threshold, commercial license above it | Usage-based, scales with MAUs | Free, open source | Usage-based, scales with MAUs |
+| **SSO across multiple apps** | No, without adding a protocol layer | Yes, that's its purpose | Yes | Yes | Yes |
+| **Operational burden** | Low - it's a library | High - you own uptime, scaling, security patching | None - Auth0 operates it | High - you own uptime, scaling, security patching | None - Microsoft operates it |
+| **Best for** | Single monolithic apps needing basic user accounts | .NET-native teams building their own IdP with specific requirements | B2C apps prioritizing developer experience and fast setup | Cost-constrained teams with infrastructure capacity | Microsoft/Azure-ecosystem teams wanting managed CIAM |
+
+## ASP.NET Core Identity
+
+ASP.NET Core Identity is the built-in, free membership system for storing user accounts, hashing passwords, managing roles, and handling flows like email confirmation - directly inside your application, with no separate service or protocol layer required.
+
+**Strengths:**
+
+- Free, built into the framework, with no separate infrastructure or service to operate
+- Handles the fundamentals well: password hashing, role management, email confirmation tokens, two-factor authentication support
+- The right, sufficient choice for a genuinely common scenario - a single monolithic web application that manages its own users and doesn't need to issue tokens to external consumers or provide SSO across multiple applications
+- Deep, native integration with the rest of ASP.NET Core, since it's designed as part of the same framework rather than bolted on
+
+**Weaknesses:**
+
+- Not designed for SSO across multiple applications, or issuing OAuth access tokens for APIs, without adding a protocol layer (commonly Duende, Keycloak, or OpenIddict) on top
+- No federation with external identity providers (Google, Microsoft, enterprise SAML/OIDC providers) without additional configuration and packages
+- Scales poorly as a standalone solution once requirements grow beyond "one app, its own users" - this is exactly the point where teams commonly pair it with a protocol framework rather than replace it
+
+**Choose this when:** you're building a single monolithic application (MVC or Razor Pages) that manages its own users, doesn't need to issue API tokens to external consumers, and doesn't require SSO across multiple applications or services.
+
+## Duende IdentityServer
+
+Duende IdentityServer is the commercial successor to the beloved, free IdentityServer4 - a comprehensive, standards-compliant OpenID Connect and OAuth 2.0 framework you embed into an ASP.NET Core application to build your own identity provider. It's a framework, not a turnkey product: you write the host, own the UI, and supply the user store (commonly ASP.NET Core Identity underneath it).
+
+**Strengths:**
+
+- Full, standards-compliant OIDC/OAuth 2.0 implementation with deep, native ASP.NET Core integration and a highly extensible architecture
+- Genuinely the right choice for organizations that need to build their own OAuth2/OIDC identity provider for internal or customer-facing applications, with specific technical requirements a managed platform can't meet
+- Built-in EF Core support for storing configuration and operational data, fitting naturally into an existing .NET data stack
+- A community edition exists for smaller companies under a revenue threshold, meaning it's not automatically a paid product for every team
+
+**Weaknesses:**
+
+- Requires a commercial license for production use above that revenue threshold - a real, ongoing cost that didn't exist with IdentityServer4, and the change that pushed a meaningful share of the ecosystem toward alternatives
+- Not turnkey - no built-in user management UI, no pre-built registration or password-reset flows, no pre-built integrations with enterprise identity providers; you're building the scaffolding around the protocol core yourself
+- Steep learning curve, requiring real understanding of OAuth flows, token types, grant types, and OIDC specifications before you can use it correctly
+- Self-hosted, meaning full operational overhead - deployment, scaling, monitoring, backup, and disaster recovery are all your responsibility, on top of the licensing cost
+
+**Choose this when:** you have specific technical requirements that push you toward building your own .NET-native identity provider, and either fall under the community edition's revenue threshold or the commercial license is a reasonable cost against those requirements - otherwise, Keycloak or OpenIddict are worth serious comparison first.
+
+## Auth0
+
+Auth0 is a fully managed identity platform - authentication, user management, MFA, social login, and enterprise federation, all operated by Auth0 rather than you. It's consistently cited as having the best documentation and fastest path to working authentication of any option in this comparison.
+
+**Strengths:**
+
+- Genuinely the best developer experience and fastest time-to-working-auth among managed platforms, with documentation that's widely regarded as best-in-class
+- Zero operational burden - Auth0 handles security patching, uptime, MFA implementation, and compliance certifications, letting your team focus entirely on your application
+- Broad, mature support for social login, enterprise SSO, and a wide range of pre-built integrations, reducing custom implementation work significantly
+- A strong default choice specifically for B2C or consumer-facing applications where getting to market quickly matters more than owning every layer of the identity stack
+
+**Weaknesses:**
+
+- Usage-based pricing that scales with monthly active users - a real, growing cost as your application succeeds, unlike the fixed infrastructure cost of a self-hosted option
+- Dependency on a third-party vendor's availability, pricing decisions, and roadmap - a genuine trade-off against the control a self-hosted identity provider gives you
+- Less natural fit if your organization is already deeply invested in a different cloud ecosystem (Azure specifically), where Entra External ID may integrate more seamlessly
+
+**Choose this when:** you're building a B2C or consumer-facing application, developer experience and speed to market are priorities, and your budget comfortably accommodates usage-based pricing that scales with your user base.
+
+## Keycloak
+
+Keycloak, from Red Hat, is a robust, fully open-source identity provider with a Java-based backend, offering OIDC, SAML, and LDAP support - the most complete free, self-hosted option in this comparison, and increasingly the community's recommended first stop for cost-constrained teams needing real infrastructure capacity.
+
+**Strengths:**
+
+- Free and genuinely production-ready, with mature enterprise features (SAML, LDAP, fine-grained authorization) that go beyond what OIDC-only alternatives offer
+- No per-user licensing cost and no revenue-threshold licensing cliff the way Duende has - cost stays fixed to infrastructure regardless of user count
+- The community consensus is clear: given Keycloak is free and production-ready, choosing a commercially-licensed alternative like Duende means either specific technical requirements Keycloak doesn't meet, or a preference for staying entirely within the .NET stack
+- Complete control over user data and infrastructure, appealing to teams with data residency or compliance requirements a managed platform can't satisfy
+
+**Weaknesses:**
+
+- Real operational overhead - you own deployment, scaling, monitoring, backup, and disaster recovery, the same infrastructure responsibility as Duende or any self-hosted option
+- A Java-based backend, which is a genuine mismatch for a purely .NET team's operational expertise and tooling, even though the OIDC/OAuth protocol layer works identically regardless of implementation language
+- Deep protocol customization is more complex here than in a .NET-native framework like Duende or OpenIddict, since you're working within Keycloak's own extension model rather than directly in familiar ASP.NET Core code
+
+**Choose this when:** you're cost-constrained but have real infrastructure capacity and operational expertise, need Keycloak's more complete enterprise feature set (SAML, LDAP) beyond pure OIDC, or need full control over user data that a managed platform can't provide.
+
+## Microsoft Entra External ID
+
+Microsoft Entra External ID is Microsoft's current, recommended customer identity and access management (CIAM) platform for new ASP.NET Core applications - explicitly positioned as the successor to Azure AD B2C, supporting both consumer authentication and B2B collaboration in a single product.
+
+**Strengths:**
+
+- The officially recommended path for new ASP.NET Core applications needing managed CIAM, per Microsoft's own current documentation - Azure AD B2C remains supported for existing applications but isn't the recommended starting point for new ones
+- Fully managed, with Microsoft operating security, scaling, and availability - the same zero-operational-burden value proposition Auth0 offers, specifically within the Microsoft ecosystem
+- Genuinely broader scope than its B2C predecessor - supports both consumer-facing authentication and B2B collaboration scenarios in the same product, useful for applications serving both external customers and internal or partner organization users
+- Deep, natural integration with the rest of Microsoft Entra ID and the broader Azure ecosystem, appealing to teams already operating there
+
+**Weaknesses:**
+
+- Newer than Azure AD B2C, meaning a smaller body of community examples and battle-tested guidance compared to the more established predecessor, though this gap is closing as Microsoft's own documentation continues to be updated
+- Some real-world scenarios - like unifying internal workforce sign-in with external customer sign-in in a single seamless flow - still require careful architecture decisions and aren't fully turnkey
+- Usage-based pricing that scales with active users, the same cost trade-off Auth0 carries relative to self-hosted options
+- Community sentiment on Azure AD B2C specifically (the predecessor) has historically flagged real configuration complexity and a learning curve worth being aware of, even as Entra External ID aims to improve on it
+
+**Choose this when:** you're building a new ASP.NET Core application needing managed CIAM, are already invested in the Microsoft/Azure ecosystem, or need to support both external customers and B2B/partner organization users within a single platform.
+
+## How to Decide
+
+A few heuristics that cover most real-world decisions:
+
+**Single monolithic app, managing its own users, no SSO or external API tokens needed?** ASP.NET Core Identity alone is genuinely sufficient - don't add a protocol layer or managed service you don't need yet.
+
+**Need SSO or API token issuance and want to stay .NET-native, with specific technical requirements a managed platform can't meet?** Duende IdentityServer is purpose-built for this, but confirm whether you fall under its community edition's revenue threshold, and seriously evaluate OpenIddict (the free, .NET-native alternative that emerged specifically in response to Duende's licensing) before committing to a paid license.
+
+**Cost-constrained but have real infrastructure and operational capacity?** Keycloak is free, production-ready, and the community's clear recommendation over a paid Duende license for teams in this position.
+
+**Building B2C/consumer-facing, want the best developer experience and fastest path to working auth, budget allows?** Auth0 remains the standard recommendation here.
+
+**Already deep in the Microsoft/Azure ecosystem, need managed CIAM for a new application?** Microsoft Entra External ID is Microsoft's own current recommended path, particularly if you also need to support B2B/partner scenarios alongside consumer authentication.
+
+A pattern worth knowing across several of these: ASP.NET Core Identity is frequently paired with a protocol framework rather than replaced by one - Identity handles user storage, password hashing, and account management, while Duende, Keycloak, or OpenIddict sits on top handling the OIDC/OAuth protocol layer. This combination shows up often enough that it's worth considering directly rather than treating the five options here as mutually exclusive.
+
+## Frequently Asked Questions
+
+### Is ASP.NET Core Identity enough for my application, or do I need something more?
+
+It's genuinely sufficient if you're building a single monolithic application that manages its own users, doesn't need to issue OAuth tokens to external API consumers, and doesn't require single sign-on across multiple applications. The moment any of those three things becomes true, you need a protocol layer (Duende, Keycloak, OpenIddict) on top of or instead of Identity alone.
+
+### Why did Duende IdentityServer become a paid product?
+
+Duende IdentityServer is the commercial successor to the free, open-source IdentityServer4. The maintainers transitioned to a commercial licensing model requiring payment for production use above a revenue threshold, which is what prompted a meaningful share of the .NET community to evaluate free alternatives like Keycloak and OpenIddict rather than accepting the new licensing terms by default.
+
+### What's OpenIddict, and why does it come up in Duende comparisons?
+
+OpenIddict is a free, .NET-native OIDC/OAuth framework that emerged as a direct response to Duende's commercial licensing - it handles the protocol layer (token issuance, validation, introspection, revocation) with tight ASP.NET Core integration and EF Core support, at zero licensing cost. It's not one of this article's five named solutions, but it's genuinely relevant to anyone evaluating Duende specifically for licensing reasons, since it fills a similar .NET-native niche without the commercial cost.
+
+### Should I choose a self-hosted or a managed identity solution?
+
+It depends on your operational capacity and priorities. Managed platforms (Auth0, Entra External ID) eliminate security patching, scaling, and availability concerns at the cost of usage-based pricing and vendor dependency. Self-hosted options (Duende, Keycloak) give you complete control and, for Keycloak specifically, no per-user cost, at the cost of owning deployment, scaling, monitoring, and disaster recovery yourself.
+
+### Is Keycloak a good fit for a purely .NET team?
+
+It's a reasonable choice specifically when cost matters more than staying entirely within the .NET stack - Keycloak's Java-based backend is a genuine operational mismatch for a purely .NET team's tooling and expertise, even though the OIDC/OAuth protocol it exposes works identically regardless of implementation language. If staying .NET-native matters more than avoiding licensing cost, Duende (if within budget) or OpenIddict are more natural fits.
+
+### What's the difference between Azure AD B2C and Microsoft Entra External ID?
+
+Microsoft Entra External ID is Microsoft's current, officially recommended CIAM platform for new ASP.NET Core applications, explicitly positioned as the successor to Azure AD B2C with broader scope - supporting both consumer authentication and B2B collaboration in one product. Azure AD B2C remains supported for existing applications, but Microsoft's own documentation directs new projects toward Entra External ID instead.
+
+### Can I combine ASP.NET Core Identity with one of the other four options?
+
+Yes, and it's a common, well-supported architecture - ASP.NET Core Identity handles the user-management layer (storing accounts, hashing passwords, managing roles), while a protocol framework like Duende IdentityServer or OpenIddict sits on top handling OIDC/OAuth flows and token issuance. This lets you keep Identity's familiar user-management model while adding the SSO and API token capabilities it doesn't provide alone.

--- a/src/posts/2028-05-30-getting-started-with-aspnet-core-identity.md
+++ b/src/posts/2028-05-30-getting-started-with-aspnet-core-identity.md
@@ -1,0 +1,178 @@
+---
+author: Steve Kaschimer
+date: 2028-05-30
+image: /images/posts/2028-05-30-hero.webp
+image_alt: "A padlock glyph nested directly inside a rounded application-window outline with no external connections, implying a user-management library embedded inside a single application rather than a separate service."
+image_prompt: "A dark-mode technical editorial illustration on a near-black background with electric teal, amber, and off-white accents. Composition centers on a single padlock glyph nested directly inside a rounded rectangle application-window outline, with no lines or shapes extending beyond the window's edge, implying a self-contained library embedded in one application rather than a separate service. A small amber envelope icon sits faintly outside the window, disconnected, implying an unsent confirmation email. Mood is contained, foundational, and quietly cautionary. Avoid: vendor logos, brand colors, circuit-board textures, gears, or generic lock clip art as the dominant motif."
+layout: post.njk
+site_title: Tech Notes
+summary: "ASP.NET Core Identity's scaffolding gets you a working login page in minutes, which is exactly why it's easy to miss the configuration that actually matters. A setup guide for password/lockout policy, wiring up a real email sender, and roles vs. claims-based authorization."
+tags: ["dotnet", "security", "identity", "aspnet-core"]
+title: "Getting Started with ASP.NET Core Identity"
+---
+
+ASP.NET Core Identity's scaffolding gets you a working login page in minutes, which is exactly why it's easy to stop there and miss the configuration that actually matters for a real application: password and lockout policies tuned to your actual risk tolerance, email confirmation wired to a real sender, and a clear-eyed sense of when you've outgrown what Identity alone can do. None of these show up as errors if you skip them - they show up as security gaps or awkward workarounds months later.
+
+This guide covers installing and scaffolding ASP.NET Core Identity, bootstrapping the configuration that matters beyond the defaults, the core patterns for roles and claims-based authorization, and the best practices - including recognizing the point where you need to pair Identity with a protocol framework rather than stretch it further. By the end you'll have a genuinely production-ready user management layer, not just a working demo.
+
+If you're deciding between auth/identity solutions first, [a comparison of the top auth and identity solutions for .NET](/posts/2028-05-23-top-5-auth-identity-solutions-dotnet-compared/) covers where ASP.NET Core Identity fits relative to Duende IdentityServer, Auth0, Keycloak, and Microsoft Entra External ID.
+
+## What You'll Need
+
+- .NET 8 SDK or later
+- A database for user storage - SQL Server is the default via EF Core, though any EF Core-supported provider works
+
+## Installing and Scaffolding
+
+```bash
+dotnet new webapp -n MyApp -au Individual
+```
+
+The `-au Individual` flag scaffolds a new project with ASP.NET Core Identity already wired in - registration, login, and account management pages included. For adding Identity to an existing project instead:
+
+```bash
+dotnet add package Microsoft.AspNetCore.Identity.EntityFrameworkCore
+dotnet add package Microsoft.EntityFrameworkCore.SqlServer
+dotnet tool install --global dotnet-aspnet-codegenerator
+dotnet aspnet-codegenerator identity -dc MyApp.Data.ApplicationDbContext
+```
+
+## Bootstrapping the Ideal Environment
+
+### Configure password and lockout policies deliberately
+
+```csharp
+var builder = WebApplication.CreateBuilder(args);
+
+builder.Services.AddDefaultIdentity<IdentityUser>(options =>
+{
+    options.Password.RequiredLength = 12;
+    options.Password.RequireNonAlphanumeric = true;
+    options.Password.RequireUppercase = true;
+
+    options.Lockout.MaxFailedAccessAttempts = 5;
+    options.Lockout.DefaultLockoutTimeSpan = TimeSpan.FromMinutes(15);
+
+    options.SignIn.RequireConfirmedEmail = true;
+})
+.AddEntityFrameworkStores<ApplicationDbContext>();
+```
+
+The scaffolded defaults are reasonable but generic - review password length, lockout thresholds, and whether email confirmation should be required before your first real user signs up, rather than accepting whatever the template chose.
+
+### Wire up a real email sender for confirmation and password reset
+
+```csharp
+public class EmailSender(IConfiguration config) : IEmailSender
+{
+    public async Task SendEmailAsync(string email, string subject, string htmlMessage)
+    {
+        // Integrate with a real provider (SendGrid, Azure Communication Services, etc.)
+        // The scaffolded template's default IEmailSender does nothing -- it's a stub
+    }
+}
+```
+
+```csharp
+builder.Services.AddTransient<IEmailSender, EmailSender>();
+```
+
+The default scaffolded `IEmailSender` implementation is a no-op stub - email confirmation and password reset links are generated correctly, but never actually sent, unless you implement this yourself against a real provider.
+
+### Add roles
+
+```csharp
+builder.Services.AddDefaultIdentity<IdentityUser>(options => { /* ... */ })
+    .AddRoles<IdentityRole>()
+    .AddEntityFrameworkStores<ApplicationDbContext>();
+```
+
+```csharp
+[Authorize(Roles = "Admin")]
+public class AdminController : Controller { }
+```
+
+`AddRoles<IdentityRole>()` isn't included by the default scaffolding - add it explicitly if your application needs role-based authorization beyond simple authenticated/not-authenticated checks.
+
+### Use claims for more granular authorization than roles alone provide
+
+```csharp
+var claims = new List<Claim> { new(ClaimTypes.Email, user.Email!), new("department", "engineering") };
+await userManager.AddClaimsAsync(user, claims);
+```
+
+```csharp
+builder.Services.AddAuthorization(options =>
+{
+    options.AddPolicy("EngineeringOnly", policy =>
+        policy.RequireClaim("department", "engineering"));
+});
+```
+
+Claims-based policies handle authorization scenarios roles alone can't express cleanly - attribute-based access (department, subscription tier, feature flags) rather than a fixed set of named roles.
+
+## Core Workflow
+
+- **Review and tune every default configuration option before your first real deployment**, not just the ones that produce an obvious error if wrong.
+- **Implement a real `IEmailSender`** before assuming email confirmation or password reset actually works - the scaffolded stub silently does nothing.
+- **Use roles for coarse-grained authorization and claims for anything more granular**, rather than trying to encode fine details into an ever-growing list of role names.
+
+## Verifying Your Setup
+
+1. **Password and lockout policies match your intended security posture** - confirm the configured values, not the scaffolded defaults, are actually what's enforced
+2. **Email confirmation and password reset emails are actually delivered** - confirm your real `IEmailSender` implementation works against your chosen provider, not just that the stub compiles
+3. **Role-based authorization correctly restricts access** - confirm `[Authorize(Roles = "Admin")]` actually blocks non-admin users
+4. **Claims-based policies evaluate correctly** - confirm a policy requiring a specific claim value correctly allows and denies access as expected
+
+## Best Practices
+
+**Never leave the default scaffolded `IEmailSender` stub in a production application.** It silently does nothing - confirming email delivery actually works before launch is not optional if your flows depend on it.
+
+**Tune password and lockout policies to your actual risk tolerance**, rather than accepting scaffolded defaults uncritically. The right values depend on your application's specific threat model.
+
+**Recognize the point where Identity alone isn't enough.** The moment you need SSO across multiple applications, need to issue OAuth access tokens for an API, or need federation with external identity providers, that's the signal to pair Identity with a protocol framework (Duende, Keycloak, OpenIddict) rather than trying to stretch Identity to cover those needs itself.
+
+**Use claims for genuinely granular authorization**, reserving roles for broad, stable categories of user. Mixing fine-grained permission logic into an ever-growing list of role names becomes unwieldy fast.
+
+**Keep the Identity database schema under migration control the same as any other EF Core-managed schema.** It's ordinary EF Core underneath the scaffolding - treat it with the same discipline as the rest of your data model.
+
+## Comparison with Duende IdentityServer
+
+| | ASP.NET Core Identity | Duende IdentityServer |
+| --- | --- | --- |
+| Scope | User storage, password management, roles | Full OIDC/OAuth protocol layer, SSO, API tokens |
+| SSO across apps | No, without an added protocol layer | Yes, that's its core purpose |
+| Cost | Free | Free under a revenue threshold, commercial above it |
+| Setup complexity | Low - scaffolded, works immediately | High - you build the host, UI, and token logic |
+
+They're frequently used together rather than as alternatives - Identity handles the user-management layer, Duende (or another protocol framework) sits on top handling OIDC/OAuth flows, SSO, and token issuance that Identity alone doesn't provide.
+
+## Frequently Asked Questions
+
+### Does ASP.NET Core Identity support single sign-on across multiple applications?
+
+Not on its own - it's designed for a single application managing its own users. SSO across multiple applications requires adding a protocol layer (Duende IdentityServer, Keycloak, or OpenIddict) that issues and validates tokens across applications, commonly using ASP.NET Core Identity underneath as the actual user store.
+
+### Why isn't my email confirmation or password reset email being sent?
+
+The default scaffolded `IEmailSender` implementation is a stub that does nothing - it generates the confirmation link correctly but never actually sends an email. You need to implement `IEmailSender` yourself against a real provider (SendGrid, Azure Communication Services, or similar) before these flows work in practice.
+
+### What's the difference between roles and claims in ASP.NET Core Identity?
+
+Roles are a named, typically coarse-grained categorization of users (Admin, Member) checked via `[Authorize(Roles = "...")]`. Claims are more granular, arbitrary key-value pairs attached to a user (department, subscription tier) checked via authorization policies. Use roles for broad, stable categories and claims for anything requiring finer-grained or more dynamic authorization logic.
+
+### Can ASP.NET Core Identity issue OAuth access tokens for an API?
+
+Not natively - Identity handles user accounts and cookie-based authentication for the application it's embedded in, not OAuth token issuance for external API consumers. That requires a protocol framework like Duende IdentityServer or OpenIddict layered on top.
+
+### How do I customize the scaffolded Identity UI?
+
+The scaffolded pages (login, registration, account management) are Razor Pages you can override by scaffolding them explicitly into your project (`dotnet aspnet-codegenerator identity`) and then editing the generated files directly, rather than being limited to the default UI that ships hidden inside the Identity package.
+
+### Is ASP.NET Core Identity secure by default?
+
+The core mechanisms (password hashing, lockout, anti-forgery tokens) are solid and secure by design, but several important behaviors - like actually requiring confirmed email before sign-in, or having sensible password/lockout policies - need to be explicitly configured rather than assumed from scaffolded defaults. Review your configuration deliberately rather than trusting the template's choices are automatically appropriate for your application.
+
+### What's the most common mistake in a first ASP.NET Core Identity setup?
+
+Leaving the default `IEmailSender` stub in place and assuming email confirmation or password reset works, when it silently does nothing until a real implementation is added. The second common mistake is trying to stretch Identity to cover SSO or API token issuance instead of recognizing that's the signal to add a protocol framework on top.

--- a/src/posts/2028-06-06-getting-started-with-entra-external-id.md
+++ b/src/posts/2028-06-06-getting-started-with-entra-external-id.md
@@ -1,0 +1,176 @@
+---
+author: Steve Kaschimer
+date: 2028-06-06
+image: /images/posts/2028-06-06-hero.webp
+image_alt: "A padlock glyph floating inside a cloud outline with a small four-pane window accent beside it, implying a fully managed identity platform tied specifically to the Microsoft ecosystem."
+image_prompt: "A dark-mode technical editorial illustration on a near-black background with electric teal, amber, and off-white accents. Composition centers on a single padlock glyph floating cleanly inside a soft cloud outline, with a small four-pane window accent positioned just beside the cloud's edge, implying a fully managed platform tied specifically to the Microsoft ecosystem. A faint amber under-construction diagonal stripe pattern sits subtly along the cloud's lower edge, implying a still-maturing product. Mood is managed, evolving, and ecosystem-native. Avoid: vendor logos, brand colors, circuit-board textures, gears, or generic lock clip art as the dominant motif."
+layout: post.njk
+site_title: Tech Notes
+summary: "The newest name in this track's comparison - Microsoft's current, officially recommended replacement for Azure AD B2C - which means double-checking any setup step against Microsoft's own docs before production. A setup guide for Microsoft.Identity.Web, user flows, and consumer/B2B scenarios."
+tags: ["dotnet", "security", "identity", "azure", "oidc"]
+title: "Getting Started with Microsoft Entra External ID for .NET"
+---
+
+Microsoft Entra External ID is genuinely the newest name in this entire series' auth comparison - Microsoft's current, officially recommended replacement for Azure AD B2C - which means the setup steps below are worth double-checking against Microsoft's own documentation before a production deployment, since this is an actively evolving product rather than a long-settled one. What's already clear is the integration path: `Microsoft.Identity.Web` remains the library ASP.NET Core applications use, the same package that's underpinned Azure AD and Azure AD B2C integration for years.
+
+This guide covers registering an application with Microsoft Entra External ID, bootstrapping authentication in an ASP.NET Core application using `Microsoft.Identity.Web`, the core patterns for consumer and B2B scenarios, and the best practices for a product that's still actively maturing. By the end you'll have working authentication integrated with Microsoft's current recommended CIAM platform.
+
+If you're deciding between auth/identity solutions first, [a comparison of the top auth and identity solutions for .NET](/posts/2028-05-23-top-5-auth-identity-solutions-dotnet-compared/) covers where Microsoft Entra External ID fits relative to ASP.NET Core Identity, Duende IdentityServer, Auth0, and Keycloak.
+
+## What You'll Need
+
+- An Azure subscription and a Microsoft Entra External ID tenant (created via the Azure portal)
+- .NET 8 SDK or later
+- An ASP.NET Core application
+
+## Setting Up Your Tenant and App Registration
+
+In the Azure portal: create a Microsoft Entra External ID tenant if you don't already have one, then register your application under **App registrations → New registration**, noting the **Application (client) ID**, **Directory (tenant) ID**, and configuring a **Redirect URI** matching your application's callback endpoint.
+
+## Installing and Bootstrapping
+
+```bash
+dotnet add package Microsoft.Identity.Web
+dotnet add package Microsoft.Identity.Web.UI
+```
+
+```csharp
+var builder = WebApplication.CreateBuilder(args);
+
+builder.Services.AddAuthentication(OpenIdConnectDefaults.AuthenticationScheme)
+    .AddMicrosoftIdentityWebApp(builder.Configuration.GetSection("EntraExternalId"));
+
+builder.Services.AddControllersWithViews()
+    .AddMicrosoftIdentityUI();
+
+var app = builder.Build();
+app.UseAuthentication();
+app.UseAuthorization();
+```
+
+```json
+// appsettings.json
+{
+  "EntraExternalId": {
+    "Instance": "https://myapp.ciamlogin.com/",
+    "ClientId": "<your-client-id>",
+    "TenantId": "<your-tenant-id>",
+    "CallbackPath": "/signin-oidc"
+  }
+}
+```
+
+`Microsoft.Identity.Web` handles the OIDC flow, token acquisition, and cookie management - the same library and pattern used for Azure AD and Azure AD B2C integration, extended to support Entra External ID's configuration model.
+
+## Bootstrapping the Ideal Environment
+
+### Protect controllers and pages
+
+```csharp
+[Authorize]
+public class ProfileController : Controller
+{
+    public IActionResult Index() => View();
+}
+```
+
+```csharp
+// Or for Razor Pages
+builder.Services.AddRazorPages()
+    .AddMicrosoftIdentityUI();
+```
+
+### Configure user flows for sign-up and sign-in
+
+In the Entra admin center, configure user flows defining what happens during sign-up and sign-in - which identity providers are available (local accounts, social providers), what user attributes are collected, and branding for the experience. This is conceptually similar to Auth0's dashboard-configured flows or Keycloak's realm settings, expressed through Microsoft's own admin experience.
+
+### Handle both consumer and B2B scenarios
+
+```csharp
+builder.Services.AddAuthentication(OpenIdConnectDefaults.AuthenticationScheme)
+    .AddMicrosoftIdentityWebApp(options =>
+    {
+        builder.Configuration.GetSection("EntraExternalId").Bind(options);
+        options.SignInScheme = CookieAuthenticationDefaults.AuthenticationScheme;
+    });
+```
+
+If your application needs to serve both external customers and internal/partner organization users, review Microsoft's current guidance carefully - this is one of the scenarios where Entra External ID's broader scope over its Azure AD B2C predecessor matters, but the exact configuration pattern for unifying both flows cleanly is still an area worth checking against the latest documentation rather than assuming a settled best practice.
+
+### Secure a Web API validating Entra External ID tokens
+
+```bash
+dotnet add package Microsoft.Identity.Web
+```
+
+```csharp
+builder.Services.AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
+    .AddMicrosoftIdentityWebApi(builder.Configuration.GetSection("EntraExternalId"));
+```
+
+## Core Workflow
+
+- **Use `Microsoft.Identity.Web` consistently for both web app and API scenarios**, since it's the maintained, first-party library across Microsoft's identity platform generally, not just Entra External ID specifically.
+- **Configure user flows in the admin center to define sign-up/sign-in behavior**, rather than trying to implement that logic in application code.
+- **Check current Microsoft documentation before finalizing configuration**, given how actively this specific product is still evolving relative to more settled options in this comparison.
+
+## Verifying Your Setup
+
+1. **Sign-up and sign-in flows work correctly end to end** - confirm a new user can complete a user flow and an existing user can sign back in
+2. **Redirect URIs are correctly configured for every environment** - confirm your app registration's redirect URIs match actual deployed URLs, not just localhost
+3. **API token validation works correctly** - confirm `AddMicrosoftIdentityWebApi` correctly validates tokens issued for your registered application
+4. **Both consumer and B2B flows work as intended, if both are in use** - confirm the specific pattern you implemented for unifying (or separating) these flows behaves as expected
+
+## Best Practices
+
+**Check current Microsoft documentation before a production deployment**, given this product's relative newness and continued active development. Configuration patterns and recommended approaches may have evolved since any specific guide (including this one) was written.
+
+**Use `Microsoft.Identity.Web` rather than raw OIDC middleware.** It's Microsoft's maintained, first-party integration library specifically designed for their identity platform, handling nuances the generic middleware doesn't account for.
+
+**Configure user flows deliberately in the admin center**, rather than trying to replicate sign-up/sign-in logic in application code - this is the intended configuration surface for that behavior.
+
+**If migrating from Azure AD B2C, follow Microsoft's official migration guidance closely**, since this is a real, documented migration path (not a from-scratch reimplementation), including specific guidance on password migration strategies.
+
+**Evaluate whether your organization's existing Azure/Microsoft investment justifies this choice over a more platform-neutral option like Auth0.** Entra External ID's strongest case is specifically for teams already operating in that ecosystem.
+
+## Comparison with Auth0
+
+| | Microsoft Entra External ID | Auth0 |
+| --- | --- | --- |
+| Ecosystem fit | Deepest for Microsoft/Azure-invested teams | Vendor-neutral, broad cross-platform support |
+| Product maturity | Newer, actively evolving | More established, longer track record |
+| B2B + consumer in one product | Native support | Requires more configuration |
+| .NET integration library | Microsoft.Identity.Web (first-party) | Auth0.AspNetCore.Authentication (Auth0-maintained) |
+| Pricing model | Usage-based, scales with MAUs | Usage-based, scales with MAUs |
+
+Both are managed platforms with a comparable zero-operational-burden proposition - Entra External ID's advantage is deep Microsoft ecosystem integration and native B2B support; Auth0's advantage is a longer track record and platform neutrality if you're not committed to Azure specifically.
+
+## Frequently Asked Questions
+
+### Should I use Microsoft Entra External ID or Azure AD B2C for a new project?
+
+Microsoft Entra External ID - it's the officially recommended CIAM platform for new ASP.NET Core applications per Microsoft's current documentation. Azure AD B2C remains supported for existing applications, but isn't the recommended starting point for new ones.
+
+### What library should I use to integrate Entra External ID with ASP.NET Core?
+
+`Microsoft.Identity.Web` (and `Microsoft.Identity.Web.UI` for web applications with a UI) - this is Microsoft's first-party, maintained integration library used across their identity platform generally, not just for Entra External ID specifically.
+
+### Can Entra External ID support both external customers and internal employees in one application?
+
+Yes, this is one of its genuine advantages over Azure AD B2C - native support for both consumer authentication and B2B collaboration. The exact configuration pattern for unifying both flows cleanly in a single application is worth checking against Microsoft's current documentation, since specific guidance in this area continues to evolve.
+
+### How do I migrate an existing Azure AD B2C application to Entra External ID?
+
+Microsoft provides official migration guidance covering the process, including specific strategies for migrating user accounts and passwords - follow that documented path rather than attempting a from-scratch reimplementation, since it's designed as a genuine migration process, not a rewrite.
+
+### Is Microsoft Entra External ID mature enough for production use?
+
+It's Microsoft's actively recommended, supported platform for new applications, but it's genuinely newer than Azure AD B2C with a correspondingly smaller body of community examples and battle-tested patterns. Check current Microsoft documentation closely for any scenario beyond straightforward sign-up/sign-in, since guidance in more complex areas continues to be refined.
+
+### How do I configure sign-up and sign-in behavior?
+
+Through user flows configured in the Entra admin center - defining available identity providers, collected user attributes, and UI branding - rather than implementing this logic directly in your application code. This is the intended configuration surface, similar in spirit to Auth0's dashboard-based flow configuration.
+
+### What's the most common mistake in a first Entra External ID setup?
+
+Following outdated guidance, given how actively this specific product is evolving relative to more settled options in this comparison - confirm any configuration pattern against current Microsoft documentation rather than an older tutorial. The second common mistake is not carefully planning the consumer/B2B unification pattern upfront if an application needs to serve both user types, since that specific configuration is more nuanced than a pure consumer-only or pure B2B-only setup.

--- a/src/posts/2028-06-13-getting-started-with-duende-identityserver.md
+++ b/src/posts/2028-06-13-getting-started-with-duende-identityserver.md
@@ -1,0 +1,174 @@
+---
+author: Steve Kaschimer
+date: 2028-06-13
+image: /images/posts/2028-06-13-hero.webp
+image_alt: "A padlock glyph connected by a thin line to a small building-shaped server icon, implying a self-hosted framework built around rather than a turnkey product."
+image_prompt: "A dark-mode technical editorial illustration on a near-black background with electric teal, amber, and off-white accents. Composition centers on a single padlock glyph connected by a thin line to a small building-shaped server icon, implying a self-hosted framework you construct around rather than a turnkey product. A small amber price-tag glyph sits faintly near the connecting line's midpoint, implying a licensing decision that must be resolved early. Mood is deliberate, framework-first, and cost-conscious. Avoid: vendor logos, brand colors, circuit-board textures, gears, or generic lock clip art as the dominant motif."
+layout: post.njk
+site_title: Tech Notes
+summary: "The first real decision happens before writing any code: is the organization under the community edition's revenue threshold, or does it need a commercial license? A setup guide for clients and scopes, pairing with ASP.NET Core Identity, and the UI work Duende doesn't ship turnkey."
+tags: ["dotnet", "security", "identity", "oidc", "architecture"]
+title: "Getting Started with Duende IdentityServer"
+---
+
+Duende IdentityServer's first real decision happens before you write any code: are you actually under the community edition's revenue threshold, or does your organization need a commercial license? That question genuinely determines whether this is the right tool at all, and it's worth resolving explicitly rather than building an identity provider around a licensing assumption you haven't confirmed. Once that's settled, Duende asks you to build more than most teams expect - it's a protocol framework, not a turnkey identity server, and the UI, user store, and admin tooling are all yours to supply.
+
+This guide covers installing Duende IdentityServer, bootstrapping clients, scopes, and a user store correctly, the core OIDC/OAuth flows you'll actually implement, and the best practices for building the scaffolding Duende deliberately doesn't provide. By the end you'll have a working identity provider and a realistic sense of the ongoing ownership that comes with it.
+
+If you're deciding between auth/identity solutions first, [a comparison of the top auth and identity solutions for .NET](/posts/2028-05-23-top-5-auth-identity-solutions-dotnet-compared/) covers where Duende IdentityServer fits relative to ASP.NET Core Identity, Auth0, Keycloak, and Microsoft Entra External ID.
+
+## What You'll Need
+
+- .NET 8 SDK or later
+- A resolved answer on licensing - confirm whether your organization qualifies for the community edition or needs a commercial license, before investing significant engineering time
+- A database for configuration and operational data (SQL Server via EF Core is well-supported)
+
+## Installing Duende IdentityServer
+
+```bash
+dotnet new install Duende.IdentityServer.Templates
+dotnet new isaspid -n MyApp.IdentityServer
+cd MyApp.IdentityServer
+```
+
+This scaffolds a host project with a starting configuration - clients, resources, and a basic UI you're expected to customize significantly, not use as-is in production.
+
+## Bootstrapping the Ideal Environment
+
+### Define clients and scopes
+
+```csharp
+// Config.cs
+public static class Config
+{
+    public static IEnumerable<Client> Clients =>
+        new[]
+        {
+            new Client
+            {
+                ClientId = "myapp-web",
+                ClientSecrets = { new Secret("secret".Sha256()) },
+                AllowedGrantTypes = GrantTypes.Code,
+                RedirectUris = { "https://localhost:5002/signin-oidc" },
+                AllowedScopes = { "openid", "profile", "myapp.api" }
+            }
+        };
+
+    public static IEnumerable<ApiScope> ApiScopes =>
+        new[] { new ApiScope("myapp.api", "My App API") };
+
+    public static IEnumerable<IdentityResource> IdentityResources =>
+        new IdentityResource[]
+        {
+            new IdentityResources.OpenId(),
+            new IdentityResources.Profile()
+        };
+}
+```
+
+Clients and scopes are the core of Duende's configuration model - each client represents an application that can request tokens, and scopes define what those tokens grant access to. Get comfortable with this vocabulary before configuring anything real, since it's the foundation everything else builds on.
+
+### Register Duende with EF Core-backed configuration storage
+
+```csharp
+var builder = WebApplication.CreateBuilder(args);
+
+builder.Services.AddIdentityServer()
+    .AddConfigurationStore(options =>
+    {
+        options.ConfigureDbContext = b => b.UseSqlServer(connectionString);
+    })
+    .AddOperationalStore(options =>
+    {
+        options.ConfigureDbContext = b => b.UseSqlServer(connectionString);
+    })
+    .AddAspNetIdentity<IdentityUser>(); // pairing with ASP.NET Core Identity for the user store
+```
+
+Pairing Duende with ASP.NET Core Identity for the actual user store is the common, well-supported pattern - Duende handles the OIDC/OAuth protocol layer, Identity handles user accounts, password hashing, and account management underneath it.
+
+### Build the login and consent UI
+
+Duende's templates include a starting UI, but production use requires real customization - registration flows, password reset, MFA prompts, and consent screens are all things you build, not things Duende ships turnkey. Budget real time for this; it's a common source of underestimated setup effort.
+
+### Configure token lifetimes deliberately
+
+```csharp
+new Client
+{
+    ClientId = "myapp-web",
+    AccessTokenLifetime = 3600, // 1 hour
+    IdentityTokenLifetime = 300, // 5 minutes
+    RefreshTokenUsage = TokenUsage.ReUse,
+    AbsoluteRefreshTokenLifetime = 2592000 // 30 days
+}
+```
+
+Default token lifetimes are reasonable starting points, but review them against your application's actual security requirements - shorter-lived access tokens with refresh tokens is a common, more secure pattern than long-lived access tokens alone.
+
+## Core Workflow
+
+- **Model your applications as clients and your APIs as scopes**, the foundational configuration every Duende deployment builds from.
+- **Pair Duende with ASP.NET Core Identity (or another user store) for actual user management**, since Duende itself doesn't provide one.
+- **Build and thoroughly test your consent and login UI** before considering the deployment production-ready - this is real, non-trivial engineering work, not a configuration step.
+
+## Verifying Your Setup
+
+1. **Clients can successfully complete the authorization code flow** - confirm a test client redirects, authenticates, and receives valid tokens
+2. **Scopes correctly restrict access** - confirm an access token only grants access to the scopes it was actually issued for
+3. **Token lifetimes match your configured values** - confirm issued tokens expire and refresh according to your actual configuration, not defaults you didn't review
+4. **The user store (Identity or otherwise) integrates correctly** - confirm user authentication genuinely flows through to token issuance
+
+## Best Practices
+
+**Confirm your licensing situation before investing significant engineering time.** This isn't a detail to resolve later - know whether you're within the community edition's threshold or need a commercial license before building meaningful architecture around Duende.
+
+**Budget real time for the UI and supporting flows Duende doesn't provide.** Login, registration, consent, password reset - none of this is turnkey, and underestimating this work is a common cause of Duende implementations running over schedule.
+
+**Pair with ASP.NET Core Identity for user storage rather than building your own from scratch**, unless you have a specific reason not to. This is the well-trodden, well-supported combination most Duende deployments use.
+
+**Review token lifetimes and refresh token policies deliberately.** Defaults are reasonable but generic - your application's actual security posture should drive these values, not an unreviewed template default.
+
+**Seriously evaluate OpenIddict or Keycloak before committing to a commercial Duende license**, if cost is a real factor. Both solve a similar problem without Duende's licensing cost, and the community's assessment is that a paid Duende license needs specific technical justification beyond just "we want to stay in .NET."
+
+## Comparison with Keycloak
+
+| | Duende IdentityServer | Keycloak |
+| --- | --- | --- |
+| Language/stack | .NET-native | Java-based backend |
+| Cost | Free under a revenue threshold, commercial above it | Free, no licensing cliff |
+| Turnkey UI/admin tooling | No - you build it | Yes - includes admin console and UI out of the box |
+| Enterprise features (SAML, LDAP) | Requires custom work or extensions | Built in |
+| .NET integration | Deepest, native ASP.NET Core | Standard OIDC/OAuth, works via middleware regardless of language |
+
+If cost is the deciding factor and you don't have specific technical requirements only Duende meets, Keycloak's free, more turnkey feature set is worth serious comparison before committing to a commercial Duende license.
+
+## Frequently Asked Questions
+
+### Do I need to pay for Duende IdentityServer?
+
+Not necessarily - a community edition exists for organizations under a specified revenue threshold. Organizations above that threshold need a commercial license for production use. Confirm which category applies to you before building significant architecture around Duende.
+
+### Does Duende IdentityServer include a login page and user registration out of the box?
+
+The project templates include a starting UI, but it's meant to be customized substantially, not used as-is in production. Registration flows, password reset, MFA, and consent screens are all things you build and own, not turnkey features Duende ships complete.
+
+### What's the difference between a client and a scope in Duende?
+
+A client represents an application requesting tokens (your web app, a mobile app, another service). A scope represents what a token grants access to (an API, specific claims). Configuring Duende means defining both - which applications can request tokens, and what those tokens actually authorize.
+
+### Should I use ASP.NET Core Identity alongside Duende IdentityServer?
+
+Yes, typically - this is the standard, well-supported pairing. Duende handles the OIDC/OAuth protocol layer (issuing and validating tokens, managing clients and scopes), while ASP.NET Core Identity handles the actual user store (accounts, password hashing, roles) underneath it.
+
+### How do I decide on appropriate token lifetimes?
+
+Balance security against user experience - shorter access token lifetimes with refresh tokens (reused or rotated) are generally more secure than long-lived access tokens, at the cost of more frequent token refresh overhead. Review Duende's default `Client` configuration values against your application's actual security requirements rather than accepting them unreviewed.
+
+### Is Duende IdentityServer harder to set up than a managed service like Auth0?
+
+Yes, meaningfully - Duende is a framework requiring you to understand OAuth flows, token types, and OIDC specifications, and to build the surrounding UI and user management flows yourself. Auth0 and similar managed platforms handle all of this for you, at the cost of usage-based pricing and less control over the implementation.
+
+### What's the most common mistake in a first Duende IdentityServer setup?
+
+Not confirming licensing status before investing significant engineering time, only to discover a commercial license is required partway through. The second common mistake is underestimating the UI and supporting-flow work Duende doesn't provide out of the box, leading to a much larger implementation effort than initially planned.

--- a/src/posts/2028-06-20-getting-started-with-keycloak-dotnet.md
+++ b/src/posts/2028-06-20-getting-started-with-keycloak-dotnet.md
@@ -1,0 +1,159 @@
+---
+author: Steve Kaschimer
+date: 2028-06-20
+image: /images/posts/2028-06-20-hero.webp
+image_alt: "A padlock glyph beside a small stacked-brick icon, implying an open-source, self-hosted identity server built from durable, freely available components."
+image_prompt: "A dark-mode technical editorial illustration on a near-black background with electric teal, amber, and off-white accents. Composition centers on a single padlock glyph positioned beside a small stacked-brick icon rendered as three offset rectangles, implying an open-source, self-hosted server built from durable, freely available components. A faint teal coffee-cup-adjacent steam-line accent sits subtly near the bricks, implying a Java-based backend without depicting an actual cup or logo. Mood is sturdy, free, and infrastructure-owned. Avoid: vendor logos, brand colors, circuit-board textures, gears, or generic lock clip art as the dominant motif."
+layout: post.njk
+site_title: Tech Notes
+summary: "Keycloak's free, standards-compliant OIDC implementation means the .NET integration side is genuinely simple - the real work lives in realms, clients, and operating a Java-based service as infrastructure regardless of how cleanly .NET talks to it. A setup guide for realms, standard OIDC middleware, and role claim structure."
+tags: ["dotnet", "security", "identity", "oidc", "devops"]
+title: "Getting Started with Keycloak for .NET"
+---
+
+Keycloak's free, standards-compliant OIDC implementation means the .NET integration side is genuinely simple - any OAuth2/OIDC-compliant provider works with the same `Microsoft.AspNetCore.Authentication.OpenIdConnect` middleware, so from ASP.NET Core's perspective, Keycloak looks like any other identity provider you point configuration at. The real work in a Keycloak setup lives on the other side: realms, clients, and the fact that you're now operating a Java-based service as part of your infrastructure, regardless of how comfortably .NET talks to it.
+
+This guide covers installing and running Keycloak, bootstrapping a realm and client for a .NET application, the core OIDC integration pattern in ASP.NET Core, and the best practices for operating Keycloak well as infrastructure your team owns. By the end you'll have a free, production-capable identity provider integrated cleanly with .NET.
+
+If you're deciding between auth/identity solutions first, [a comparison of the top auth and identity solutions for .NET](/posts/2028-05-23-top-5-auth-identity-solutions-dotnet-compared/) covers where Keycloak fits relative to ASP.NET Core Identity, Duende IdentityServer, Auth0, and Microsoft Entra External ID.
+
+## What You'll Need
+
+- Docker, for running Keycloak locally or as a starting point for production deployment
+- .NET 8 SDK or later
+- Real infrastructure and operational capacity if deploying to production - Keycloak is self-hosted
+
+## Installing and Running Keycloak
+
+```bash
+docker run -d --name keycloak -p 8080:8080 \
+  -e KEYCLOAK_ADMIN=admin \
+  -e KEYCLOAK_ADMIN_PASSWORD=admin \
+  quay.io/keycloak/keycloak:latest start-dev
+```
+
+`start-dev` runs Keycloak in development mode - convenient for local setup, but not the configuration you'd run in production, which needs a proper database, TLS, and hardened settings.
+
+## Bootstrapping the Ideal Environment
+
+### Create a realm
+
+In the Keycloak admin console (`http://localhost:8080`): **Create Realm**, naming it for your application or organization. A realm is Keycloak's top-level isolation boundary - users, clients, and roles all live within a specific realm, and realms don't share data with each other by default.
+
+### Create a client for your .NET application
+
+**Clients → Create client**, with:
+
+- **Client type**: OpenID Connect
+- **Client authentication**: On (for a confidential client like a server-rendered web app)
+- **Valid redirect URIs**: `https://localhost:5001/signin-oidc`
+
+Note the generated **Client Secret** under the Credentials tab - your .NET application uses this alongside the Client ID to authenticate to Keycloak.
+
+### Integrate with ASP.NET Core via standard OIDC middleware
+
+```bash
+dotnet add package Microsoft.AspNetCore.Authentication.OpenIdConnect
+```
+
+```csharp
+var builder = WebApplication.CreateBuilder(args);
+
+builder.Services.AddAuthentication(options =>
+{
+    options.DefaultScheme = CookieAuthenticationDefaults.AuthenticationScheme;
+    options.DefaultChallengeScheme = OpenIdConnectDefaults.AuthenticationScheme;
+})
+.AddCookie()
+.AddOpenIdConnect(options =>
+{
+    options.Authority = "http://localhost:8080/realms/myapp-realm";
+    options.ClientId = "myapp-web";
+    options.ClientSecret = builder.Configuration["Keycloak:ClientSecret"];
+    options.ResponseType = "code";
+    options.SaveTokens = true;
+});
+```
+
+This is exactly the standard `Microsoft.AspNetCore.Authentication.OpenIdConnect` middleware, pointed at Keycloak's realm-specific issuer URL - there's no Keycloak-specific SDK required, since it's a fully standards-compliant OIDC provider and the generic middleware handles the protocol correctly.
+
+### Configure roles and map them to claims
+
+**Realm roles → Create role**, then assign roles to users under **Users → [user] → Role mapping**. To include roles as claims in the issued token, configure a client scope mapper under **Client scopes → roles → Mappers**.
+
+```csharp
+builder.Services.AddAuthorization(options =>
+{
+    options.AddPolicy("AdminOnly", policy =>
+        policy.RequireClaim("realm_access.roles", "admin")); // exact claim structure depends on mapper config
+});
+```
+
+Keycloak nests realm roles under a `realm_access` claim by default rather than a flat role claim - worth confirming the actual token structure (via a tool like jwt.io during development) before writing authorization policies against assumed claim shapes.
+
+## Core Workflow
+
+- **Use realms to isolate different applications or environments**, rather than putting everything in Keycloak's default realm.
+- **Use standard ASP.NET Core OIDC middleware, not a Keycloak-specific package**, since Keycloak's standards compliance means the generic middleware works correctly without special handling.
+- **Confirm actual token claim structure before writing authorization policies against it**, since Keycloak's default claim nesting (`realm_access.roles`) differs from a flat claim structure other providers might use.
+
+## Verifying Your Setup
+
+1. **The OIDC flow completes correctly end to end** - confirm login redirects to Keycloak, authenticates, and returns to your application with a valid session
+2. **Realm and client configuration matches your application's actual URLs** - confirm redirect URIs are correct for every environment
+3. **Role claims appear in tokens with the expected structure** - confirm your authorization policies correctly match the actual claim shape Keycloak issues
+4. **Production deployment uses hardened configuration, not `start-dev`** - confirm a real database, TLS, and production-appropriate settings before going live
+
+## Best Practices
+
+**Never run Keycloak in `start-dev` mode in production.** It's explicitly a development convenience - production needs a real database backend, TLS, and hardened configuration.
+
+**Use realms deliberately to isolate applications or environments.** Don't default everything into Keycloak's built-in realm; a dedicated realm per application (or per environment) keeps configuration and user data appropriately separated.
+
+**Verify actual token claim structure rather than assuming a shape.** Keycloak's default nesting of roles under `realm_access` is a common source of "my authorization policy isn't matching" confusion if you assumed a flat claim structure.
+
+**Budget real operational capacity for running Keycloak.** It's a genuine service you're responsible for - uptime, scaling, backups, and security patching are all yours, the same commitment as any self-hosted option in this comparison.
+
+**Take advantage of Keycloak's broader protocol support (SAML, LDAP) if you actually need it.** This is one of its real advantages over a purely OIDC-focused alternative like Duende or OpenIddict - underusing it means missing part of why you chose Keycloak in the first place.
+
+## Comparison with Duende IdentityServer
+
+| | Keycloak | Duende IdentityServer |
+| --- | --- | --- |
+| Cost | Free, no licensing cliff | Free under a revenue threshold, commercial above it |
+| Language/stack | Java-based backend | .NET-native |
+| Turnkey UI/admin console | Yes, included | No - you build it |
+| Protocol support | OIDC, OAuth, SAML, LDAP | OIDC, OAuth (SAML/LDAP require extensions) |
+| .NET integration | Standard OIDC middleware, no special SDK needed | Deepest, native ASP.NET Core |
+
+Keycloak's turnkey admin console and broader protocol support make it the community's typical recommendation over a paid Duende license for cost-constrained teams - the trade-off is operating a Java-based service rather than staying entirely within the .NET stack.
+
+## Frequently Asked Questions
+
+### Do I need a special Keycloak SDK for .NET, or does standard OIDC middleware work?
+
+Standard `Microsoft.AspNetCore.Authentication.OpenIdConnect` middleware works correctly - Keycloak is a fully standards-compliant OIDC/OAuth provider, so there's no Keycloak-specific package required from the .NET side. Point the standard middleware's `Authority` at your realm's issuer URL and it works the same as with any other compliant provider.
+
+### What's a realm in Keycloak?
+
+A realm is Keycloak's top-level isolation boundary - a self-contained set of users, clients, roles, and configuration that doesn't share data with other realms. Use separate realms to isolate different applications or environments rather than putting everything into Keycloak's single default realm.
+
+### Why isn't my role-based authorization policy matching?
+
+Most commonly because Keycloak nests realm roles under a `realm_access.roles` claim structure by default, rather than a flat role claim some other providers use. Inspect an actual issued token (via jwt.io or similar during development) to confirm the real claim structure before writing authorization policies against an assumed shape.
+
+### Is Keycloak actually free, with no hidden licensing cost?
+
+Yes - it's fully open source with no per-user licensing or revenue-threshold cliff, unlike Duende IdentityServer. Your only real cost is the infrastructure and operational time required to run it, the same as any self-hosted option.
+
+### Should I use start-dev mode for a production Keycloak deployment?
+
+No - `start-dev` is explicitly a development convenience that uses an in-memory-adjacent configuration unsuitable for production. A real deployment needs a proper database, TLS, and hardened production configuration, following Keycloak's official production deployment guidance.
+
+### Does Keycloak support SAML in addition to OIDC/OAuth?
+
+Yes - this is one of Keycloak's genuine advantages over OIDC-only alternatives like Duende or OpenIddict, useful if you need to integrate with enterprise identity providers or applications that specifically require SAML rather than OIDC.
+
+### What's the most common mistake in a first Keycloak setup?
+
+Running `start-dev` mode in production instead of a properly hardened configuration with a real database and TLS. The second common mistake is assuming a flat role claim structure without checking Keycloak's actual token output, leading to authorization policies that silently never match.

--- a/src/posts/2028-06-27-getting-started-with-auth0-dotnet.md
+++ b/src/posts/2028-06-27-getting-started-with-auth0-dotnet.md
@@ -1,0 +1,189 @@
+---
+author: Steve Kaschimer
+date: 2028-06-27
+image: /images/posts/2028-06-27-hero.webp
+image_alt: "A padlock glyph floating cleanly inside a plain cloud outline with no additional accents, implying a fully managed, vendor-neutral identity platform reachable in minutes."
+image_prompt: "A dark-mode technical editorial illustration on a near-black background with electric teal, amber, and off-white accents. Composition centers on a single padlock glyph floating cleanly inside a soft, plain cloud outline with no additional accents or attachments, implying a fully managed, vendor-neutral platform reachable quickly with minimal setup. A small stopwatch glyph sits faintly beneath the cloud, implying speed to a working result. Mood is fast, polished, and turnkey. Avoid: vendor logos, brand colors, circuit-board textures, gears, or generic lock clip art as the dominant motif."
+layout: post.njk
+site_title: Tech Notes
+summary: "The value proposition shows up in the first ten minutes - register an application, install one SDK package, working login without hand-writing an OAuth flow. A setup guide for web app vs. API integration patterns, namespaced custom claims, and clearing both local and vendor sessions on logout."
+tags: ["dotnet", "security", "identity", "oidc", "tooling"]
+title: "Getting Started with Auth0 for .NET"
+---
+
+Auth0's whole value proposition shows up in the first ten minutes - register an application in the dashboard, install one SDK package, and you have working login, without writing an OAuth flow by hand or standing up any infrastructure. The setup work that actually matters happens after that quick win: configuring token validation correctly for your API, deciding how roles and permissions map to Auth0's model, and understanding what you're paying for as your user base grows.
+
+This guide covers registering an application with Auth0, bootstrapping authentication in an ASP.NET Core app and API, the core patterns for roles and permissions, and the best practices for using a managed platform well rather than fighting its opinions. By the end you'll have working authentication with minimal infrastructure, and a clear sense of how Auth0's pricing scales as you grow.
+
+If you're deciding between auth/identity solutions first, [a comparison of the top auth and identity solutions for .NET](/posts/2028-05-23-top-5-auth-identity-solutions-dotnet-compared/) covers where Auth0 fits relative to ASP.NET Core Identity, Duende IdentityServer, Keycloak, and Microsoft Entra External ID.
+
+## What You'll Need
+
+- An Auth0 account and tenant
+- .NET 8 SDK or later
+- An ASP.NET Core application (MVC, Razor Pages, or an API)
+
+## Registering Your Application
+
+In the Auth0 dashboard: **Applications → Create Application**, choosing "Regular Web Application" for a server-rendered app or "Machine to Machine"/"API" for a backend service. Note the **Domain**, **Client ID**, and **Client Secret** - these are what your application uses to talk to Auth0.
+
+## Installing and Bootstrapping
+
+### For an ASP.NET Core web application
+
+```bash
+dotnet add package Auth0.AspNetCore.Authentication
+```
+
+```csharp
+var builder = WebApplication.CreateBuilder(args);
+
+builder.Services.AddAuth0WebAppAuthentication(options =>
+{
+    options.Domain = builder.Configuration["Auth0:Domain"]!;
+    options.ClientId = builder.Configuration["Auth0:ClientId"]!;
+});
+
+var app = builder.Build();
+app.UseAuthentication();
+app.UseAuthorization();
+```
+
+```csharp
+[Authorize]
+public class ProfileController : Controller
+{
+    public IActionResult Index() => View();
+}
+```
+
+Configuring the domain and client ID is genuinely most of what's required - the SDK handles the OIDC flow, token validation, and cookie management for you.
+
+### For an ASP.NET Core Web API validating Auth0-issued tokens
+
+```bash
+dotnet add package Microsoft.AspNetCore.Authentication.JwtBearer
+```
+
+```csharp
+builder.Services.AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
+    .AddJwtBearer(options =>
+    {
+        options.Authority = $"https://{builder.Configuration["Auth0:Domain"]}/";
+        options.Audience = builder.Configuration["Auth0:Audience"];
+    });
+```
+
+`Audience` must match the API identifier you configured for this API in the Auth0 dashboard (**Applications → APIs**) - a mismatch here is a common source of "token is valid but access is denied" confusion, since the token was issued correctly but for a different intended audience.
+
+## Bootstrapping the Ideal Environment
+
+### Configure login/logout URLs correctly
+
+```csharp
+builder.Services.AddAuth0WebAppAuthentication(options =>
+{
+    options.Domain = builder.Configuration["Auth0:Domain"]!;
+    options.ClientId = builder.Configuration["Auth0:ClientId"]!;
+});
+```
+
+In the Auth0 dashboard, configure **Allowed Callback URLs** and **Allowed Logout URLs** to match your application's actual URLs exactly - a mismatch here is the most common cause of a login flow that appears to work but fails at the redirect step.
+
+### Add roles and permissions
+
+In the Auth0 dashboard: **User Management → Roles**, define roles and assign permissions, then attach roles to users. Configure your API's Auth0 settings to include roles as a custom claim in issued tokens (via an Auth0 Action or Rule), since roles aren't included in a token by default without explicit configuration.
+
+```csharp
+[Authorize(Policy = "AdminOnly")]
+public class AdminController : Controller { }
+```
+
+```csharp
+builder.Services.AddAuthorization(options =>
+{
+    options.AddPolicy("AdminOnly", policy =>
+        policy.RequireClaim("https://myapp.com/roles", "admin"));
+});
+```
+
+Auth0 recommends namespacing custom claims with a URL-like prefix (`https://myapp.com/roles`) to avoid collisions with standard OIDC claims - worth following this convention rather than using a bare claim name.
+
+### Handle logout correctly
+
+```csharp
+[HttpGet("/logout")]
+public async Task Logout()
+{
+    await HttpContext.SignOutAsync(CookieAuthenticationDefaults.AuthenticationScheme);
+    await HttpContext.SignOutAsync(Auth0Constants.AuthenticationScheme);
+}
+```
+
+Logout needs to clear both your application's local cookie session and Auth0's own session - signing out of only one leaves the user in a confusing partially-logged-out state.
+
+## Core Workflow
+
+- **Use the Auth0.AspNetCore.Authentication SDK for web applications, JWT Bearer authentication for APIs** - these are two different integration patterns for two different application types, don't conflate them.
+- **Configure custom claims (roles, permissions) via Auth0 Actions**, since they're not included in issued tokens by default.
+- **Test callback and logout URLs against your actual deployed URLs**, not just localhost, before considering a deployment complete - these need explicit configuration per environment.
+
+## Verifying Your Setup
+
+1. **Login and logout flows work end to end** - confirm a user can log in, access a protected resource, and log out cleanly with both local and Auth0 sessions cleared
+2. **API token validation works correctly** - confirm `Audience` matches your configured API identifier and tokens are correctly validated
+3. **Custom claims (roles) appear in issued tokens** - confirm your Auth0 Action correctly adds role claims, and your authorization policies correctly evaluate them
+4. **Callback and logout URLs are correctly configured for every environment** - confirm production URLs are added to Auth0's allowed lists, not just development ones
+
+## Best Practices
+
+**Configure Allowed Callback URLs and Allowed Logout URLs precisely, for every environment.** A mismatch here is the most common cause of a login flow that seems configured correctly but fails at the redirect step.
+
+**Namespace custom claims to avoid collisions with standard OIDC claims.** Auth0's recommended URL-like prefix convention (`https://myapp.com/roles`) is worth following consistently.
+
+**Clear both the local application session and the Auth0 session on logout.** Signing out of only one leaves users in a confusing, partially-authenticated state.
+
+**Monitor your monthly active user count against Auth0's pricing tiers.** Usage-based pricing means cost scales with your application's success - know where you sit relative to tier boundaries rather than being surprised by a bill.
+
+**Use Auth0 Actions for anything that needs to modify tokens or enforce additional logic during authentication**, rather than trying to replicate that logic in your application after the fact.
+
+## Comparison with Microsoft Entra External ID
+
+| | Auth0 | Microsoft Entra External ID |
+| --- | --- | --- |
+| Ecosystem fit | Vendor-neutral, broad cross-platform support | Deepest for Microsoft/Azure-invested teams |
+| Developer experience | Widely regarded as best-in-class documentation | Strong, improving, newer product |
+| B2B + consumer in one product | Requires more configuration | Native support for both |
+| Pricing model | Usage-based, scales with MAUs | Usage-based, scales with MAUs |
+
+Both are managed platforms with a comparable zero-operational-burden value proposition - the choice largely comes down to whether your organization is already invested in Azure specifically, or values Auth0's cross-platform neutrality and documentation quality.
+
+## Frequently Asked Questions
+
+### Why does my API return "unauthorized" even though the token looks valid?
+
+The most common cause is an `Audience` mismatch - your API's JWT Bearer configuration needs to match the API identifier configured in Auth0's dashboard exactly. A token issued for a different audience will fail validation even if it's otherwise correctly signed and unexpired.
+
+### How do I add custom claims like roles to Auth0-issued tokens?
+
+Use an Auth0 Action (configured in the dashboard under **Actions → Flows → Login**) to add custom claims during the login flow - roles and permissions aren't included in issued tokens by default without this explicit configuration step.
+
+### Why does my login redirect fail even though my Client ID and Domain are correct?
+
+Check your Allowed Callback URLs in the Auth0 dashboard - they need to match your application's actual redirect URL exactly, for every environment (development, staging, production) you're testing against. This is the most common cause of an otherwise-correctly-configured login flow failing at the final redirect step.
+
+### How do I properly log a user out of both my application and Auth0?
+
+Call `SignOutAsync` for both your application's local cookie authentication scheme and the Auth0 authentication scheme - clearing only one leaves the user in a confusing state where they appear logged out locally but Auth0 still considers them authenticated (or vice versa).
+
+### Is Auth0 expensive at scale?
+
+It's usage-based, scaling with monthly active users - cost grows as your application succeeds, which is different from a self-hosted option's fixed infrastructure cost. Monitor your usage against Auth0's pricing tiers so growth in users translates to an expected, not surprising, cost increase.
+
+### Can I use Auth0 for both a web application and its backing API?
+
+Yes - use the `Auth0.AspNetCore.Authentication` SDK for the web application's login flow (cookie-based session), and JWT Bearer authentication configured with your API's audience for the API itself, which validates the access tokens the web application (or other clients) send with requests.
+
+### What's the most common mistake in a first Auth0 setup?
+
+Misconfigured Allowed Callback/Logout URLs, causing a login or logout flow that appears correctly set up to fail at the redirect step. The second common mistake is not configuring an Auth0 Action to include custom claims like roles, leading to confusing "the user is authenticated but my authorization policy still rejects them" issues.


### PR DESCRIPTION
## Summary

- Schedules and drafts the Auth & Identity for .NET Tuesday track (May-June 2028), continuing the weekly Tuesday cadence from the .NET Deployment Options track
- Six posts: an anchor comparison post (`The Top 5 Auth & Identity Solutions for .NET Compared`) plus getting-started guides for ASP.NET Core Identity, Microsoft Entra External ID, Duende IdentityServer, Keycloak, and Auth0
- `editorial-plan.md` updated: series moved from Backlog into a new dated section, all 6 entries marked `Status: draft`. This is the final scheduled .NET Tuesday track - only .NET IDEs & Editors remains in the backlog.

## Test plan

- [x] `npm run deploy` builds all posts (including this track's 6 new files) without error
- [x] `node scripts/a11y-check.js` (axe-core, WCAG 2.1 A/AA, light + dark) reports zero violations across home/post/about/privacy/terms/404
- [x] Verified each getting-started post cross-links back to the anchor comparison post
- [x] Verified each post's built `_site/posts/.../index.html` exists
- [x] `editorial-plan.md` CRLF line endings preserved (verified via `file` and byte-count check)


---
_Generated by [Claude Code](https://claude.ai/code/session_01WKyNF7L5qzrfct8cec6A32)_