### PR TITLE
Add .NET IDEs & Editors Tuesday track (July-August 2028)

### DIFF
--- a/editorial-plan.md
+++ b/editorial-plan.md
@@ -1478,17 +1478,69 @@ Six posts on how .NET applications handle authentication and identity, picking u
 
 ---
 
-## 📅 Backlog - Unscheduled Series
+## 📅 Tuesday Track - .NET IDEs & Editors (July-August 2028)
 
-One six-post series remains unscheduled, drawn from the drafts in `docs/article-ideas/`. It continues the Tuesday cadence once the Auth & Identity for .NET series ends on 2028-06-27. It's deliberately undated - that horizon is too far out to put honest dates against - so the series gets one entry rather than six speculative ones, expanded into individual dated posts when it moves onto the calendar.
+Six posts on where .NET developers actually write and debug C# in 2028, picking up the Tuesday cadence directly from the Auth & Identity for .NET track. A comparison post anchors the track and each of the five follow-ups is a complete setup for one editor. This is the final scheduled series drawn from the current `docs/article-ideas/` backlog - the Backlog section below is now empty.
 
-### .NET IDEs & Editors (6 posts)
-- **Status:** `idea`
-- **Source:** `docs/article-ideas/top-5-dotnet-ides-editors-compared.md` + 5 getting-started drafts
-- **Series:** Top 5 comparison, then Visual Studio, JetBrains Rider, VS Code, Cursor, Neovim
+### The Top 5 .NET IDEs & Editors Compared: Which One Should You Choose?
+- **Status:** `draft`
+- **Scheduled:** 2028-07-04
+- **Source:** `docs/article-ideas/top-5-dotnet-ides-editors-compared.md`
+- **File:** `src/posts/2028-07-04-top-5-dotnet-ides-editors-compared.md`
 - **Pitch:** "Visual Studio on Windows" stopped being the automatic answer. Rider has a real claim to being better for day-to-day C# work, VS Code became genuinely solid once the C# Dev Kit shipped, and in mid-2026 JetBrains extended full C# tooling - debugging included - to Cursor and other VS Code-compatible editors.
 - **Angle:** Compares the five on platform support, cost, C# intelligence, and debugging, with Neovim included specifically for the terminal-first crowd rather than as a novelty entry. States the licensing detail that drives most of the current landscape upfront: Microsoft's C# Dev Kit is licensed for genuine VS Code only and does not run on Cursor or other forks, which is exactly the gap JetBrains moved into. Deliberately scoped to the core development experience and cross-references the AI Coding Agents track rather than re-litigating agent capability.
 - **Tags:** `dotnet`, `tooling`, `developer-productivity`, `ai-coding-tools`
+
+### Getting Started with Visual Studio for .NET Development
+- **Status:** `draft`
+- **Scheduled:** 2028-07-11
+- **Source:** `docs/article-ideas/getting-started-with-visual-studio.md`
+- **File:** `src/posts/2028-07-11-getting-started-with-visual-studio.md`
+- **Pitch:** The install wizard makes the first decision that matters most, and it's easy to get wrong: which workloads to install. Checking every box "just in case" turns a reasonable install into a multi-hour, disk-hungry mess.
+- **Angle:** Covers deliberate workload selection over installing everything available, tuning background analysis scope and Solution Explorer tracking for large-solution responsiveness, committing `.editorconfig` from day one as the highest-leverage team-consistency setting, and conditional breakpoints over littering code with temporary print statements. Direct that Community edition is genuinely free for individuals, open-source projects, and teams of up to five - not just a trial - and that Visual Studio for Mac is fully discontinued with no path forward on macOS.
+- **Tags:** `dotnet`, `tooling`, `developer-productivity`
+
+### Getting Started with JetBrains Rider for .NET Development
+- **Status:** `draft`
+- **Scheduled:** 2028-07-18
+- **Source:** `docs/article-ideas/getting-started-with-rider.md`
+- **File:** `src/posts/2028-07-18-getting-started-with-rider.md`
+- **Pitch:** The reputation for being faster and smarter than Visual Studio for day-to-day C# work isn't marketing copy - it comes directly from ReSharper's static analysis engine running natively inside the IDE rather than as an add-on.
+- **Angle:** Covers Solution-Wide Analysis as continuous background checking across the entire solution rather than just open files, ReSharper-native refactoring and navigation as the clearest day-to-day strength, shared `.editorconfig` conventions that let Rider and Visual Studio coexist on the same team without friction, and the built-in database tools shared with DataGrip. Direct that it's a genuinely first-class cross-platform experience, not a Windows product ported elsewhere - the strongest full .NET IDE choice on macOS now that Visual Studio for Mac is gone.
+- **Tags:** `dotnet`, `tooling`, `developer-productivity`
+
+### Getting Started with VS Code for .NET Development
+- **Status:** `draft`
+- **Scheduled:** 2028-07-25
+- **Source:** `docs/article-ideas/getting-started-with-vscode-dotnet.md`
+- **File:** `src/posts/2028-07-25-getting-started-with-vscode-dotnet.md`
+- **Pitch:** The C# story used to require a fair amount of manual extension-hunting to get something resembling IntelliSense and a working debugger. That's not the situation anymore - the C# Dev Kit bundles the pieces that matter into one coherent extension.
+- **Angle:** Covers opening the folder containing a `.sln`/`.csproj` (not loose files) as the fix for the most common "IntelliSense isn't working" complaint, committing `.vscode/settings.json` and `.editorconfig` for team-wide consistency, the built-in Test Explorer and F5 debugging workflow, and the extension's genuine first-party Microsoft investment rather than community-maintained status. States plainly that the C# Dev Kit's license restricts it to genuine VS Code and does not run on Cursor or other forks - the detail that drives most of this track's Cursor post.
+- **Tags:** `dotnet`, `tooling`, `developer-productivity`
+
+### Getting Started with C# Development in Cursor
+- **Status:** `draft`
+- **Scheduled:** 2028-08-01
+- **Source:** `docs/article-ideas/getting-started-with-cursor-dotnet.md`
+- **File:** `src/posts/2028-08-01-getting-started-with-cursor-dotnet.md`
+- **Pitch:** Cursor's C# story had a real, well-known gap until mid-2026: the C# Dev Kit refuses to run on VS Code forks, leaving Cursor users doing .NET work with a degraded experience - until JetBrains extended ReSharper's full engine, debugging included, directly into Cursor as of their 2026.2 release.
+- **Angle:** Covers installing ReSharper's extension from Cursor's marketplace, the same `.editorconfig`-respecting conventions that keep formatting consistent across a mixed-editor team, debugging as specifically the capability that was missing before 2026.2, and a practical pattern for combining Cursor's Agent mode for larger changes with ReSharper's inline inspections to verify agent-generated code the same way hand-written code gets checked. Honest about the combined licensing cost - a ReSharper license plus any Cursor Pro tier - and cross-references this series' separate Cursor AI-agent setup guide rather than repeating it.
+- **Tags:** `dotnet`, `tooling`, `developer-productivity`, `ai-coding-tools`
+
+### Getting Started with Neovim for .NET Development
+- **Status:** `draft`
+- **Scheduled:** 2028-08-08
+- **Source:** `docs/article-ideas/getting-started-with-neovim-dotnet.md`
+- **File:** `src/posts/2028-08-08-getting-started-with-neovim-dotnet.md`
+- **Pitch:** Every other editor in this track gives you IntelliSense and debugging the moment you install it. Neovim gives you neither - you assemble both yourself, from a language server, a completion plugin, and a debug adapter, each configured explicitly.
+- **Angle:** Covers `csharp-ls` (or OmniSharp) via `nvim-lspconfig` for core IDE-like features, `nvim-dap` paired with `netcoredbg` as the most setup-intensive piece with no out-of-the-box equivalent, `nvim-dap-ui` as the non-optional upgrade over bare `nvim-dap` commands for a usable debugging panel, and building configuration incrementally rather than trying to replicate every IDE feature before writing real code. Honest throughout that this requires meaningfully more upfront investment than any other option in the track, worth it specifically for developers who value full control and a terminal-first workflow.
+- **Tags:** `dotnet`, `tooling`, `developer-productivity`
+
+---
+
+## 📅 Backlog - Unscheduled Series
+
+No series remain unscheduled - every series drafted into `docs/article-ideas/` has been scheduled and drafted as of the .NET IDEs & Editors track above. New entries get added here as future series are drafted.
 
 ---
 

--- a/src/posts/2028-07-04-top-5-dotnet-ides-editors-compared.md
+++ b/src/posts/2028-07-04-top-5-dotnet-ides-editors-compared.md
@@ -1,0 +1,168 @@
+---
+author: Steve Kaschimer
+date: 2028-07-04
+image: /images/posts/2028-07-04-hero.webp
+image_alt: "Five columns of abstract editor glyphs positioned along a horizontal axis running from a heavyweight, deeply integrated IDE on the left to a fully self-assembled, terminal-first setup on the right."
+image_prompt: "A dark-mode technical editorial illustration on a near-black background with electric teal, amber, and off-white accents. Composition is five vertical columns of equal width separated by thin hairline rules, each column topped by a distinct abstract glyph rendered in flat geometry: a dense, solid application-window glyph with a small Windows-pane accent implying deep first-party integration, a lighter application-window glyph with a small gear-free magnifying-glass accent implying sharp refactoring intelligence, a minimal outlined window glyph implying a lightweight but capable editor, the same minimal outlined window glyph paired with a small spark/agent accent implying AI-agent capability layered on top, and a bare terminal-prompt bracket glyph implying no GUI at all. Beneath the glyphs, a shared horizontal axis labeled in monospaced type runs from 'turnkey IDE' on the left to 'self-assembled' on the right, with a small glowing teal dot positioned at a different point under each column. Mood is comparative, developer-tooling-focused, and non-partisan. Avoid: vendor logos, brand colors, circuit-board textures, gears, or generic laptop clip art as the dominant motif."
+layout: post.njk
+site_title: Tech Notes
+summary: "\"Visual Studio on Windows\" stopped being the automatic answer. Rider has a real claim to being better for day-to-day C# work, VS Code became genuinely solid once the C# Dev Kit shipped, and JetBrains extended full C# tooling to Cursor in mid-2026. A practical breakdown of five ways .NET developers write and debug C# in 2026."
+tags: ["dotnet", "tooling", "developer-productivity", "ai-coding-tools"]
+title: "The Top 5 .NET IDEs & Editors Compared: Which One Should You Choose?"
+---
+
+For a long time, "which IDE for .NET" had an obvious answer: Visual Studio, on Windows, no real debate. That's genuinely no longer true. JetBrains Rider has a real claim to being better for day-to-day C# work than Visual Studio itself, even on Windows. VS Code went from "barely usable for C#" to "genuinely solid" once Microsoft shipped the C# Dev Kit. And as of mid-2026, JetBrains extended full C# tooling - including debugging - to Cursor and other VS Code-compatible AI editors, closing a gap that had quietly been blocking .NET developers from using those tools seriously.
+
+This guide compares five ways .NET developers write and debug C# in 2026: Visual Studio, JetBrains Rider, VS Code, Cursor, and Neovim - the last one included specifically for the terminal-first crowd who want a genuinely lightweight, fully keyboard-driven .NET setup rather than any flavor of IDE. One licensing detail worth knowing before anything else: Microsoft's official C# Dev Kit extension is licensed for use only in genuine Visual Studio Code - it does not run on Cursor or other VS Code-compatible forks, which is exactly the gap that made JetBrains' 2026 move into that space a genuinely significant development.
+
+If you're also evaluating these editors specifically for their AI agent capabilities, this series' AI coding agents comparison covers Cursor and Claude Code in that context - this guide focuses on the core .NET/C# development experience: IntelliSense, refactoring, debugging, and project tooling. This series continues with dedicated getting-started walkthroughs for each editor.
+
+## Quick Comparison
+
+| | Visual Studio | JetBrains Rider | VS Code | Cursor | Neovim |
+| --- | --- | --- | --- | --- | --- |
+| **Platform** | Windows (macOS support discontinued) | Windows, macOS, Linux | Windows, macOS, Linux | Windows, macOS, Linux | Windows, macOS, Linux |
+| **Cost** | Free (Community) to paid (Pro/Enterprise) | Paid subscription (free for some use cases) | Free | Free tier + paid Pro | Free, open source |
+| **C# intelligence** | Deepest, first-party | ReSharper-grade, arguably best-in-class | Strong via C# Dev Kit | Strong via ReSharper extension (2026.2+) | Via LSP (csharp-ls or OmniSharp), more manual setup |
+| **Debugging** | Best-in-class, deeply integrated | Excellent, cross-platform | Solid via C# Dev Kit | Now available via ReSharper (2026.2+) | Possible via LSP/DAP, more setup required |
+| **Best for** | Windows-centric teams, deepest Microsoft/Azure integration | Cross-platform teams wanting the most powerful refactoring and navigation | Lightweight full-stack work, teams already living in VS Code | AI-agent-centric workflows wanting real C# tooling on top | Terminal-first developers wanting a fully customized, keyboard-driven setup |
+
+## Visual Studio
+
+Visual Studio remains the deepest, most first-party .NET development experience that exists - built by the same organization that builds .NET itself, with integration into Azure, Windows desktop development, and enterprise tooling that no competitor fully replicates.
+
+**Strengths:**
+
+- The deepest possible integration with the .NET platform, Azure services, and Windows-specific development (WPF, WinForms, UWP) - unmatched by any competitor for these specific scenarios
+- Best-in-class debugging tools, including advanced diagnostics, IntelliTrace, and profiling capabilities that go beyond what most other editors offer
+- Visual Studio Community is free for individual developers, open-source projects, and teams of up to five, including nearly all Professional-tier features
+- The template, project system, and tooling ecosystem built around Visual Studio (NuGet integration, test explorer, designer tools) is the most mature and complete of any option here
+
+**Weaknesses:**
+
+- Effectively Windows-only now - Visual Studio for Mac has been officially retired by Microsoft, meaning macOS developers wanting full Visual Studio capability have no path forward on that platform
+- Genuinely heavier than every other option in this comparison - startup time, memory usage, and general resource consumption are all noticeably higher
+- A real learning curve given its extensive feature set, which can feel like overkill for developers who only need a fraction of what it offers
+
+**Choose this when:** you're on Windows, working deeply within the Microsoft/Azure ecosystem, doing Windows desktop development specifically, or your team values Visual Studio's unmatched debugging and diagnostic depth enough to accept its resource cost.
+
+## JetBrains Rider
+
+Rider is built on the IntelliJ platform with ReSharper's C# intelligence baked directly in, and it's earned a genuine reputation - not just marketing - for being faster and smarter than Visual Studio for day-to-day C# work, even among Windows developers who could just use Visual Studio instead.
+
+**Strengths:**
+
+- Cross-platform by design - full .NET IDE capability on Windows, macOS, and Linux, which matters enormously now that Visual Studio for Mac is gone
+- Refactoring and code navigation are widely regarded as best-in-class, built on ReSharper's mature, deeply respected static analysis engine
+- Performance on large solutions is a genuine strength - Rider handles big codebases noticeably better than some alternatives
+- Strong support beyond core .NET, including Unity game development and Xamarin/MAUI, without needing separate tooling
+
+**Weaknesses:**
+
+- A paid subscription product - there's no free tier equivalent to Visual Studio Community for most commercial use, a real ongoing cost to factor in
+- Some developers coming from Visual Studio experience a real adjustment period, since Rider's conventions and UI, while polished, aren't identical
+- Certain very Windows-specific designer tools (some WPF/WinForms visual designers) are less mature in Rider than in Visual Studio itself
+
+**Choose this when:** you want the strongest cross-platform .NET development experience, especially on macOS or Linux where Visual Studio isn't a full option, or you specifically value Rider's refactoring and navigation strength enough to justify the subscription cost.
+
+## VS Code
+
+VS Code's C# story has changed dramatically since 2023 - Microsoft's C# Dev Kit extension took it from "usable in a pinch" to "genuinely solid" for a real share of .NET workflows, all while keeping VS Code's core identity: lightweight, fast, and extensible across every language, not just C#.
+
+**Strengths:**
+
+- Free, fast, and lightweight compared to a full IDE, while still offering strong IntelliSense, debugging, and project management through the C# Dev Kit
+- The best choice for full-stack developers who move between C# and other languages (TypeScript, Python, and others) in the same workflow, since VS Code handles all of them natively
+- An enormous extension ecosystem beyond just C# tooling - Docker, Kubernetes, cloud tooling, and virtually every other technology a modern .NET developer might touch
+- Genuine first-party Microsoft investment in the C# Dev Kit means this isn't a community-maintained afterthought - it's actively developed by the same organization building .NET
+
+**Weaknesses:**
+
+- Still doesn't match Visual Studio's or Rider's depth for the most advanced refactoring, code analysis, and large-solution navigation scenarios
+- The C# Dev Kit's license restricts it to genuine Visual Studio Code specifically - it does not run on Cursor or other VS Code-compatible forks, a real limitation worth knowing if you're evaluating AI-centric editors built on the same codebase
+- Some advanced debugging and diagnostic scenarios that are native to Visual Studio require more extension configuration to replicate in VS Code
+
+**Choose this when:** you want a fast, lightweight, genuinely capable C# environment and value flexibility across multiple languages and technologies over the deepest possible .NET-specific tooling.
+
+## Cursor
+
+Cursor's core identity - covered in depth in the AI coding agents comparison in this series - is an AI-agent-centric editor built on VS Code's foundation. Its C# story used to be a real gap specifically because of the C# Dev Kit's licensing restriction; that changed meaningfully in mid-2026.
+
+**Strengths:**
+
+- As of JetBrains' 2026.2 release, ReSharper now provides full C# tooling - inspections, Solution Explorer, refactorings, navigation, unit testing, and debugging - directly inside Cursor and other VS Code-compatible AI editors, closing what had been the most significant .NET-specific gap in this class of tool
+- Combines genuinely strong AI-agent capabilities (covered in this series' AI coding agents comparison) with, as of 2026.2, real first-party-quality C# tooling rather than a compromised community extension
+- Built on the same VS Code foundation, so the broader extension ecosystem and familiar editing experience carry over for developers already comfortable with VS Code
+
+**Weaknesses:**
+
+- Prior to mid-2026, Cursor genuinely lacked a trustworthy, full-featured C# debugging story, since Microsoft's official extension is licensed against exactly this kind of fork - worth knowing if you're reading older comparisons or advice
+- Even with ReSharper's extension, Cursor is fundamentally an AI-agent-first editor - its C# tooling, while now genuinely strong, is a newer addition rather than the core identity of the product
+- A paid Pro tier is where the deepest agent capabilities live, adding cost on top of any ReSharper licensing needed for the full C# experience
+
+**Choose this when:** AI-agent-driven development is central to your workflow and you specifically want that combined with genuinely capable C# tooling - a combination that's now real as of ReSharper's 2026.2 release, but wasn't reliably available before.
+
+## Neovim
+
+Neovim is the terminal-first option in this comparison - a highly extensible, keyboard-driven editor with no GUI overhead, where .NET support comes through the Language Server Protocol rather than a purpose-built C# extension or IDE feature set.
+
+**Strengths:**
+
+- Genuinely the lightest-weight option here by a wide margin - runs comfortably over SSH, on modest hardware, or inside a terminal multiplexer alongside other tools
+- Fully keyboard-driven and endlessly customizable, appealing strongly to developers who want their editor configured exactly to their own workflow rather than accepting an IDE's defaults
+- Works well with `csharp-ls` or OmniSharp as a language server, providing real IntelliSense, go-to-definition, and diagnostics without a heavyweight IDE
+- Naturally fits a broader terminal-centric toolchain - tmux, fzf, ripgrep, and similar tools compose naturally around it
+
+**Weaknesses:**
+
+- Genuinely more setup required than any other option here - there's no out-of-the-box .NET experience; you're assembling a language server, debugging support (via `nvim-dap` and a .NET debug adapter), and completion plugins yourself
+- Debugging support, while possible, is meaningfully less polished and more manual to configure than any GUI-based option in this comparison
+- A real learning curve, both for Neovim itself (if coming from a GUI editor) and for the .NET-specific configuration needed to get a comparable experience to the other four options
+
+**Choose this when:** you're already comfortable in a terminal-first, keyboard-driven workflow and specifically want a lightweight, fully customized .NET setup - not a good fit if you want a working experience with minimal configuration effort.
+
+## How to Decide
+
+A few heuristics that cover most real-world decisions:
+
+**On Windows, deep in the Microsoft/Azure ecosystem, or doing Windows desktop development?** Visual Studio remains the deepest, most complete option - and Community edition is free for most individual and small-team use.
+
+**Want the strongest cross-platform .NET experience, especially on macOS or Linux?** Rider is the clear answer, particularly now that Visual Studio for Mac is gone - its refactoring and navigation strength are worth the subscription for many teams.
+
+**Want a fast, lightweight, genuinely capable editor that also handles other languages well?** VS Code with the C# Dev Kit covers a huge share of real-world .NET work without Visual Studio's or Rider's resource footprint.
+
+**AI-agent-driven development is central to your workflow, and you need real C# tooling alongside it?** Cursor is now a legitimate option as of ReSharper's 2026.2 release - check that release timing against whatever guide or recommendation you're reading, since this was a genuinely recent shift.
+
+**Terminal-first, keyboard-driven, and willing to invest setup time for full customization?** Neovim delivers a genuinely lightweight .NET workflow, at the cost of assembling it yourself rather than getting it out of the box.
+
+Platform constraints often decide this before feature comparisons even matter - if you're on macOS, Visual Studio simply isn't a full option anymore, which makes Rider or VS Code the realistic choices regardless of other preferences.
+
+## Frequently Asked Questions
+
+### Is Visual Studio for Mac really gone?
+
+Yes - Microsoft has officially retired Visual Studio for Mac. macOS developers wanting a full .NET IDE experience should move to JetBrains Rider or use VS Code with the C# Dev Kit instead; there's no path forward on Visual Studio for Mac itself.
+
+### Can I use Microsoft's C# Dev Kit in Cursor?
+
+No - the C# Dev Kit's license restricts it to genuine Visual Studio Code specifically, and it does not run on Cursor or other VS Code-compatible forks. This was a real gap for .NET developers wanting to use Cursor until JetBrains extended ReSharper to cover exactly this scenario as of their 2026.2 release.
+
+### Is JetBrains Rider actually better than Visual Studio for C# development?
+
+For day-to-day coding, refactoring, and navigation, many experienced .NET developers genuinely think so, even on Windows where Visual Studio is also fully available. Visual Studio retains real advantages in specific areas - deepest Azure integration, Windows-specific designers, and certain advanced diagnostic tooling - so the honest answer depends on which parts of the workflow matter most to you.
+
+### Is Visual Studio Community actually free for real projects, or just for evaluation?
+
+It's genuinely free for individual developers, open-source projects, and teams of up to five people, including nearly all Professional-tier features - not just a time-limited trial. Larger teams or organizations need Professional or Enterprise licensing.
+
+### How good is C# support in VS Code compared to a few years ago?
+
+Substantially better - the C# Dev Kit, first released in 2023, moved VS Code from "workable in a pinch" to what's now widely described as genuinely solid for a real share of C# workflows. It still doesn't match Visual Studio's or Rider's depth for the most advanced scenarios, but it's a legitimate, actively maintained option now, not a compromise.
+
+### Is Neovim a realistic choice for professional .NET development, or just a novelty for enthusiasts?
+
+It's a genuine, if niche, choice - real .NET developers use Neovim productively with `csharp-ls`/OmniSharp and `nvim-dap` for debugging. It requires meaningfully more setup investment than any GUI option in this comparison, so it fits developers who specifically value that level of customization and terminal-first workflow over an out-of-the-box experience.
+
+### Should I choose my .NET editor based on AI agent capabilities or core C# tooling first?
+
+It depends on how central AI-assisted development is to your workflow, but core C# tooling (debugging, refactoring, navigation) is worth evaluating on its own merits regardless - a comparison of the top AI coding agents in this series covers the AI-specific side in depth. As of 2026.2, Cursor is no longer a compromise on the C# tooling side either, so the two considerations don't have to trade off against each other the way they used to.

--- a/src/posts/2028-07-11-getting-started-with-visual-studio.md
+++ b/src/posts/2028-07-11-getting-started-with-visual-studio.md
@@ -1,0 +1,132 @@
+---
+author: Steve Kaschimer
+date: 2028-07-11
+image: /images/posts/2028-07-11-hero.webp
+image_alt: "A dense, solid application-window glyph with a small four-pane Windows accent beside it, implying a heavyweight IDE with deep first-party platform integration."
+image_prompt: "A dark-mode technical editorial illustration on a near-black background with electric teal, amber, and off-white accents. Composition centers on a single dense, solid application-window glyph rendered as a filled rounded rectangle, with a small four-pane window accent positioned just beside it, implying deep first-party platform integration. A faint amber checklist icon with a few boxes checked sits subtly beneath, implying a deliberate installer workload selection. Mood is established, deep, and deliberately weighty. Avoid: vendor logos, brand colors, circuit-board textures, gears, or generic laptop clip art as the dominant motif."
+layout: post.njk
+site_title: Tech Notes
+summary: "The install wizard makes the first decision that matters most, and it's easy to get wrong: which workloads to install. A setup guide for deliberate workload selection, tuning background analysis scope for large solutions, and committing .editorconfig from day one."
+tags: ["dotnet", "tooling", "developer-productivity"]
+title: "Getting Started with Visual Studio for .NET Development"
+---
+
+Visual Studio's install wizard makes the first decision that matters most, and it's easy to get wrong: which workloads to install. Checking every box "just in case" turns a reasonable install into a multi-hour, disk-hungry mess; checking too few means discovering mid-project that you're missing Azure tooling or a specific project type. Getting this right at install time, plus a handful of settings worth changing from their defaults, is most of what separates a smooth Visual Studio setup from one that feels sluggish from day one.
+
+This guide covers installing Visual Studio with the right workloads, bootstrapping solution and project settings that keep a growing codebase fast to work in, the core debugging and diagnostic workflow that's Visual Studio's strongest differentiator, and the best practices that take advantage of what it does better than any other .NET editor. By the end you'll have a setup tuned for your actual work, not a default install carrying weight you don't need.
+
+If you're deciding between .NET IDEs and editors first, [a comparison of the top .NET IDEs and editors](/posts/2028-07-04-top-5-dotnet-ides-editors-compared/) covers where Visual Studio fits relative to Rider, VS Code, Cursor, and Neovim.
+
+## What You'll Need
+
+- Windows (Visual Studio for Mac has been discontinued - macOS developers should look at Rider or VS Code instead)
+- Enough disk space for your chosen workloads - budget generously; a full ASP.NET/Azure setup can run several gigabytes
+
+## Installing Visual Studio
+
+Download the Visual Studio Installer from Microsoft's site, then select workloads deliberately rather than everything available:
+
+- **ASP.NET and web development** - for any web API, MVC, Blazor, or Minimal API work
+- **.NET desktop development** - for WPF, WinForms, or console applications
+- **Azure development** - only if you're actually deploying to or integrating with Azure services
+- **Data storage and processing** - for SQL Server Data Tools and related database tooling
+
+Community edition is free for individual developers, open-source projects, and teams of up to five - confirm this covers your situation before assuming you need Professional or Enterprise.
+
+## Bootstrapping the Ideal Environment
+
+### Configure solution-wide settings that scale with codebase size
+
+For larger solutions, adjust these settings early rather than after performance starts to feel sluggish:
+
+**Tools → Options → Projects and Solutions → General**: Enable "Reload modified project files unless a build is in progress" and consider disabling "Track Active Item in Solution Explorer" for very large solutions, since it adds overhead as the tree grows.
+
+**Tools → Options → Text Editor → C# → Advanced**: Review background analysis scope - setting it to "Current document" rather than "Entire solution" can meaningfully improve responsiveness in large codebases, at the cost of not surfacing errors in files you haven't opened.
+
+### Set up EditorConfig for consistent formatting across the team
+
+```ini
+# .editorconfig
+[*.cs]
+indent_style = space
+indent_size = 4
+dotnet_sort_system_directives_first = true
+csharp_new_line_before_open_brace = all
+```
+
+Committing `.editorconfig` to source control means every team member's Visual Studio instance applies the same formatting rules automatically - this is the mechanism that keeps code style consistent without relying on individual settings.
+
+### Configure NuGet package sources
+
+**Tools → NuGet Package Manager → Package Manager Settings**: Confirm nuget.org is configured, and add any private feeds (Azure Artifacts, a company-internal feed) your organization uses. Getting this right once at setup avoids repeated "package not found" confusion later.
+
+### Enable useful but non-default productivity features
+
+**Tools → Options → Text Editor → C# → Advanced**: Enable "Show inheritance margin" for a visual indicator of interface implementations and overrides directly in the gutter - genuinely useful for navigating unfamiliar code, and off by default in some versions.
+
+## Core Workflow
+
+- **Use Solution Explorer's search and Go To (Ctrl+,) for navigation on large solutions**, rather than scrolling through the project tree manually.
+- **Set breakpoints with conditions and hit counts for debugging loops or high-frequency code paths.** Right-click a breakpoint for conditional options rather than manually stepping through many iterations to find the one you care about.
+- **Use Live Unit Testing (Enterprise edition) or the Test Explorer for continuous feedback** on test status as you edit, rather than manually re-running tests after every change.
+
+## Verifying Your Setup
+
+1. **The right workloads are installed** - confirm you can create a new project of each type your team actually works with, without a "missing workload" prompt
+2. **`.editorconfig` is being respected** - confirm formatting on save matches your committed configuration, not individual IDE defaults
+3. **NuGet restores work against all configured sources** - confirm a build pulls packages correctly from both public and any private feeds
+4. **Debugging performance is acceptable** - for a large solution, confirm breakpoints hit promptly and stepping doesn't lag noticeably
+
+## Best Practices
+
+**Install only the workloads you actually need, and add more later if required.** A lean install is faster to maintain, update, and reason about than a maximal one carrying unused weight.
+
+**Commit `.editorconfig` to source control from day one.** This is the single highest-leverage setting for keeping a team's Visual Studio instances producing consistent code style without manual coordination.
+
+**Use conditional breakpoints and tracepoints instead of littering code with temporary `Console.WriteLine` statements.** Visual Studio's debugger is genuinely powerful here - underusing it in favor of print debugging gives up real capability.
+
+**Adjust background analysis scope for large solutions if responsiveness degrades.** This is a real, known trade-off (less proactive error surfacing vs. better performance) worth tuning deliberately rather than accepting sluggishness as inevitable.
+
+**Take advantage of Visual Studio's profiling tools (Diagnostic Tools window, CPU/memory profilers) before reaching for a third-party profiler.** They're built in and often sufficient for the majority of performance investigation needs.
+
+## Comparison with JetBrains Rider
+
+| | Visual Studio | JetBrains Rider |
+| --- | --- | --- |
+| Platform | Windows only (Mac discontinued) | Windows, macOS, Linux |
+| Cost | Free (Community) to paid | Paid subscription |
+| Debugging depth | Best-in-class, deepest diagnostics | Excellent, cross-platform |
+| Azure/Windows integration | Deepest available | Solid but not as deep |
+| Resource usage | Heavier | Generally lighter, especially on large solutions |
+
+Visual Studio's advantage is depth within the Microsoft ecosystem specifically; Rider's is cross-platform reach and often better day-to-day responsiveness - the choice is less about raw capability and more about platform and ecosystem fit.
+
+## Frequently Asked Questions
+
+### Do I need Visual Studio Professional, or is Community enough?
+
+Community is genuinely free for individual developers, open-source projects, and teams of up to five, and includes nearly all Professional-tier features. Larger organizations need Professional or Enterprise licensing - confirm which category applies to you rather than assuming you need to pay.
+
+### Can I use Visual Studio on macOS?
+
+No - Visual Studio for Mac has been officially discontinued by Microsoft. macOS developers wanting a full .NET IDE experience should use JetBrains Rider or VS Code with the C# Dev Kit instead.
+
+### How do I keep a large solution from feeling sluggish?
+
+Adjust background analysis scope (Tools → Options → Text Editor → C# → Advanced) from "Entire solution" to "Current document," disable unnecessary real-time tracking features for very large solutions, and install only the workloads you actually use. These changes trade some proactive error-surfacing for meaningfully better responsiveness.
+
+### What's the easiest way to keep code formatting consistent across my team?
+
+Commit a `.editorconfig` file to your repository root. Visual Studio automatically applies its formatting rules to every team member's editor, without requiring individual IDE configuration or a separate formatting tool.
+
+### Does Visual Studio have good support for non-Windows deployment targets, like Linux containers?
+
+Yes - Docker and container tooling integrate well with Visual Studio's debugging and publish workflows, even though the IDE itself only runs on Windows. You can build, debug, and deploy to Linux containers from a Windows-based Visual Studio instance without issue.
+
+### How do conditional breakpoints work, and why should I use them?
+
+Right-click a breakpoint and choose "Conditions" to specify an expression that must be true for the breakpoint to actually pause execution - useful for a loop where you only care about a specific iteration, or a method called many times where only one particular call matters. This avoids manually stepping through irrelevant iterations to reach the one you actually need to inspect.
+
+### What's the most common mistake in a first Visual Studio setup?
+
+Installing every available workload "just in case," resulting in a heavier, slower install than actually needed. The second common mistake is not committing `.editorconfig` early, leading to inconsistent formatting across a team as more developers join and each brings their own default settings.

--- a/src/posts/2028-07-18-getting-started-with-rider.md
+++ b/src/posts/2028-07-18-getting-started-with-rider.md
@@ -1,0 +1,127 @@
+---
+author: Steve Kaschimer
+date: 2028-07-18
+image: /images/posts/2028-07-18-hero.webp
+image_alt: "A lighter application-window glyph with a small magnifying-glass accent beside it, implying sharp, native code intelligence rather than raw platform weight."
+image_prompt: "A dark-mode technical editorial illustration on a near-black background with electric teal, amber, and off-white accents. Composition centers on a single lighter, outlined application-window glyph with a small magnifying-glass accent positioned just beside it, implying sharp, native refactoring and navigation intelligence rather than raw platform weight. Three small platform-shape dots (a rounded square, a triangle-adjacent shape, and a penguin-free rounded outline) sit faintly beneath, implying cross-platform reach without depicting real OS logos. Mood is sharp, cross-platform, and confidently fast. Avoid: vendor logos, brand colors, circuit-board textures, gears, or generic laptop clip art as the dominant motif."
+layout: post.njk
+site_title: Tech Notes
+summary: "The reputation for being faster and smarter than Visual Studio for day-to-day C# work isn't marketing copy - it comes from ReSharper's static analysis engine running natively inside the IDE. A setup guide for Solution-Wide Analysis, ReSharper-native refactoring, and shared .editorconfig conventions."
+tags: ["dotnet", "tooling", "developer-productivity"]
+title: "Getting Started with JetBrains Rider for .NET Development"
+---
+
+Rider's reputation for being faster and smarter than Visual Studio for day-to-day C# work isn't marketing copy - it comes directly from ReSharper's static analysis engine running natively inside the IDE rather than as an add-on, plus a genuinely cross-platform foundation that makes it the strongest full .NET IDE choice on macOS or Linux now that Visual Studio for Mac is gone. Getting Rider tuned to your actual workflow, rather than accepting its (already good) defaults, is what separates "solid IDE" from "the IDE that finds your bugs before you write the test."
+
+This guide covers installing Rider, bootstrapping solution settings and code inspection profiles, the core refactoring and navigation workflow that's Rider's clearest strength, and the best practices for taking full advantage of ReSharper's analysis engine baked directly in. By the end you'll have a cross-platform .NET setup tuned for speed and depth.
+
+If you're deciding between .NET IDEs and editors first, [a comparison of the top .NET IDEs and editors](/posts/2028-07-04-top-5-dotnet-ides-editors-compared/) covers where Rider fits relative to Visual Studio, VS Code, Cursor, and Neovim.
+
+## What You'll Need
+
+- Windows, macOS, or Linux
+- A JetBrains account and an active Rider license (a free tier applies to certain use cases like students, open-source maintainers, and evaluation - check current terms for what applies to you)
+
+## Installing Rider
+
+Download Rider directly from JetBrains, or install via the JetBrains Toolbox App if you're already managing other JetBrains products (IntelliJ IDEA, PyCharm) and want centralized updates:
+
+```bash
+# Toolbox App handles installation and updates across all JetBrains IDEs
+```
+
+On first launch, sign in with your JetBrains account and open or create a solution.
+
+## Bootstrapping the Ideal Environment
+
+### Configure code inspection severity to match your team's standards
+
+**Settings → Editor → Inspection Settings → Inspection Severity**: ReSharper's inspection engine ships with sensible defaults, but review and adjust severity levels for rules your team feels strongly about - escalating some to errors, downgrading others that don't match your conventions.
+
+### Set up a shared code style via .editorconfig
+
+```ini
+# .editorconfig
+[*.cs]
+indent_style = space
+indent_size = 4
+csharp_new_line_before_open_brace = all
+dotnet_naming_rule.private_fields_should_be_camel_case.severity = warning
+```
+
+Rider respects `.editorconfig` the same way Visual Studio does, meaning a team can move between the two IDEs (or mix them) and get consistent formatting and naming conventions either way - worth committing early, especially for teams not fully standardized on one IDE.
+
+### Configure the built-in database tools, if you're working with SQL
+
+**View → Tool Windows → Database**: Rider includes a full-featured database tool (shared with JetBrains' DataGrip) for connecting to and querying SQL Server, PostgreSQL, and other databases directly, without a separate tool - worth setting up early if your workflow involves frequent direct database inspection.
+
+### Enable Rider's unit test runner for your test framework
+
+Rider auto-detects xUnit, NUnit, and MSTest projects and surfaces a Test Explorer-equivalent panel automatically - confirm your test projects are recognized and runnable directly from the IDE rather than only via `dotnet test` in a terminal.
+
+## Core Workflow
+
+- **Use Rider's Solution-Wide Analysis (the status bar indicator) to catch issues across the entire solution, not just the open file.** This runs continuously in the background and surfaces problems (unused code, potential null references, style violations) proactively.
+- **Lean on Rider's refactoring tools (Ctrl+Shift+R / ⌘⇧R) for renames, extractions, and more complex structural changes.** This is Rider's clearest strength over lighter editors - refactorings are semantically aware, not text-substitution-based.
+- **Use "Navigate To" (Ctrl+N / ⌘O) for fast symbol, file, and type navigation** rather than manually browsing the Solution Explorer tree, especially on large solutions.
+
+## Verifying Your Setup
+
+1. **Inspection severity matches team conventions** - confirm the rules you escalated or downgraded actually reflect the correct severity in the editor
+2. **`.editorconfig` is respected consistently** - confirm formatting and naming conventions apply automatically on save or reformat
+3. **Tests are discovered and runnable** - confirm your test projects appear in Rider's test runner and execute correctly
+4. **Solution-wide analysis is actively running** - confirm the status bar indicator shows analysis progress/completion, not an error state
+
+## Best Practices
+
+**Take advantage of Solution-Wide Analysis rather than only fixing issues in files you happen to open.** This is one of Rider's most valuable proactive features - underusing it means missing problems elsewhere in the codebase that the IDE already found for you.
+
+**Commit `.editorconfig` early, especially on teams mixing Rider and Visual Studio.** Both IDEs respect the same file, making it the most reliable way to keep formatting and naming consistent regardless of which IDE each developer uses.
+
+**Use Rider's refactoring tools instead of manual find-and-replace for renames and structural changes.** Semantically aware refactoring understands your code's actual structure, avoiding the false positives and missed references that text-based replacement risks.
+
+**Review and tune inspection severity deliberately, rather than accepting every default at face value.** ReSharper's engine is opinionated in places your team might reasonably disagree with - adjust rather than silently ignoring warnings you've decided don't apply.
+
+**Use the built-in database tools if your workflow involves frequent SQL work.** It's a genuine, full-featured capability included with Rider, not a lesser bundled extra - worth setting up rather than reaching for a separate standalone tool by default.
+
+## Comparison with Visual Studio
+
+| | JetBrains Rider | Visual Studio |
+| --- | --- | --- |
+| Platform | Windows, macOS, Linux | Windows only (Mac discontinued) |
+| Cost | Paid subscription | Free (Community) to paid |
+| Refactoring/navigation | Best-in-class, ReSharper-native | Strong, but generally considered less powerful |
+| Large solution performance | Strong | Can degrade without tuning |
+| Azure/Windows-specific tooling | Solid, not as deep | Deepest available |
+
+Rider's cross-platform reach and refactoring strength make it the natural choice outside Windows, or for teams who specifically value that navigation and inspection depth enough to justify the subscription over Visual Studio's free tier.
+
+## Frequently Asked Questions
+
+### Is Rider actually free for any use case?
+
+JetBrains offers free licensing for certain situations - students, teachers, open-source project maintainers, and evaluation periods are common examples - but most commercial use requires a paid subscription. Check JetBrains' current licensing terms directly to confirm what applies to your specific situation.
+
+### Does Rider work well on macOS and Linux, or is it a compromised port?
+
+It's a genuinely first-class experience on all three platforms - Rider isn't a Windows product ported elsewhere; it's built cross-platform from the ground up on the IntelliJ platform. This is precisely why it's the strongest full .NET IDE option on macOS now that Visual Studio for Mac has been discontinued.
+
+### What's Solution-Wide Analysis, and should I leave it enabled?
+
+It's Rider's continuous background analysis of your entire solution (not just open files), surfacing issues like unused code, potential bugs, and style violations proactively. Leave it enabled - it's one of Rider's most valuable features, and disabling it to save resources gives up a meaningful amount of the IDE's value.
+
+### Can Rider and Visual Studio coexist on a team, with different developers using each?
+
+Yes, and it's a reasonably common setup - both respect the same `.editorconfig` conventions, use compatible `.sln`/`.csproj` project formats, and work against the same Git repository without friction. Commit `.editorconfig` early to keep formatting and naming consistent regardless of which IDE a given developer prefers.
+
+### Is Rider's debugger as good as Visual Studio's?
+
+It's excellent and covers the vast majority of debugging scenarios most .NET developers need, including cross-platform debugging that Visual Studio can't offer at all (since it only runs on Windows). Visual Studio retains an edge in some of the most advanced diagnostic and profiling scenarios, but for typical day-to-day debugging, Rider is fully competitive.
+
+### How do I migrate my team's code style conventions from Visual Studio to Rider?
+
+If you already have a `.editorconfig` file, most conventions carry over directly since both IDEs read the same format. For ReSharper-specific inspection severities not covered by `.editorconfig`, you may need to configure Rider's inspection settings separately, though the two systems overlap significantly for common conventions.
+
+### What's the most common mistake in a first Rider setup?
+
+Not taking advantage of Solution-Wide Analysis and refactoring tools, using Rider more like a lightweight text editor than the deep IDE it actually is. The second common mistake is not committing `.editorconfig`, leading to inconsistent formatting on teams where some developers use Rider and others use Visual Studio or VS Code.

--- a/src/posts/2028-07-25-getting-started-with-vscode-dotnet.md
+++ b/src/posts/2028-07-25-getting-started-with-vscode-dotnet.md
@@ -1,0 +1,155 @@
+---
+author: Steve Kaschimer
+date: 2028-07-25
+image: /images/posts/2028-07-25-hero.webp
+image_alt: "A minimal outlined window glyph with no additional accents, implying a lightweight, general-purpose editor made genuinely capable through one well-integrated extension."
+image_prompt: "A dark-mode technical editorial illustration on a near-black background with electric teal, amber, and off-white accents. Composition centers on a single minimal outlined window glyph, thin-lined and uncluttered, implying a lightweight, general-purpose editor. A small amber puzzle-piece accent sits snugly fitted into the window's lower corner, implying one well-integrated extension rather than a full built-in IDE. Mood is fast, extensible, and unpretentious. Avoid: vendor logos, brand colors, circuit-board textures, gears, or generic laptop clip art as the dominant motif."
+layout: post.njk
+site_title: Tech Notes
+summary: "The C# story used to require manual extension-hunting to get something resembling IntelliSense and a working debugger. That's not the situation anymore - the C# Dev Kit bundles the pieces that matter into one coherent extension. A setup guide for workspace loading, debugging config, and the license restriction that excludes Cursor."
+tags: ["dotnet", "tooling", "developer-productivity"]
+title: "Getting Started with VS Code for .NET Development"
+---
+
+VS Code's C# story used to require a fair amount of manual extension-hunting to get something resembling IntelliSense and a working debugger. That's not the situation anymore - Microsoft's C# Dev Kit bundles the pieces that matter into one coherent extension, and the setup is now genuinely a few clicks rather than a scavenger hunt. The part still worth knowing deliberately: that extension is licensed specifically for genuine VS Code, not for Cursor or other VS Code-compatible forks, which matters if you're choosing between editors in this family.
+
+This guide covers installing VS Code and the C# Dev Kit, bootstrapping a project with the settings that keep a growing solution fast and consistent, the core debugging and testing workflow, and the best practices for getting a genuinely solid .NET experience out of what's still a lightweight, general-purpose editor at heart. By the end you'll have a fast, capable C# setup that doesn't carry a full IDE's resource footprint.
+
+If you're deciding between .NET IDEs and editors first, [a comparison of the top .NET IDEs and editors](/posts/2028-07-04-top-5-dotnet-ides-editors-compared/) covers where VS Code fits relative to Visual Studio, Rider, Cursor, and Neovim.
+
+## What You'll Need
+
+- Windows, macOS, or Linux
+- .NET 8 SDK or later, installed separately from VS Code itself
+
+## Installing VS Code and the C# Dev Kit
+
+Download VS Code from code.visualstudio.com, then install the extension from the Extensions view (Ctrl+Shift+X / ⌘⇧X):
+
+- **C# Dev Kit** - the primary extension, bundling IntelliSense, debugging, project management, and test integration
+- **C#** (base language extension, installed automatically as a dependency of C# Dev Kit)
+
+Confirm the .NET SDK is installed and discoverable:
+
+```bash
+dotnet --version
+```
+
+## Bootstrapping the Ideal Environment
+
+### Open a folder or workspace, not just individual files
+
+C# Dev Kit's project awareness (Solution Explorer-equivalent view, build integration, test discovery) activates properly when you open a folder containing a `.sln` or `.csproj` file, rather than opening loose `.cs` files individually - this is the single most common reason IntelliSense or the test explorer doesn't seem to be working as expected.
+
+### Configure workspace settings for the project
+
+```json
+// .vscode/settings.json
+{
+  "dotnet.defaultSolution": "MyApp.sln",
+  "omnisharp.enableEditorConfigSupport": true,
+  "editor.formatOnSave": true
+}
+```
+
+Committing `.vscode/settings.json` to source control (where appropriate for your team) ensures every developer's VS Code instance points at the right solution file and respects the same formatting behavior, rather than each person configuring it individually.
+
+### Set up launch and debugging configuration
+
+C# Dev Kit typically generates a `.vscode/launch.json` automatically the first time you start debugging, but reviewing and adjusting it is worth doing for non-default scenarios:
+
+```json
+// .vscode/launch.json
+{
+  "configurations": [
+    {
+      "name": "Launch API",
+      "type": "coreclr",
+      "request": "launch",
+      "program": "${workspaceFolder}/bin/Debug/net8.0/MyApp.Api.dll",
+      "args": [],
+      "cwd": "${workspaceFolder}",
+      "stopAtEntry": false
+    }
+  ]
+}
+```
+
+### Commit .editorconfig for consistent formatting
+
+```ini
+# .editorconfig
+[*.cs]
+indent_style = space
+indent_size = 4
+dotnet_sort_system_directives_first = true
+```
+
+The same `.editorconfig` mechanism used by Visual Studio and Rider works here too - this is what keeps formatting consistent across a team regardless of which of these editors each developer prefers.
+
+## Core Workflow
+
+- **Use the built-in Test Explorer (visible once C# Dev Kit detects test projects) rather than running `dotnet test` manually for iterative work.** It surfaces individual test results directly in the editor gutter.
+- **Set breakpoints and use the Debug panel (F5) the same way you would in a full IDE.** C# Dev Kit's debugging integration is genuinely solid for the majority of everyday debugging needs.
+- **Use "Go to Definition" and "Find All References" (F12 / Shift+F12) for navigation**, which work correctly once the project is properly loaded as a folder/workspace.
+
+## Verifying Your Setup
+
+1. **IntelliSense is working** - confirm autocomplete, hover documentation, and error squiggles appear correctly for your project's types
+2. **The project loaded as a workspace, not loose files** - confirm a Solution Explorer-equivalent panel shows your actual project structure
+3. **Debugging works end to end** - confirm F5 builds, launches, and correctly hits breakpoints
+4. **Tests are discovered** - confirm your test projects appear in the Test Explorer and can be run individually or as a full suite
+
+## Best Practices
+
+**Always open the folder containing your `.sln` or `.csproj`, never individual loose files.** This is the root cause of the vast majority of "IntelliSense isn't working" issues in VS Code for C#.
+
+**Commit `.vscode/settings.json` and `.editorconfig` where appropriate for your team.** This keeps every developer's environment configured consistently without individual setup effort, the same discipline that applies across every IDE in this comparison.
+
+**Use the C# Dev Kit specifically - confirm it's genuine VS Code, not a compatible fork.** Its license restricts it to official VS Code; if you're using Cursor or another fork, you'll need a different C# tooling path (see this series' Cursor guide).
+
+**Don't expect VS Code to match Visual Studio's or Rider's most advanced refactoring and analysis depth.** It's a genuinely capable, lightweight option - not a full IDE replacement for every scenario, particularly very large solutions or the deepest diagnostic tooling.
+
+**Take advantage of VS Code's broader extension ecosystem alongside C# Dev Kit.** Docker, Kubernetes, and cloud tooling extensions integrate naturally in the same editor, which is a real advantage for full-stack or infrastructure-adjacent .NET work.
+
+## Comparison with Cursor
+
+| | VS Code | Cursor |
+| --- | --- | --- |
+| C# tooling | C# Dev Kit, first-party Microsoft | ReSharper extension (2026.2+), JetBrains |
+| License restriction | None for its own extension | C# Dev Kit specifically doesn't run here; use ReSharper's extension instead |
+| AI agent capabilities | Via GitHub Copilot or other extensions | Native, agent-centric by design |
+| Foundation | The original VS Code codebase | A fork of VS Code |
+| Best fit | Teams wanting official Microsoft tooling with broad extension support | Teams wanting AI-agent-centric workflows with genuine C# tooling |
+
+Both share the same core editing experience since Cursor is built on VS Code's foundation - the meaningful difference is which C# extension path is actually available to you, and how central AI-agent workflows are to your day-to-day development.
+
+## Frequently Asked Questions
+
+### Why isn't IntelliSense working even though I installed C# Dev Kit?
+
+The most common cause is opening individual `.cs` files rather than opening the folder containing your `.sln` or `.csproj` file - C# Dev Kit needs project context to provide full IntelliSense, and that context only loads when you open the project as a workspace.
+
+### Can I use the C# Dev Kit in Cursor?
+
+No - its license restricts it to genuine Visual Studio Code specifically. If you're using Cursor, JetBrains' ReSharper extension (available as of their 2026.2 release) is the path to full C# tooling, including debugging, in that editor instead.
+
+### Is VS Code good enough to replace Visual Studio for real .NET work?
+
+For a genuinely large share of workflows, yes - the C# Dev Kit provides strong IntelliSense, debugging, and test integration. For the most advanced refactoring, diagnostic, and large-solution scenarios, Visual Studio or Rider still have an edge, so the right answer depends on how deep your specific needs go.
+
+### How do I configure which solution VS Code should use if I have multiple in my workspace?
+
+Set `"dotnet.defaultSolution"` in `.vscode/settings.json` to point at the specific `.sln` file you want C# Dev Kit to use as the active solution, avoiding ambiguity if your workspace folder contains more than one.
+
+### Does VS Code support debugging Blazor or ASP.NET Core applications?
+
+Yes - C# Dev Kit's debugging integration handles ASP.NET Core (including Minimal APIs, MVC, and Blazor) the same way it handles any other .NET project type, with breakpoints, variable inspection, and the standard debugging toolbar.
+
+### Is VS Code free to use for commercial .NET development?
+
+Yes - both VS Code itself and the C# Dev Kit extension are free to use, including for commercial development, without the licensing considerations that apply to Visual Studio Professional/Enterprise or Rider's subscription.
+
+### What's the most common mistake in a first VS Code setup for .NET?
+
+Opening loose `.cs` files instead of the project folder, leading to confusing IntelliSense and navigation failures that look like a broken installation but are actually a workspace-loading issue. The second common mistake is expecting Cursor to work identically to VS Code for C# tooling, when the C# Dev Kit's licensing specifically excludes that fork.

--- a/src/posts/2028-08-01-getting-started-with-cursor-dotnet.md
+++ b/src/posts/2028-08-01-getting-started-with-cursor-dotnet.md
@@ -1,0 +1,145 @@
+---
+author: Steve Kaschimer
+date: 2028-08-01
+image: /images/posts/2028-08-01-hero.webp
+image_alt: "The same minimal outlined window glyph used for VS Code, paired with a small spark accent, implying AI-agent capability layered on top of a genuinely capable C# tooling foundation."
+image_prompt: "A dark-mode technical editorial illustration on a near-black background with electric teal, amber, and off-white accents. Composition centers on a minimal outlined window glyph, visually similar to a companion illustration in this same series, but with a small spark or star-burst accent positioned at its upper corner, implying AI-agent capability layered on top of the same editing foundation. A faint amber puzzle-piece accent (echoing a sibling illustration) sits fitted into the window's lower corner, implying a newly closed tooling gap. Mood is agentic, capable, and recently completed. Avoid: vendor logos, brand colors, circuit-board textures, gears, or generic laptop clip art as the dominant motif."
+layout: post.njk
+site_title: Tech Notes
+summary: "The C# story had a real, well-known gap until mid-2026: the C# Dev Kit refuses to run on VS Code forks, leaving Cursor users doing .NET work with a degraded experience - until JetBrains extended ReSharper's full engine into Cursor. A setup guide for installing ReSharper's extension and combining Agent mode with real-time inspections."
+tags: ["dotnet", "tooling", "developer-productivity", "ai-coding-tools"]
+title: "Getting Started with C# Development in Cursor"
+---
+
+Cursor already got a full getting-started treatment elsewhere in this series, focused on its AI-agent workflow - rules, MCP, Background Agents. This guide covers different ground: the actual C# development experience, which had a real, well-known gap until mid-2026. Microsoft's C# Dev Kit is licensed specifically for genuine Visual Studio Code and refuses to run on Cursor or other compatible forks, which meant Cursor users doing .NET work were stuck with a degraded experience - until JetBrains extended ReSharper's full engine, debugging included, directly into Cursor as of their 2026.2 release.
+
+This guide covers installing and configuring ReSharper's extension for Cursor, bootstrapping a .NET project so both the C# tooling and Cursor's AI-agent capabilities work well together, the core debugging and refactoring workflow now available, and the best practices for combining genuinely capable C# tooling with agent-assisted development in one editor. By the end you'll have closed the gap that used to make Cursor a compromise for serious .NET work.
+
+If you're deciding between .NET IDEs and editors first, [a comparison of the top .NET IDEs and editors](/posts/2028-07-04-top-5-dotnet-ides-editors-compared/) covers where Cursor fits relative to Visual Studio, Rider, VS Code, and Neovim. For Cursor's AI-agent setup specifically (rules, MCP, background agents), see this series' dedicated Cursor getting-started guide.
+
+## What You'll Need
+
+- Cursor installed (see this series' AI coding agents getting-started guide for base installation)
+- .NET 8 SDK or later
+- A ReSharper license covering Cursor's extension - confirm current JetBrains licensing terms, since this is a relatively new offering as of 2026.2
+
+## Installing ReSharper for Cursor
+
+Install the ReSharper extension from Cursor's extension marketplace (or the Open VSX registry, depending on how your Cursor installation is configured), then sign in with your JetBrains account to activate the license.
+
+Confirm the .NET SDK is discoverable:
+
+```bash
+dotnet --version
+```
+
+## Bootstrapping the Ideal Environment
+
+### Open the project as a folder containing your solution
+
+The same rule that applies to VS Code's C# Dev Kit applies here - open the folder containing your `.sln` or `.csproj` file, not individual loose `.cs` files, so ReSharper's engine can load full project context.
+
+### Configure inspection severity to match your team's conventions
+
+ReSharper's inspection engine inside Cursor carries the same configurability as it does in Rider - review default severities and adjust to your team's actual standards rather than accepting every default:
+
+```ini
+# .editorconfig
+[*.cs]
+indent_style = space
+indent_size = 4
+dotnet_naming_rule.private_fields_should_be_camel_case.severity = warning
+```
+
+Since `.editorconfig` is respected consistently across Visual Studio, Rider, VS Code, and now Cursor via this extension, a team mixing editors can still converge on the same formatting and naming conventions.
+
+### Set up debugging configuration
+
+```json
+// .vscode/launch.json
+{
+  "configurations": [
+    {
+      "name": "Launch API",
+      "type": "coreclr",
+      "request": "launch",
+      "program": "${workspaceFolder}/bin/Debug/net8.0/MyApp.Api.dll",
+      "cwd": "${workspaceFolder}",
+      "stopAtEntry": false
+    }
+  ]
+}
+```
+
+This is the debugging capability that was the most significant gap before ReSharper's 2026.2 extension - confirm breakpoints, variable inspection, and step-through debugging all work correctly, since this is genuinely new territory for Cursor users coming from a prior, more limited setup.
+
+### Combining AI-agent workflows with real C# tooling
+
+With both pieces in place, a practical pattern: use Cursor's Agent mode for larger, multi-file changes, and lean on ReSharper's inline inspections and quick-fixes for the moment-to-moment correctness feedback an agent's generated code should still be checked against. The two are complementary, not competing - an agent can write a large refactor, and ReSharper's real-time analysis catches issues in that generated code the same way it would for hand-written code.
+
+## Core Workflow
+
+- **Use ReSharper's Solution-Wide Analysis and inspections for the same proactive issue-catching Rider provides**, now available without leaving Cursor's AI-agent-centric environment.
+- **Use Cursor's Agent mode for larger structural changes, and verify the result against ReSharper's inspections and tests**, rather than trusting agent-generated code without the same scrutiny you'd apply to hand-written code.
+- **Use "Find All References" and semantic navigation from ReSharper's engine**, not just Cursor's built-in (VS Code-derived) navigation, for the most accurate results in C# specifically.
+
+## Verifying Your Setup
+
+1. **ReSharper is active and licensed correctly** - confirm inspections, quick-fixes, and code completion reflect ReSharper's engine, not just base VS Code-derived C# support
+2. **Debugging works end to end** - confirm breakpoints, stepping, and variable inspection all function correctly, since this was the most significant prior gap
+3. **`.editorconfig` conventions are respected** - confirm formatting and naming rules apply consistently
+4. **Solution-wide analysis runs correctly** - confirm issues are surfaced across the whole solution, not just the currently open file
+
+## Best Practices
+
+**Confirm your ReSharper-for-Cursor license and extension version are current**, given how recently (2026.2) this capability shipped - don't assume older guidance or Stack Overflow answers reflect the current state of what's possible.
+
+**Use ReSharper's inspections to verify AI-agent-generated code, not just your own hand-written code.** This is a genuinely useful combination - an agent moves fast, and real-time static analysis catches issues in what it produces the same way it would for anyone else's code.
+
+**Don't assume every Rider feature is present identically inside Cursor's extension.** It's genuinely comprehensive as of its 2026.2 release, but confirm specific advanced features you rely on are actually available before assuming full parity.
+
+**Keep `.editorconfig` as your source of truth for team-wide formatting**, since it's the one mechanism that stays consistent whether a given team member is in Cursor, VS Code, Rider, or Visual Studio.
+
+**Evaluate whether you need both a ReSharper license and Cursor's Pro tier**, and budget for both if your workflow genuinely needs full capability from each - this is a real, combined cost worth accounting for deliberately.
+
+## Comparison with VS Code
+
+| | Cursor (with ReSharper extension) | VS Code (with C# Dev Kit) |
+| --- | --- | --- |
+| C# tooling provider | JetBrains ReSharper (2026.2+) | Microsoft, first-party |
+| Debugging | Now available via ReSharper | Native via C# Dev Kit |
+| AI agent capabilities | Native, agent-centric by design | Via GitHub Copilot or other extensions |
+| Licensing | Requires ReSharper license + Cursor | Free (C# Dev Kit itself has no separate cost) |
+| Best fit | AI-agent-centric workflows needing genuine C# depth | Official Microsoft tooling, broadest extension compatibility |
+
+The practical trade-off is licensing cost and provider (JetBrains vs. Microsoft) versus how central AI-agent-driven development is to your actual workflow - both now offer genuinely capable C# tooling, which wasn't true for Cursor before mid-2026.
+
+## Frequently Asked Questions
+
+### Why couldn't I use full C# tooling in Cursor before 2026?
+
+Microsoft's C# Dev Kit extension is licensed specifically for genuine Visual Studio Code and refuses to run on Cursor or other compatible forks. Before JetBrains extended ReSharper to cover this gap in their 2026.2 release, Cursor users doing .NET work had a meaningfully more limited experience - weaker IntelliSense and no reliable first-party debugging.
+
+### Does ReSharper's Cursor extension include debugging?
+
+Yes, as of the 2026.2 release - this was specifically the most significant capability that had been missing, and its inclusion is what makes the extension a genuine full-C#-tooling solution rather than a partial one.
+
+### Do I need a separate ReSharper license to use this in Cursor?
+
+Yes - confirm current JetBrains licensing terms for the Cursor-specific offering, since this is a relatively new product as of 2026.2 and terms may continue to be refined. It's a real, additional cost on top of any Cursor subscription.
+
+### Can I use both Cursor's native AI agent features and ReSharper's inspections together?
+
+Yes, and this is the combination the setup is designed for - use Cursor's Agent mode for larger, AI-driven changes, and let ReSharper's real-time inspections and quick-fixes verify the resulting code the same way they would for hand-written changes.
+
+### Is this the same ReSharper engine used in Rider, or a lighter version?
+
+It's described as bringing the full engine - inspections, Solution Explorer, refactorings, navigation, unit testing, and debugging - the same one Rider is built on, rather than a stripped-down subset. Confirm specific advanced features you rely on are present if you're migrating a workflow that depends on them.
+
+### Should I use VS Code or Cursor if I want the official Microsoft C# tooling specifically?
+
+VS Code - the C# Dev Kit's licensing is specific to genuine Visual Studio Code. If official, first-party Microsoft tooling matters to you specifically (versus JetBrains' ReSharper engine), VS Code is the only option between the two that supports it.
+
+### What's the most common mistake when setting up C# development in Cursor?
+
+Assuming Cursor's built-in, VS Code-derived C# support (without the ReSharper extension) is sufficient for serious .NET work, and being surprised by weaker IntelliSense and debugging gaps. The second common mistake is not budgeting for the combined cost of a ReSharper license alongside Cursor's own subscription tiers.

--- a/src/posts/2028-08-08-getting-started-with-neovim-dotnet.md
+++ b/src/posts/2028-08-08-getting-started-with-neovim-dotnet.md
@@ -1,0 +1,194 @@
+---
+author: Steve Kaschimer
+date: 2028-08-08
+image: /images/posts/2028-08-08-hero.webp
+image_alt: "A bare terminal-prompt bracket glyph with no window frame at all, implying an editor assembled entirely from individually configured, keyboard-driven pieces."
+image_prompt: "A dark-mode technical editorial illustration on a near-black background with electric teal, amber, and off-white accents. Composition centers on a single bare terminal-prompt bracket glyph (a simple `>` chevron shape) with no surrounding window frame at all, implying an editor assembled entirely from individually configured pieces rather than a bundled application. A few small disconnected building-block shapes float loosely around the bracket, implying separate components (language server, completion, debugger) waiting to be wired together. Mood is minimal, self-assembled, and deliberately unbundled. Avoid: vendor logos, brand colors, circuit-board textures, gears, or generic laptop clip art as the dominant motif."
+layout: post.njk
+site_title: Tech Notes
+summary: "Every other editor in this track gives you IntelliSense and debugging the moment you install it. Neovim gives you neither - you assemble both yourself. A setup guide for csharp-ls via nvim-lspconfig, nvim-dap paired with netcoredbg, and building configuration incrementally."
+tags: ["dotnet", "tooling", "developer-productivity"]
+title: "Getting Started with Neovim for .NET Development"
+---
+
+Every other editor in this series gives you IntelliSense and debugging the moment you install it. Neovim gives you neither - you assemble both yourself, from a language server, a completion plugin, and a debug adapter, each configured explicitly. That's the honest trade the whole editor makes: nothing works until you wire it up, and once you have, it's exactly the setup you wanted, running exactly as fast as your hardware allows, with none of a GUI IDE's overhead.
+
+This guide covers installing Neovim and the pieces that make C# development genuinely functional - a language server, completion, and debugging - bootstrapping a configuration that stays maintainable as it grows, the core navigation and debugging workflow once everything's connected, and the best practices for keeping a from-scratch .NET setup working reliably. By the end you'll have a lightweight, fully keyboard-driven .NET environment built entirely to your own specification.
+
+If you're deciding between .NET IDEs and editors first, [a comparison of the top .NET IDEs and editors](/posts/2028-07-04-top-5-dotnet-ides-editors-compared/) covers where Neovim fits relative to Visual Studio, Rider, VS Code, and Cursor.
+
+## What You'll Need
+
+- Neovim 0.9 or later
+- .NET 8 SDK or later
+- A plugin manager (lazy.nvim is the current standard choice for new configurations)
+- Comfort editing Lua, since modern Neovim configuration is written in it
+
+## Installing Neovim and Core Dependencies
+
+```bash
+# macOS
+brew install neovim
+
+# Linux (via package manager, or download a release binary)
+# Windows: via winget or Scoop
+winget install Neovim.Neovim
+```
+
+Install a C# language server - `csharp-ls` is a lighter-weight option; OmniSharp is the more established, heavier alternative with broader feature coverage:
+
+```bash
+dotnet tool install --global csharp-ls
+```
+
+## Bootstrapping the Ideal Environment
+
+### Set up a plugin manager
+
+```lua
+-- ~/.config/nvim/lua/config/lazy.lua
+require("lazy").setup({
+  { "neovim/nvim-lspconfig" },
+  { "hrsh7th/nvim-cmp" },
+  { "hrsh7th/cmp-nvim-lsp" },
+  { "mfussenegger/nvim-dap" },
+  { "rcarriga/nvim-dap-ui" },
+})
+```
+
+### Configure the C# language server
+
+```lua
+-- ~/.config/nvim/lua/config/lsp.lua
+local lspconfig = require("lspconfig")
+
+lspconfig.csharp_ls.setup({
+  capabilities = require("cmp_nvim_lsp").default_capabilities(),
+})
+```
+
+This gives you the core IDE-like features - go-to-definition, hover documentation, diagnostics, and completion - driven by the language server rather than a purpose-built extension the way VS Code or Rider provide out of the box.
+
+### Configure completion
+
+```lua
+-- ~/.config/nvim/lua/config/completion.lua
+local cmp = require("cmp")
+
+cmp.setup({
+  sources = {
+    { name = "nvim_lsp" },
+  },
+  mapping = cmp.mapping.preset.insert({
+    ["<Tab>"] = cmp.mapping.select_next_item(),
+    ["<CR>"] = cmp.mapping.confirm({ select = true }),
+  }),
+})
+```
+
+### Configure debugging with nvim-dap
+
+Debugging is the piece that requires the most deliberate setup - Neovim has no built-in debug adapter for .NET, so you configure `nvim-dap` against `netcoredbg`:
+
+```bash
+# Install netcoredbg (the .NET debug adapter), platform-specific instructions vary
+```
+
+```lua
+-- ~/.config/nvim/lua/config/dap.lua
+local dap = require("dap")
+
+dap.adapters.coreclr = {
+  type = "executable",
+  command = "/path/to/netcoredbg/netcoredbg",
+  args = { "--interpreter=vscode" },
+}
+
+dap.configurations.cs = {
+  {
+    type = "coreclr",
+    name = "Launch API",
+    request = "launch",
+    program = function()
+      return vim.fn.input("Path to dll: ", vim.fn.getcwd() .. "/bin/Debug/net8.0/", "file")
+    end,
+  },
+}
+```
+
+This is meaningfully more setup than any other editor in this comparison requires, and it's exactly the trade-off Neovim asks you to accept - full control over the configuration, in exchange for none of it being automatic.
+
+### Set up EditorConfig support
+
+```lua
+{ "editorconfig/editorconfig-vim" }
+```
+
+The same `.editorconfig` mechanism every other editor in this series respects works here too, once the plugin is installed - keeping formatting consistent with teammates using Visual Studio, Rider, VS Code, or Cursor.
+
+## Core Workflow
+
+- **Use LSP-provided navigation (`gd` for go-to-definition, `gr` for references) once the language server is configured.** These map to the same underlying capability IDEs provide, just triggered by keybindings you define yourself.
+- **Use `nvim-dap-ui` to get a visual debugging panel** (variables, call stack, breakpoints) rather than working with `nvim-dap`'s commands alone - it closes much of the usability gap with a GUI debugger.
+- **Build your configuration incrementally, adding plugins as you hit real friction**, rather than trying to replicate every IDE feature on day one. A working, minimal setup is more valuable than an ambitious, half-finished one.
+
+## Verifying Your Setup
+
+1. **The language server attaches correctly** - confirm `:LspInfo` shows `csharp_ls` (or OmniSharp) active and attached to your buffer
+2. **Completion and navigation work** - confirm autocomplete suggestions, hover documentation, and go-to-definition all function correctly
+3. **Debugging connects and hits breakpoints** - confirm `nvim-dap` launches your application and breakpoints pause execution as expected
+4. **`.editorconfig` is respected** - confirm formatting matches your committed configuration
+
+## Best Practices
+
+**Start with a minimal, working configuration and add capability incrementally.** Trying to replicate every IDE feature before writing any real code is a common way to lose momentum on a from-scratch Neovim setup.
+
+**Use `csharp-ls` for a lighter footprint, or OmniSharp if you need its broader feature coverage.** Neither is strictly better - `csharp-ls` is faster to set up and lighter-weight; OmniSharp has a longer track record and more comprehensive feature support in some areas.
+
+**Invest specifically in `nvim-dap-ui`, not just `nvim-dap` alone.** Bare `nvim-dap` works but is meaningfully less usable day-to-day than having a proper visual panel for variables, breakpoints, and the call stack.
+
+**Keep your configuration in version control.** A Neovim setup this customized is worth treating as a real, versioned artifact - both for your own history and so you can restore it on a new machine without rebuilding from memory.
+
+**Be realistic about the setup investment before committing.** Neovim's .NET experience can be genuinely excellent, but it requires meaningfully more upfront work than any other option in this comparison - worth it specifically for developers who value that level of control and a terminal-first workflow.
+
+## Comparison with VS Code
+
+| | Neovim | VS Code |
+| --- | --- | --- |
+| Setup effort | High - assemble LSP, completion, debugging yourself | Low - install C# Dev Kit and go |
+| Resource usage | Lightest of any option in this comparison | Light, but heavier than Neovim |
+| Customization | Complete - every piece is yours to configure | Substantial, via settings and extensions |
+| Debugging | Possible via nvim-dap, more manual | Native, works out of the box |
+| Best fit | Terminal-first developers wanting full control | Developers wanting a working setup with minimal configuration |
+
+Neovim's advantage is total control and minimal resource footprint; VS Code's is a working .NET experience in minutes rather than hours - the trade-off is genuinely about how much setup investment you're willing to make for that control.
+
+## Frequently Asked Questions
+
+### Is Neovim actually viable for professional .NET development, or is it mostly a novelty?
+
+It's genuinely viable and used productively by real .NET developers, particularly those already comfortable in a terminal-first, keyboard-driven workflow. It requires substantially more setup than any GUI option in this comparison, so it fits a specific kind of developer rather than being a universal recommendation.
+
+### Should I use csharp-ls or OmniSharp?
+
+`csharp-ls` is lighter-weight and faster to set up; OmniSharp has a longer track record and broader feature coverage in some areas, at the cost of being heavier. Try `csharp-ls` first for a simpler setup, and move to OmniSharp if you hit a specific feature gap it doesn't cover.
+
+### How do I get a debugger working for .NET in Neovim?
+
+Install `netcoredbg` as the debug adapter, configure `nvim-dap` to use it (specifying the adapter command and a launch configuration), and add `nvim-dap-ui` for a usable visual debugging panel. This is the most setup-intensive piece of a Neovim .NET configuration, with no equivalent to a GUI IDE's out-of-the-box debugging.
+
+### Can I use .editorconfig with Neovim the same way I would with Visual Studio or Rider?
+
+Yes, via the `editorconfig-vim` plugin (or Neovim's growing native support in recent versions) - this keeps formatting conventions consistent with teammates using any other editor in this comparison, since `.editorconfig` isn't tied to any specific tool.
+
+### How much time should I budget for setting up a working .NET environment in Neovim?
+
+Meaningfully more than any other editor here - expect real, hands-on configuration time rather than an install-and-go experience. Budget for this honestly before committing, especially if you're doing it for the first time rather than reusing an existing configuration.
+
+### Does Neovim support refactoring tools comparable to Rider's or Visual Studio's?
+
+To a degree, depending on your language server's capabilities and any additional plugins you configure, but generally not to the same depth as Rider's ReSharper-powered refactoring engine. This is a real capability gap worth knowing about if deep, semantically-aware refactoring is central to your workflow.
+
+### What's the most common mistake in a first Neovim .NET setup?
+
+Trying to replicate every feature of a full IDE before writing any real code, losing momentum on configuration rather than getting to a minimal, working setup quickly and building from there. The second common mistake is skipping `nvim-dap-ui`, ending up with a functional but genuinely unpleasant debugging experience compared to what a small amount of additional configuration would provide.


### PR DESCRIPTION
## Summary

- Schedules and drafts the .NET IDEs & Editors Tuesday track (July-August 2028), continuing the weekly Tuesday cadence from the Auth & Identity for .NET track
- Six posts: an anchor comparison post (`The Top 5 .NET IDEs & Editors Compared`) plus getting-started guides for Visual Studio, JetBrains Rider, VS Code, C# development in Cursor (via JetBrains' 2026.2 ReSharper extension), and Neovim
- `editorial-plan.md` updated: series moved from Backlog into a new dated section, all 6 entries marked `Status: draft`. This is the final series drawn from the current `docs/article-ideas/` backlog - the Backlog section is now empty.

## Test plan

- [x] `npm run deploy` builds all posts (including this track's 6 new files) without error
- [x] `node scripts/a11y-check.js` (axe-core, WCAG 2.1 A/AA, light + dark) reports zero violations across home/post/about/privacy/terms/404
- [x] Verified each getting-started post cross-links back to the anchor comparison post
- [x] Verified each post's built `_site/posts/.../index.html` exists
- [x] `editorial-plan.md` CRLF line endings preserved (verified via `file` and byte-count check)


---
_Generated by [Claude Code](https://claude.ai/code/session_01WKyNF7L5qzrfct8cec6A32)_