### PR TITLE
Add Modern Application Architecture Patterns in .NET series, volume 2 (49 posts)

### DIFF
--- a/editorial-plan.md
+++ b/editorial-plan.md
@@ -2039,6 +2039,453 @@ Fifty-five posts translating Martin Fowler's *Patterns of Enterprise Application
 
 ---
 
+## 📅 Sunday Track - Modern Application Architecture Patterns in .NET (Volume 2) (September 2029-August 2030)
+
+Forty-nine posts continuing the Modern Application Architecture Patterns in .NET series past Volume I's Fowler-catalog foundation - dependency injection, Clean/Hexagonal/Vertical Slice architecture, Domain-Driven Design building blocks, CQRS, messaging and event-driven patterns, distributed workflow coordination, resilience patterns, and architecture-at-scale concerns such as feature flags, health checks, rate limiting, and leader election. Runs weekly on Sundays immediately following Volume I as a standing series alongside the Tuesday .NET tracks. This is volume 2 of 3; volume 3 will extend the series once drafted into `docs/article-ideas/`. Note: articles 3 and 49 both cover "The Architecture Complexity Ladder" (the series' opening framework and its closing retrospective) - the source drafts share the same `architecture-complexity-ladder` slug, so article 49's destination file and URL use `architecture-complexity-ladder-revisited` to avoid colliding with article 3's published post.
+
+### Modern .NET Architecture: What Changed After PoEAA?
+- **Status:** `draft`
+- **Scheduled:** 2029-09-02
+- **Source:** `docs/article-ideas/01-modern-dotnet-architecture-after-poeaa.md`
+- **File:** `src/posts/2029-09-02-modern-dotnet-architecture-after-poeaa.md`
+- **Pitch:** Volume II begins where Patterns of Enterprise Application Architecture leaves off: the network, cloud, messaging, DDD, CQRS, resilience, and feature-oriented architecture changed the problems we routinely solve.
+- **Angle:** Adapted from the fully-drafted source at `docs/article-ideas/01-modern-dotnet-architecture-after-poeaa.md` - frontmatter converted to house style (author/date/image/image_alt/image_prompt/layout/site_title/summary/tags/title), duplicate H1 title stripped from the body where present (articles 37 onward in this volume do not open with a duplicate H1), and source em-dash formatting artifacts (literal `---` mid-sentence, which this site's markdown pipeline doesn't convert to a typographic dash) fixed to the house ` - ` convention. Pattern content, C# examples, and structure are otherwise unchanged from the original draft.
+- **Tags:** `dotnet`, `architecture`, `design-patterns`, `software-design`
+
+### Patterns, Principles, Styles, and Practices: Know What You're Choosing
+- **Status:** `draft`
+- **Scheduled:** 2029-09-09
+- **Source:** `docs/article-ideas/02-patterns-principles-styles-practices.md`
+- **File:** `src/posts/2029-09-09-patterns-principles-styles-practices.md`
+- **Pitch:** Separate architectural styles, design patterns, principles, practices, and technologies so architecture discussions become about decisions rather than labels.
+- **Angle:** Adapted from the fully-drafted source at `docs/article-ideas/02-patterns-principles-styles-practices.md` - frontmatter converted to house style (author/date/image/image_alt/image_prompt/layout/site_title/summary/tags/title), duplicate H1 title stripped from the body where present (articles 37 onward in this volume do not open with a duplicate H1), and source em-dash formatting artifacts (literal `---` mid-sentence, which this site's markdown pipeline doesn't convert to a typographic dash) fixed to the house ` - ` convention. Pattern content, C# examples, and structure are otherwise unchanged from the original draft.
+- **Tags:** `dotnet`, `architecture`, `design-patterns`, `software-design`
+
+### The Architecture Complexity Ladder
+- **Status:** `draft`
+- **Scheduled:** 2029-09-16
+- **Source:** `docs/article-ideas/03-architecture-complexity-ladder.md`
+- **File:** `src/posts/2029-09-16-architecture-complexity-ladder.md`
+- **Pitch:** Learn when a .NET application has earned additional architecture, from straightforward CRUD through domain modeling, CQRS, messaging, and distributed workflows.
+- **Angle:** Adapted from the fully-drafted source at `docs/article-ideas/03-architecture-complexity-ladder.md` - frontmatter converted to house style (author/date/image/image_alt/image_prompt/layout/site_title/summary/tags/title), duplicate H1 title stripped from the body where present (articles 37 onward in this volume do not open with a duplicate H1), and source em-dash formatting artifacts (literal `---` mid-sentence, which this site's markdown pipeline doesn't convert to a typographic dash) fixed to the house ` - ` convention. Pattern content, C# examples, and structure are otherwise unchanged from the original draft.
+- **Tags:** `dotnet`, `architecture`, `design-patterns`, `software-design`
+
+### Modular Monolith or Microservices? Start With the Boundary
+- **Status:** `draft`
+- **Scheduled:** 2029-09-23
+- **Source:** `docs/article-ideas/04-modular-monolith-or-microservices.md`
+- **File:** `src/posts/2029-09-23-modular-monolith-or-microservices.md`
+- **Pitch:** Choose deployment boundaries after identifying business boundaries, and understand why a modular monolith is often the strongest starting point for a modern .NET system.
+- **Angle:** Adapted from the fully-drafted source at `docs/article-ideas/04-modular-monolith-or-microservices.md` - frontmatter converted to house style (author/date/image/image_alt/image_prompt/layout/site_title/summary/tags/title), duplicate H1 title stripped from the body where present (articles 37 onward in this volume do not open with a duplicate H1), and source em-dash formatting artifacts (literal `---` mid-sentence, which this site's markdown pipeline doesn't convert to a typographic dash) fixed to the house ` - ` convention. Pattern content, C# examples, and structure are otherwise unchanged from the original draft.
+- **Tags:** `dotnet`, `architecture`, `design-patterns`, `microservices`
+
+### Don't Start With Patterns: Start With Problems
+- **Status:** `draft`
+- **Scheduled:** 2029-09-30
+- **Source:** `docs/article-ideas/05-start-with-problems-not-patterns.md`
+- **File:** `src/posts/2029-09-30-start-with-problems-not-patterns.md`
+- **Pitch:** Use forces, failure modes, and explicit trade-offs to decide whether a pattern belongs in a .NET architecture instead of applying patterns by reputation.
+- **Angle:** Adapted from the fully-drafted source at `docs/article-ideas/05-start-with-problems-not-patterns.md` - frontmatter converted to house style (author/date/image/image_alt/image_prompt/layout/site_title/summary/tags/title), duplicate H1 title stripped from the body where present (articles 37 onward in this volume do not open with a duplicate H1), and source em-dash formatting artifacts (literal `---` mid-sentence, which this site's markdown pipeline doesn't convert to a typographic dash) fixed to the house ` - ` convention. Pattern content, C# examples, and structure are otherwise unchanged from the original draft.
+- **Tags:** `dotnet`, `architecture`, `design-patterns`, `software-design`
+
+### Dependency Injection Beyond AddScoped
+- **Status:** `draft`
+- **Scheduled:** 2029-10-07
+- **Source:** `docs/article-ideas/06-dependency-injection.md`
+- **File:** `src/posts/2029-10-07-dependency-injection.md`
+- **Pitch:** Use dependency injection as an architectural composition technique in modern .NET, with explicit dependencies, correct lifetimes, keyed services, factories, decorators, and a disciplined composition root.
+- **Angle:** Adapted from the fully-drafted source at `docs/article-ideas/06-dependency-injection.md` - frontmatter converted to house style (author/date/image/image_alt/image_prompt/layout/site_title/summary/tags/title), duplicate H1 title stripped from the body where present (articles 37 onward in this volume do not open with a duplicate H1), and source em-dash formatting artifacts (literal `---` mid-sentence, which this site's markdown pipeline doesn't convert to a typographic dash) fixed to the house ` - ` convention. Pattern content, C# examples, and structure are otherwise unchanged from the original draft.
+- **Tags:** `dotnet`, `architecture`, `design-patterns`, `software-design`
+
+### Clean Architecture in Modern .NET Without the Ceremony
+- **Status:** `draft`
+- **Scheduled:** 2029-10-14
+- **Source:** `docs/article-ideas/07-clean-architecture.md`
+- **File:** `src/posts/2029-10-14-clean-architecture.md`
+- **Pitch:** Apply Clean Architecture's dependency rule in .NET without blindly copying layers, interfaces, repositories, and project templates that the application does not need.
+- **Angle:** Adapted from the fully-drafted source at `docs/article-ideas/07-clean-architecture.md` - frontmatter converted to house style (author/date/image/image_alt/image_prompt/layout/site_title/summary/tags/title), duplicate H1 title stripped from the body where present (articles 37 onward in this volume do not open with a duplicate H1), and source em-dash formatting artifacts (literal `---` mid-sentence, which this site's markdown pipeline doesn't convert to a typographic dash) fixed to the house ` - ` convention. Pattern content, C# examples, and structure are otherwise unchanged from the original draft.
+- **Tags:** `dotnet`, `architecture`, `design-patterns`, `software-design`
+
+### Hexagonal Architecture and Ports & Adapters in Modern .NET
+- **Status:** `draft`
+- **Scheduled:** 2029-10-21
+- **Source:** `docs/article-ideas/08-hexagonal-architecture-ports-adapters.md`
+- **File:** `src/posts/2029-10-21-hexagonal-architecture-ports-adapters.md`
+- **Pitch:** Design a .NET application around use-case ports and replaceable adapters so HTTP, databases, brokers, and external APIs remain outside the application core.
+- **Angle:** Adapted from the fully-drafted source at `docs/article-ideas/08-hexagonal-architecture-ports-adapters.md` - frontmatter converted to house style (author/date/image/image_alt/image_prompt/layout/site_title/summary/tags/title), duplicate H1 title stripped from the body where present (articles 37 onward in this volume do not open with a duplicate H1), and source em-dash formatting artifacts (literal `---` mid-sentence, which this site's markdown pipeline doesn't convert to a typographic dash) fixed to the house ` - ` convention. Pattern content, C# examples, and structure are otherwise unchanged from the original draft.
+- **Tags:** `dotnet`, `architecture`, `design-patterns`, `software-design`
+
+### Vertical Slice Architecture in Modern .NET
+- **Status:** `draft`
+- **Scheduled:** 2029-10-28
+- **Source:** `docs/article-ideas/09-vertical-slice-architecture.md`
+- **File:** `src/posts/2029-10-28-vertical-slice-architecture.md`
+- **Pitch:** Organize modern .NET applications around features and use cases instead of technical layers, while keeping shared domain and infrastructure boundaries deliberate.
+- **Angle:** Adapted from the fully-drafted source at `docs/article-ideas/09-vertical-slice-architecture.md` - frontmatter converted to house style (author/date/image/image_alt/image_prompt/layout/site_title/summary/tags/title), duplicate H1 title stripped from the body where present (articles 37 onward in this volume do not open with a duplicate H1), and source em-dash formatting artifacts (literal `---` mid-sentence, which this site's markdown pipeline doesn't convert to a typographic dash) fixed to the house ` - ` convention. Pattern content, C# examples, and structure are otherwise unchanged from the original draft.
+- **Tags:** `dotnet`, `architecture`, `design-patterns`, `software-design`
+
+### Mediator in Modern .NET: Useful Boundary or Expensive Method Call?
+- **Status:** `draft`
+- **Scheduled:** 2029-11-04
+- **Source:** `docs/article-ideas/10-mediator.md`
+- **File:** `src/posts/2029-11-04-mediator.md`
+- **Pitch:** Use mediator-style dispatch deliberately for command/query pipelines and cross-cutting behaviors, and recognize when direct method calls are the simpler .NET design.
+- **Angle:** Adapted from the fully-drafted source at `docs/article-ideas/10-mediator.md` - frontmatter converted to house style (author/date/image/image_alt/image_prompt/layout/site_title/summary/tags/title), duplicate H1 title stripped from the body where present (articles 37 onward in this volume do not open with a duplicate H1), and source em-dash formatting artifacts (literal `---` mid-sentence, which this site's markdown pipeline doesn't convert to a typographic dash) fixed to the house ` - ` convention. Pattern content, C# examples, and structure are otherwise unchanged from the original draft.
+- **Tags:** `dotnet`, `architecture`, `design-patterns`, `software-design`
+
+### Entity in Domain-Driven Design
+- **Status:** `draft`
+- **Scheduled:** 2029-11-11
+- **Source:** `docs/article-ideas/11-entity-ddd.md`
+- **File:** `src/posts/2029-11-11-entity-ddd.md`
+- **Pitch:** Model domain concepts whose identity and continuity matter more than their current attribute values, while protecting invariants with ordinary modern C#.
+- **Angle:** Adapted from the fully-drafted source at `docs/article-ideas/11-entity-ddd.md` - frontmatter converted to house style (author/date/image/image_alt/image_prompt/layout/site_title/summary/tags/title), duplicate H1 title stripped from the body where present (articles 37 onward in this volume do not open with a duplicate H1), and source em-dash formatting artifacts (literal `---` mid-sentence, which this site's markdown pipeline doesn't convert to a typographic dash) fixed to the house ` - ` convention. Pattern content, C# examples, and structure are otherwise unchanged from the original draft.
+- **Tags:** `dotnet`, `architecture`, `design-patterns`, `domain-driven-design`
+
+### Aggregate and Aggregate Root: The Consistency Boundary
+- **Status:** `draft`
+- **Scheduled:** 2029-11-18
+- **Source:** `docs/article-ideas/12-aggregate-aggregate-root.md`
+- **File:** `src/posts/2029-11-18-aggregate-aggregate-root.md`
+- **Pitch:** Design DDD aggregates around transactional consistency and business invariants instead of object graphs or database relationships.
+- **Angle:** Adapted from the fully-drafted source at `docs/article-ideas/12-aggregate-aggregate-root.md` - frontmatter converted to house style (author/date/image/image_alt/image_prompt/layout/site_title/summary/tags/title), duplicate H1 title stripped from the body where present (articles 37 onward in this volume do not open with a duplicate H1), and source em-dash formatting artifacts (literal `---` mid-sentence, which this site's markdown pipeline doesn't convert to a typographic dash) fixed to the house ` - ` convention. Pattern content, C# examples, and structure are otherwise unchanged from the original draft.
+- **Tags:** `dotnet`, `architecture`, `design-patterns`, `domain-driven-design`
+
+### Domain Service: Behavior That Doesn't Belong to an Entity
+- **Status:** `draft`
+- **Scheduled:** 2029-11-25
+- **Source:** `docs/article-ideas/13-domain-service.md`
+- **File:** `src/posts/2029-11-25-domain-service.md`
+- **Pitch:** Model domain operations that require domain knowledge but do not naturally belong to one entity or value object, without turning services into an anemic-domain dumping ground.
+- **Angle:** Adapted from the fully-drafted source at `docs/article-ideas/13-domain-service.md` - frontmatter converted to house style (author/date/image/image_alt/image_prompt/layout/site_title/summary/tags/title), duplicate H1 title stripped from the body where present (articles 37 onward in this volume do not open with a duplicate H1), and source em-dash formatting artifacts (literal `---` mid-sentence, which this site's markdown pipeline doesn't convert to a typographic dash) fixed to the house ` - ` convention. Pattern content, C# examples, and structure are otherwise unchanged from the original draft.
+- **Tags:** `dotnet`, `architecture`, `design-patterns`, `domain-driven-design`
+
+### Domain Events: Making Business Consequences Explicit
+- **Status:** `draft`
+- **Scheduled:** 2029-12-02
+- **Source:** `docs/article-ideas/14-domain-events.md`
+- **File:** `src/posts/2029-12-02-domain-events.md`
+- **Pitch:** Model meaningful facts that have already happened inside a bounded context, defer their dispatch safely, and distinguish domain events from durable integration messages.
+- **Angle:** Adapted from the fully-drafted source at `docs/article-ideas/14-domain-events.md` - frontmatter converted to house style (author/date/image/image_alt/image_prompt/layout/site_title/summary/tags/title), duplicate H1 title stripped from the body where present (articles 37 onward in this volume do not open with a duplicate H1), and source em-dash formatting artifacts (literal `---` mid-sentence, which this site's markdown pipeline doesn't convert to a typographic dash) fixed to the house ` - ` convention. Pattern content, C# examples, and structure are otherwise unchanged from the original draft.
+- **Tags:** `dotnet`, `architecture`, `design-patterns`, `domain-driven-design`
+
+### Specification: Giving Business Predicates a Name
+- **Status:** `draft`
+- **Scheduled:** 2029-12-09
+- **Source:** `docs/article-ideas/15-specification.md`
+- **File:** `src/posts/2029-12-09-specification.md`
+- **Pitch:** Encapsulate reusable business predicates and composable selection rules without turning every LINQ expression into an abstraction or coupling the domain to persistence mechanics.
+- **Angle:** Adapted from the fully-drafted source at `docs/article-ideas/15-specification.md` - frontmatter converted to house style (author/date/image/image_alt/image_prompt/layout/site_title/summary/tags/title), duplicate H1 title stripped from the body where present (articles 37 onward in this volume do not open with a duplicate H1), and source em-dash formatting artifacts (literal `---` mid-sentence, which this site's markdown pipeline doesn't convert to a typographic dash) fixed to the house ` - ` convention. Pattern content, C# examples, and structure are otherwise unchanged from the original draft.
+- **Tags:** `dotnet`, `architecture`, `design-patterns`, `domain-driven-design`
+
+### Anti-Corruption Layer: Protecting Your Domain From Someone Else's Model
+- **Status:** `draft`
+- **Scheduled:** 2029-12-16
+- **Source:** `docs/article-ideas/16-anti-corruption-layer.md`
+- **File:** `src/posts/2029-12-16-anti-corruption-layer.md`
+- **Pitch:** Protect a modern .NET domain from legacy systems, vendor APIs, and foreign bounded contexts by translating protocols, data, errors, and semantics at an explicit boundary.
+- **Angle:** Adapted from the fully-drafted source at `docs/article-ideas/16-anti-corruption-layer.md` - frontmatter converted to house style (author/date/image/image_alt/image_prompt/layout/site_title/summary/tags/title), duplicate H1 title stripped from the body where present (articles 37 onward in this volume do not open with a duplicate H1), and source em-dash formatting artifacts (literal `---` mid-sentence, which this site's markdown pipeline doesn't convert to a typographic dash) fixed to the house ` - ` convention. Pattern content, C# examples, and structure are otherwise unchanged from the original draft.
+- **Tags:** `dotnet`, `architecture`, `design-patterns`, `domain-driven-design`
+
+### Command: Modeling an Intent to Change the System
+- **Status:** `draft`
+- **Scheduled:** 2029-12-23
+- **Source:** `docs/article-ideas/17-command.md`
+- **File:** `src/posts/2029-12-23-command.md`
+- **Pitch:** Model application requests as explicit business intentions, distinguish commands from events and CRUD updates, and design command handling around validation, invariants, transactions, and idempotency.
+- **Angle:** Adapted from the fully-drafted source at `docs/article-ideas/17-command.md` - frontmatter converted to house style (author/date/image/image_alt/image_prompt/layout/site_title/summary/tags/title), duplicate H1 title stripped from the body where present (articles 37 onward in this volume do not open with a duplicate H1), and source em-dash formatting artifacts (literal `---` mid-sentence, which this site's markdown pipeline doesn't convert to a typographic dash) fixed to the house ` - ` convention. Pattern content, C# examples, and structure are otherwise unchanged from the original draft.
+- **Tags:** `dotnet`, `architecture`, `design-patterns`, `cqrs`
+
+### Query: Designing Reads for What the Caller Actually Needs
+- **Status:** `draft`
+- **Scheduled:** 2029-12-30
+- **Source:** `docs/article-ideas/18-query.md`
+- **File:** `src/posts/2029-12-30-query.md`
+- **Pitch:** Design read operations independently from write-side domain models, project directly into caller-oriented DTOs, and optimize query paths without weakening domain invariants.
+- **Angle:** Adapted from the fully-drafted source at `docs/article-ideas/18-query.md` - frontmatter converted to house style (author/date/image/image_alt/image_prompt/layout/site_title/summary/tags/title), duplicate H1 title stripped from the body where present (articles 37 onward in this volume do not open with a duplicate H1), and source em-dash formatting artifacts (literal `---` mid-sentence, which this site's markdown pipeline doesn't convert to a typographic dash) fixed to the house ` - ` convention. Pattern content, C# examples, and structure are otherwise unchanged from the original draft.
+- **Tags:** `dotnet`, `architecture`, `design-patterns`, `cqrs`
+
+### CQRS: Separate Reads and Writes Before You Separate Databases
+- **Status:** `draft`
+- **Scheduled:** 2030-01-06
+- **Source:** `docs/article-ideas/19-cqrs.md`
+- **File:** `src/posts/2030-01-06-cqrs.md`
+- **Pitch:** Apply Command Query Responsibility Segregation incrementally in .NET, beginning with separate application models and progressing to independent stores only when scaling, consistency, or query needs justify the cost.
+- **Angle:** Adapted from the fully-drafted source at `docs/article-ideas/19-cqrs.md` - frontmatter converted to house style (author/date/image/image_alt/image_prompt/layout/site_title/summary/tags/title), duplicate H1 title stripped from the body where present (articles 37 onward in this volume do not open with a duplicate H1), and source em-dash formatting artifacts (literal `---` mid-sentence, which this site's markdown pipeline doesn't convert to a typographic dash) fixed to the house ` - ` convention. Pattern content, C# examples, and structure are otherwise unchanged from the original draft.
+- **Tags:** `dotnet`, `architecture`, `design-patterns`, `cqrs`
+
+### Result Pattern: Making Expected Failure Explicit
+- **Status:** `draft`
+- **Scheduled:** 2030-01-13
+- **Source:** `docs/article-ideas/20-result-pattern.md`
+- **File:** `src/posts/2030-01-13-result-pattern.md`
+- **Pitch:** Represent expected application outcomes explicitly in modern C#, distinguish business failure from exceptional failure, and map results cleanly to HTTP without replacing exceptions indiscriminately.
+- **Angle:** Adapted from the fully-drafted source at `docs/article-ideas/20-result-pattern.md` - frontmatter converted to house style (author/date/image/image_alt/image_prompt/layout/site_title/summary/tags/title), duplicate H1 title stripped from the body where present (articles 37 onward in this volume do not open with a duplicate H1), and source em-dash formatting artifacts (literal `---` mid-sentence, which this site's markdown pipeline doesn't convert to a typographic dash) fixed to the house ` - ` convention. Pattern content, C# examples, and structure are otherwise unchanged from the original draft.
+- **Tags:** `dotnet`, `architecture`, `design-patterns`, `software-design`
+
+### Idempotency: Making Retries Safe
+- **Status:** `draft`
+- **Scheduled:** 2030-01-20
+- **Source:** `docs/article-ideas/21-idempotency.md`
+- **File:** `src/posts/2030-01-20-idempotency.md`
+- **Pitch:** Design HTTP commands and distributed operations so repeated delivery of the same logical request does not repeat harmful effects, using stable operation identity, atomic persistence, replayed responses, and careful expiration.
+- **Angle:** Adapted from the fully-drafted source at `docs/article-ideas/21-idempotency.md` - frontmatter converted to house style (author/date/image/image_alt/image_prompt/layout/site_title/summary/tags/title), duplicate H1 title stripped from the body where present (articles 37 onward in this volume do not open with a duplicate H1), and source em-dash formatting artifacts (literal `---` mid-sentence, which this site's markdown pipeline doesn't convert to a typographic dash) fixed to the house ` - ` convention. Pattern content, C# examples, and structure are otherwise unchanged from the original draft.
+- **Tags:** `dotnet`, `architecture`, `design-patterns`, `reliability`
+
+### Publish/Subscribe: Decoupling Producers From Reactions
+- **Status:** `draft`
+- **Scheduled:** 2030-01-27
+- **Source:** `docs/article-ideas/22-publish-subscribe.md`
+- **File:** `src/posts/2030-01-27-publish-subscribe.md`
+- **Pitch:** Use publish/subscribe to decouple producers from multiple independent consumers, and understand delivery, ordering, durability, and contract-versioning implications in modern .NET systems.
+- **Angle:** Adapted from the fully-drafted source at `docs/article-ideas/22-publish-subscribe.md` - frontmatter converted to house style (author/date/image/image_alt/image_prompt/layout/site_title/summary/tags/title), duplicate H1 title stripped from the body where present (articles 37 onward in this volume do not open with a duplicate H1), and source em-dash formatting artifacts (literal `---` mid-sentence, which this site's markdown pipeline doesn't convert to a typographic dash) fixed to the house ` - ` convention. Pattern content, C# examples, and structure are otherwise unchanged from the original draft.
+- **Tags:** `dotnet`, `architecture`, `design-patterns`, `messaging`
+
+### Competing Consumers: Scaling Work Horizontally
+- **Status:** `draft`
+- **Scheduled:** 2030-02-03
+- **Source:** `docs/article-ideas/23-competing-consumers.md`
+- **File:** `src/posts/2030-02-03-competing-consumers.md`
+- **Pitch:** Process queued work with multiple independent workers, while handling at-least-once delivery, ordering constraints, poison messages, concurrency, and partitioning in modern .NET.
+- **Angle:** Adapted from the fully-drafted source at `docs/article-ideas/23-competing-consumers.md` - frontmatter converted to house style (author/date/image/image_alt/image_prompt/layout/site_title/summary/tags/title), duplicate H1 title stripped from the body where present (articles 37 onward in this volume do not open with a duplicate H1), and source em-dash formatting artifacts (literal `---` mid-sentence, which this site's markdown pipeline doesn't convert to a typographic dash) fixed to the house ` - ` convention. Pattern content, C# examples, and structure are otherwise unchanged from the original draft.
+- **Tags:** `dotnet`, `architecture`, `design-patterns`, `messaging`
+
+### Transactional Outbox: Making Database Changes and Events Reliable
+- **Status:** `draft`
+- **Scheduled:** 2030-02-10
+- **Source:** `docs/article-ideas/24-transactional-outbox.md`
+- **File:** `src/posts/2030-02-10-transactional-outbox.md`
+- **Pitch:** Persist integration messages in the same local transaction as business state, then publish them asynchronously with at-least-once delivery and observable retry semantics.
+- **Angle:** Adapted from the fully-drafted source at `docs/article-ideas/24-transactional-outbox.md` - frontmatter converted to house style (author/date/image/image_alt/image_prompt/layout/site_title/summary/tags/title), duplicate H1 title stripped from the body where present (articles 37 onward in this volume do not open with a duplicate H1), and source em-dash formatting artifacts (literal `---` mid-sentence, which this site's markdown pipeline doesn't convert to a typographic dash) fixed to the house ` - ` convention. Pattern content, C# examples, and structure are otherwise unchanged from the original draft.
+- **Tags:** `dotnet`, `architecture`, `design-patterns`, `reliability`
+
+### Inbox and Idempotent Consumer: Making Duplicate Messages Harmless
+- **Status:** `draft`
+- **Scheduled:** 2030-02-17
+- **Source:** `docs/article-ideas/25-inbox-idempotent-consumer.md`
+- **File:** `src/posts/2030-02-17-inbox-idempotent-consumer.md`
+- **Pitch:** Detect and safely ignore duplicate message deliveries by persisting consumed message identity with business effects in one local transaction.
+- **Angle:** Adapted from the fully-drafted source at `docs/article-ideas/25-inbox-idempotent-consumer.md` - frontmatter converted to house style (author/date/image/image_alt/image_prompt/layout/site_title/summary/tags/title), duplicate H1 title stripped from the body where present (articles 37 onward in this volume do not open with a duplicate H1), and source em-dash formatting artifacts (literal `---` mid-sentence, which this site's markdown pipeline doesn't convert to a typographic dash) fixed to the house ` - ` convention. Pattern content, C# examples, and structure are otherwise unchanged from the original draft.
+- **Tags:** `dotnet`, `architecture`, `design-patterns`, `reliability`
+
+### Dead Letter Queue: What To Do With Messages That Never Succeed
+- **Status:** `draft`
+- **Scheduled:** 2030-02-24
+- **Source:** `docs/article-ideas/26-dead-letter-queue.md`
+- **File:** `src/posts/2030-02-24-dead-letter-queue.md`
+- **Pitch:** Quarantine permanently failing messages after bounded retries, preserve diagnostics and replayability, and avoid turning dead-letter queues into invisible data graveyards.
+- **Angle:** Adapted from the fully-drafted source at `docs/article-ideas/26-dead-letter-queue.md` - frontmatter converted to house style (author/date/image/image_alt/image_prompt/layout/site_title/summary/tags/title), duplicate H1 title stripped from the body where present (articles 37 onward in this volume do not open with a duplicate H1), and source em-dash formatting artifacts (literal `---` mid-sentence, which this site's markdown pipeline doesn't convert to a typographic dash) fixed to the house ` - ` convention. Pattern content, C# examples, and structure are otherwise unchanged from the original draft.
+- **Tags:** `dotnet`, `architecture`, `design-patterns`, `messaging`
+
+### Queue-Based Load Leveling: Absorbing Bursts Without Crushing Dependencies
+- **Status:** `draft`
+- **Scheduled:** 2030-03-03
+- **Source:** `docs/article-ideas/27-queue-based-load-leveling.md`
+- **File:** `src/posts/2030-03-03-queue-based-load-leveling.md`
+- **Pitch:** Use a queue as a buffer between bursty producers and capacity-limited consumers so work is smoothed over time and downstream systems remain stable.
+- **Angle:** Adapted from the fully-drafted source at `docs/article-ideas/27-queue-based-load-leveling.md` - frontmatter converted to house style (author/date/image/image_alt/image_prompt/layout/site_title/summary/tags/title), duplicate H1 title stripped from the body where present (articles 37 onward in this volume do not open with a duplicate H1), and source em-dash formatting artifacts (literal `---` mid-sentence, which this site's markdown pipeline doesn't convert to a typographic dash) fixed to the house ` - ` convention. Pattern content, C# examples, and structure are otherwise unchanged from the original draft.
+- **Tags:** `dotnet`, `architecture`, `design-patterns`, `messaging`
+
+### Event Sourcing: Persisting Facts Instead of Current State
+- **Status:** `draft`
+- **Scheduled:** 2030-03-10
+- **Source:** `docs/article-ideas/28-event-sourcing.md`
+- **File:** `src/posts/2030-03-10-event-sourcing.md`
+- **Pitch:** Persist domain changes as an append-only stream of events, rebuild state through replay, and understand projections, snapshots, schema evolution, concurrency, and why most systems should not adopt Event Sourcing casually.
+- **Angle:** Adapted from the fully-drafted source at `docs/article-ideas/28-event-sourcing.md` - frontmatter converted to house style (author/date/image/image_alt/image_prompt/layout/site_title/summary/tags/title), duplicate H1 title stripped from the body where present (articles 37 onward in this volume do not open with a duplicate H1), and source em-dash formatting artifacts (literal `---` mid-sentence, which this site's markdown pipeline doesn't convert to a typographic dash) fixed to the house ` - ` convention. Pattern content, C# examples, and structure are otherwise unchanged from the original draft.
+- **Tags:** `dotnet`, `architecture`, `design-patterns`, `event-sourcing`
+
+### Saga: Coordinating a Business Transaction Across Services
+- **Status:** `draft`
+- **Scheduled:** 2030-03-17
+- **Source:** `docs/article-ideas/29-saga.md`
+- **File:** `src/posts/2030-03-17-saga.md`
+- **Pitch:** Coordinate long-running business workflows across independently committed services using choreography or orchestration, explicit state, idempotency, timeouts, and compensating actions.
+- **Angle:** Adapted from the fully-drafted source at `docs/article-ideas/29-saga.md` - frontmatter converted to house style (author/date/image/image_alt/image_prompt/layout/site_title/summary/tags/title), duplicate H1 title stripped from the body where present (articles 37 onward in this volume do not open with a duplicate H1), and source em-dash formatting artifacts (literal `---` mid-sentence, which this site's markdown pipeline doesn't convert to a typographic dash) fixed to the house ` - ` convention. Pattern content, C# examples, and structure are otherwise unchanged from the original draft.
+- **Tags:** `dotnet`, `architecture`, `design-patterns`, `distributed-systems`
+
+### Compensating Transaction: Undoing Business Effects Without Rewinding Time
+- **Status:** `draft`
+- **Scheduled:** 2030-03-24
+- **Source:** `docs/article-ideas/30-compensating-transaction.md`
+- **File:** `src/posts/2030-03-24-compensating-transaction.md`
+- **Pitch:** Design semantic undo operations for distributed workflows where committed steps cannot be atomically rolled back, including irreversible effects, compensation ordering, idempotency, and manual recovery.
+- **Angle:** Adapted from the fully-drafted source at `docs/article-ideas/30-compensating-transaction.md` - frontmatter converted to house style (author/date/image/image_alt/image_prompt/layout/site_title/summary/tags/title), duplicate H1 title stripped from the body where present (articles 37 onward in this volume do not open with a duplicate H1), and source em-dash formatting artifacts (literal `---` mid-sentence, which this site's markdown pipeline doesn't convert to a typographic dash) fixed to the house ` - ` convention. Pattern content, C# examples, and structure are otherwise unchanged from the original draft.
+- **Tags:** `dotnet`, `architecture`, `design-patterns`, `distributed-systems`
+
+### Backend for Frontend: APIs Shaped Around Client Needs
+- **Status:** `draft`
+- **Scheduled:** 2030-03-31
+- **Source:** `docs/article-ideas/31-backend-for-frontend.md`
+- **File:** `src/posts/2030-03-31-backend-for-frontend.md`
+- **Pitch:** Give materially different client experiences their own backend boundary for aggregation, orchestration, security, and client-specific contracts without duplicating core business logic.
+- **Angle:** Adapted from the fully-drafted source at `docs/article-ideas/31-backend-for-frontend.md` - frontmatter converted to house style (author/date/image/image_alt/image_prompt/layout/site_title/summary/tags/title), duplicate H1 title stripped from the body where present (articles 37 onward in this volume do not open with a duplicate H1), and source em-dash formatting artifacts (literal `---` mid-sentence, which this site's markdown pipeline doesn't convert to a typographic dash) fixed to the house ` - ` convention. Pattern content, C# examples, and structure are otherwise unchanged from the original draft.
+- **Tags:** `dotnet`, `architecture`, `design-patterns`, `api-design`
+
+### API Gateway: A Deliberate Edge for Distributed APIs
+- **Status:** `draft`
+- **Scheduled:** 2030-04-07
+- **Source:** `docs/article-ideas/32-api-gateway.md`
+- **File:** `src/posts/2030-04-07-api-gateway.md`
+- **Pitch:** Use an API Gateway as a shared edge for routing, authentication, rate limiting, policy, and selective aggregation while avoiding a centralized business-logic bottleneck.
+- **Angle:** Adapted from the fully-drafted source at `docs/article-ideas/32-api-gateway.md` - frontmatter converted to house style (author/date/image/image_alt/image_prompt/layout/site_title/summary/tags/title), duplicate H1 title stripped from the body where present (articles 37 onward in this volume do not open with a duplicate H1), and source em-dash formatting artifacts (literal `---` mid-sentence, which this site's markdown pipeline doesn't convert to a typographic dash) fixed to the house ` - ` convention. Pattern content, C# examples, and structure are otherwise unchanged from the original draft.
+- **Tags:** `dotnet`, `architecture`, `design-patterns`, `api-design`
+
+### Retry: Recovering From Transient Failure Without Making Things Worse
+- **Status:** `draft`
+- **Scheduled:** 2030-04-14
+- **Source:** `docs/article-ideas/33-retry.md`
+- **File:** `src/posts/2030-04-14-retry.md`
+- **Pitch:** Use bounded retries for genuinely transient failures, with backoff, jitter, idempotency, retry budgets, cancellation, and careful placement in modern .NET applications.
+- **Angle:** Adapted from the fully-drafted source at `docs/article-ideas/33-retry.md` - frontmatter converted to house style (author/date/image/image_alt/image_prompt/layout/site_title/summary/tags/title), duplicate H1 title stripped from the body where present (articles 37 onward in this volume do not open with a duplicate H1), and source em-dash formatting artifacts (literal `---` mid-sentence, which this site's markdown pipeline doesn't convert to a typographic dash) fixed to the house ` - ` convention. Pattern content, C# examples, and structure are otherwise unchanged from the original draft.
+- **Tags:** `dotnet`, `architecture`, `design-patterns`, `resilience`
+
+### Circuit Breaker: Stop Calling a Dependency That Is Already Failing
+- **Status:** `draft`
+- **Scheduled:** 2030-04-21
+- **Source:** `docs/article-ideas/34-circuit-breaker.md`
+- **File:** `src/posts/2030-04-21-circuit-breaker.md`
+- **Pitch:** Fail fast when a dependency is persistently unhealthy, allowing recovery while preventing cascading latency, retry storms, and resource exhaustion.
+- **Angle:** Adapted from the fully-drafted source at `docs/article-ideas/34-circuit-breaker.md` - frontmatter converted to house style (author/date/image/image_alt/image_prompt/layout/site_title/summary/tags/title), duplicate H1 title stripped from the body where present (articles 37 onward in this volume do not open with a duplicate H1), and source em-dash formatting artifacts (literal `---` mid-sentence, which this site's markdown pipeline doesn't convert to a typographic dash) fixed to the house ` - ` convention. Pattern content, C# examples, and structure are otherwise unchanged from the original draft.
+- **Tags:** `dotnet`, `architecture`, `design-patterns`, `resilience`
+
+### Bulkhead: Preventing One Failure From Consuming Everything
+- **Status:** `draft`
+- **Scheduled:** 2030-04-28
+- **Source:** `docs/article-ideas/35-bulkhead.md`
+- **File:** `src/posts/2030-04-28-bulkhead.md`
+- **Pitch:** Partition concurrency and resources so overload or failure in one dependency or workload cannot exhaust the entire application.
+- **Angle:** Adapted from the fully-drafted source at `docs/article-ideas/35-bulkhead.md` - frontmatter converted to house style (author/date/image/image_alt/image_prompt/layout/site_title/summary/tags/title), duplicate H1 title stripped from the body where present (articles 37 onward in this volume do not open with a duplicate H1), and source em-dash formatting artifacts (literal `---` mid-sentence, which this site's markdown pipeline doesn't convert to a typographic dash) fixed to the house ` - ` convention. Pattern content, C# examples, and structure are otherwise unchanged from the original draft.
+- **Tags:** `dotnet`, `architecture`, `design-patterns`, `resilience`
+
+### Cache-Aside: Faster Reads Without Pretending Caches Are Simple
+- **Status:** `draft`
+- **Scheduled:** 2030-05-05
+- **Source:** `docs/article-ideas/36-cache-aside.md`
+- **File:** `src/posts/2030-05-05-cache-aside.md`
+- **Pitch:** Load frequently read data into a cache on demand while explicitly handling misses, invalidation, staleness, stampedes, expiration, and multi-instance behavior.
+- **Angle:** Adapted from the fully-drafted source at `docs/article-ideas/36-cache-aside.md` - frontmatter converted to house style (author/date/image/image_alt/image_prompt/layout/site_title/summary/tags/title), duplicate H1 title stripped from the body where present (articles 37 onward in this volume do not open with a duplicate H1), and source em-dash formatting artifacts (literal `---` mid-sentence, which this site's markdown pipeline doesn't convert to a typographic dash) fixed to the house ` - ` convention. Pattern content, C# examples, and structure are otherwise unchanged from the original draft.
+- **Tags:** `dotnet`, `architecture`, `design-patterns`, `caching`
+
+### Modular Monolith: Strong Boundaries Without a Distributed System
+- **Status:** `draft`
+- **Scheduled:** 2030-05-12
+- **Source:** `docs/article-ideas/37-modular-monolith.md`
+- **File:** `src/posts/2030-05-12-modular-monolith.md`
+- **Pitch:** A modular monolith keeps one deployable application while dividing it into explicit business modules with controlled dependencies.
+- **Angle:** Adapted from the fully-drafted source at `docs/article-ideas/37-modular-monolith.md` - frontmatter converted to house style (author/date/image/image_alt/image_prompt/layout/site_title/summary/tags/title), duplicate H1 title stripped from the body where present (articles 37 onward in this volume do not open with a duplicate H1), and source em-dash formatting artifacts (literal `---` mid-sentence, which this site's markdown pipeline doesn't convert to a typographic dash) fixed to the house ` - ` convention. Pattern content, C# examples, and structure are otherwise unchanged from the original draft.
+- **Tags:** `dotnet`, `architecture`, `design-patterns`, `microservices`
+
+### Strangler Fig: Modernizing Systems Without the Big-Bang Rewrite
+- **Status:** `draft`
+- **Scheduled:** 2030-05-19
+- **Source:** `docs/article-ideas/38-strangler-fig.md`
+- **File:** `src/posts/2030-05-19-strangler-fig.md`
+- **Pitch:** The Strangler Fig pattern replaces an existing system incrementally.
+- **Angle:** Adapted from the fully-drafted source at `docs/article-ideas/38-strangler-fig.md` - frontmatter converted to house style (author/date/image/image_alt/image_prompt/layout/site_title/summary/tags/title), duplicate H1 title stripped from the body where present (articles 37 onward in this volume do not open with a duplicate H1), and source em-dash formatting artifacts (literal `---` mid-sentence, which this site's markdown pipeline doesn't convert to a typographic dash) fixed to the house ` - ` convention. Pattern content, C# examples, and structure are otherwise unchanged from the original draft.
+- **Tags:** `dotnet`, `architecture`, `design-patterns`, `microservices`
+
+### Feature Flags: Separating Deployment From Release
+- **Status:** `draft`
+- **Scheduled:** 2030-05-26
+- **Source:** `docs/article-ideas/39-feature-flags.md`
+- **File:** `src/posts/2030-05-26-feature-flags.md`
+- **Pitch:** A feature flag lets deployed code exist without making the behavior available to everyone.
+- **Angle:** Adapted from the fully-drafted source at `docs/article-ideas/39-feature-flags.md` - frontmatter converted to house style (author/date/image/image_alt/image_prompt/layout/site_title/summary/tags/title), duplicate H1 title stripped from the body where present (articles 37 onward in this volume do not open with a duplicate H1), and source em-dash formatting artifacts (literal `---` mid-sentence, which this site's markdown pipeline doesn't convert to a typographic dash) fixed to the house ` - ` convention. Pattern content, C# examples, and structure are otherwise unchanged from the original draft.
+- **Tags:** `dotnet`, `architecture`, `design-patterns`, `software-design`
+
+### Health Checks: Liveness, Readiness, and Knowing What 'Healthy' Means
+- **Status:** `draft`
+- **Scheduled:** 2030-06-02
+- **Source:** `docs/article-ideas/40-health-checks.md`
+- **File:** `src/posts/2030-06-02-health-checks.md`
+- **Pitch:** A health endpoint answers an operational question about a running application.
+- **Angle:** Adapted from the fully-drafted source at `docs/article-ideas/40-health-checks.md` - frontmatter converted to house style (author/date/image/image_alt/image_prompt/layout/site_title/summary/tags/title), duplicate H1 title stripped from the body where present (articles 37 onward in this volume do not open with a duplicate H1), and source em-dash formatting artifacts (literal `---` mid-sentence, which this site's markdown pipeline doesn't convert to a typographic dash) fixed to the house ` - ` convention. Pattern content, C# examples, and structure are otherwise unchanged from the original draft.
+- **Tags:** `dotnet`, `architecture`, `design-patterns`, `observability`
+
+### Rate Limiting: Protecting Capacity and Fairness at the Boundary
+- **Status:** `draft`
+- **Scheduled:** 2030-06-09
+- **Source:** `docs/article-ideas/41-rate-limiting.md`
+- **File:** `src/posts/2030-06-09-rate-limiting.md`
+- **Pitch:** Rate limiting controls how much work a caller may introduce over time.
+- **Angle:** Adapted from the fully-drafted source at `docs/article-ideas/41-rate-limiting.md` - frontmatter converted to house style (author/date/image/image_alt/image_prompt/layout/site_title/summary/tags/title), duplicate H1 title stripped from the body where present (articles 37 onward in this volume do not open with a duplicate H1), and source em-dash formatting artifacts (literal `---` mid-sentence, which this site's markdown pipeline doesn't convert to a typographic dash) fixed to the house ` - ` convention. Pattern content, C# examples, and structure are otherwise unchanged from the original draft.
+- **Tags:** `dotnet`, `architecture`, `design-patterns`, `resilience`
+
+### Timeouts and Deadline Propagation: Giving Distributed Work a Time Budget
+- **Status:** `draft`
+- **Scheduled:** 2030-06-16
+- **Source:** `docs/article-ideas/42-timeouts-deadlines.md`
+- **File:** `src/posts/2030-06-16-timeouts-deadlines.md`
+- **Pitch:** Every remote call can wait forever unless something decides otherwise.
+- **Angle:** Adapted from the fully-drafted source at `docs/article-ideas/42-timeouts-deadlines.md` - frontmatter converted to house style (author/date/image/image_alt/image_prompt/layout/site_title/summary/tags/title), duplicate H1 title stripped from the body where present (articles 37 onward in this volume do not open with a duplicate H1), and source em-dash formatting artifacts (literal `---` mid-sentence, which this site's markdown pipeline doesn't convert to a typographic dash) fixed to the house ` - ` convention. Pattern content, C# examples, and structure are otherwise unchanged from the original draft.
+- **Tags:** `dotnet`, `architecture`, `design-patterns`, `resilience`
+
+### Optimistic Concurrency: Detecting Conflicting Changes Without Holding Locks
+- **Status:** `draft`
+- **Scheduled:** 2030-06-23
+- **Source:** `docs/article-ideas/43-optimistic-concurrency.md`
+- **File:** `src/posts/2030-06-23-optimistic-concurrency.md`
+- **Pitch:** Optimistic concurrency assumes conflicts are uncommon enough that work can proceed without holding a long-lived lock.
+- **Angle:** Adapted from the fully-drafted source at `docs/article-ideas/43-optimistic-concurrency.md` - frontmatter converted to house style (author/date/image/image_alt/image_prompt/layout/site_title/summary/tags/title), duplicate H1 title stripped from the body where present (articles 37 onward in this volume do not open with a duplicate H1), and source em-dash formatting artifacts (literal `---` mid-sentence, which this site's markdown pipeline doesn't convert to a typographic dash) fixed to the house ` - ` convention. Pattern content, C# examples, and structure are otherwise unchanged from the original draft.
+- **Tags:** `dotnet`, `architecture`, `design-patterns`, `concurrency`
+
+### Distributed Lock and Lease: Coordinating Exclusive Work Across Processes
+- **Status:** `draft`
+- **Scheduled:** 2030-06-30
+- **Source:** `docs/article-ideas/44-distributed-lock-lease.md`
+- **File:** `src/posts/2030-06-30-distributed-lock-lease.md`
+- **Pitch:** Sometimes multiple processes must coordinate so that only one performs a piece of work at a time.
+- **Angle:** Adapted from the fully-drafted source at `docs/article-ideas/44-distributed-lock-lease.md` - frontmatter converted to house style (author/date/image/image_alt/image_prompt/layout/site_title/summary/tags/title), duplicate H1 title stripped from the body where present (articles 37 onward in this volume do not open with a duplicate H1), and source em-dash formatting artifacts (literal `---` mid-sentence, which this site's markdown pipeline doesn't convert to a typographic dash) fixed to the house ` - ` convention. Pattern content, C# examples, and structure are otherwise unchanged from the original draft.
+- **Tags:** `dotnet`, `architecture`, `design-patterns`, `concurrency`
+
+### Leader Election: Choosing One Active Coordinator
+- **Status:** `draft`
+- **Scheduled:** 2030-07-07
+- **Source:** `docs/article-ideas/45-leader-election.md`
+- **File:** `src/posts/2030-07-07-leader-election.md`
+- **Pitch:** Some workloads need many application instances for availability but exactly one active coordinator for a particular responsibility.
+- **Angle:** Adapted from the fully-drafted source at `docs/article-ideas/45-leader-election.md` - frontmatter converted to house style (author/date/image/image_alt/image_prompt/layout/site_title/summary/tags/title), duplicate H1 title stripped from the body where present (articles 37 onward in this volume do not open with a duplicate H1), and source em-dash formatting artifacts (literal `---` mid-sentence, which this site's markdown pipeline doesn't convert to a typographic dash) fixed to the house ` - ` convention. Pattern content, C# examples, and structure are otherwise unchanged from the original draft.
+- **Tags:** `dotnet`, `architecture`, `design-patterns`, `distributed-systems`
+
+### Observability Context Propagation: Following One Operation Across the System
+- **Status:** `draft`
+- **Scheduled:** 2030-07-14
+- **Source:** `docs/article-ideas/46-observability-context-propagation.md`
+- **File:** `src/posts/2030-07-14-observability-context-propagation.md`
+- **Pitch:** A distributed operation may cross:
+- **Angle:** Adapted from the fully-drafted source at `docs/article-ideas/46-observability-context-propagation.md` - frontmatter converted to house style (author/date/image/image_alt/image_prompt/layout/site_title/summary/tags/title), duplicate H1 title stripped from the body where present (articles 37 onward in this volume do not open with a duplicate H1), and source em-dash formatting artifacts (literal `---` mid-sentence, which this site's markdown pipeline doesn't convert to a typographic dash) fixed to the house ` - ` convention. Pattern content, C# examples, and structure are otherwise unchanged from the original draft.
+- **Tags:** `dotnet`, `architecture`, `design-patterns`, `observability`
+
+### Consumer-Driven Contract Testing: Catching Integration Breakage Before Deployment
+- **Status:** `draft`
+- **Scheduled:** 2030-07-21
+- **Source:** `docs/article-ideas/47-consumer-driven-contract-testing.md`
+- **File:** `src/posts/2030-07-21-consumer-driven-contract-testing.md`
+- **Pitch:** Independent deployment creates a dangerous possibility:
+- **Angle:** Adapted from the fully-drafted source at `docs/article-ideas/47-consumer-driven-contract-testing.md` - frontmatter converted to house style (author/date/image/image_alt/image_prompt/layout/site_title/summary/tags/title), duplicate H1 title stripped from the body where present (articles 37 onward in this volume do not open with a duplicate H1), and source em-dash formatting artifacts (literal `---` mid-sentence, which this site's markdown pipeline doesn't convert to a typographic dash) fixed to the house ` - ` convention. Pattern content, C# examples, and structure are otherwise unchanged from the original draft.
+- **Tags:** `dotnet`, `architecture`, `design-patterns`, `testing`
+
+### Sidecar: Moving Cross-Cutting Runtime Capabilities Beside the Application
+- **Status:** `draft`
+- **Scheduled:** 2030-07-28
+- **Source:** `docs/article-ideas/48-sidecar.md`
+- **File:** `src/posts/2030-07-28-sidecar.md`
+- **Pitch:** A Sidecar runs a supporting process beside an application instance.
+- **Angle:** Adapted from the fully-drafted source at `docs/article-ideas/48-sidecar.md` - frontmatter converted to house style (author/date/image/image_alt/image_prompt/layout/site_title/summary/tags/title), duplicate H1 title stripped from the body where present (articles 37 onward in this volume do not open with a duplicate H1), and source em-dash formatting artifacts (literal `---` mid-sentence, which this site's markdown pipeline doesn't convert to a typographic dash) fixed to the house ` - ` convention. Pattern content, C# examples, and structure are otherwise unchanged from the original draft.
+- **Tags:** `dotnet`, `architecture`, `design-patterns`, `microservices`
+
+### The Architecture Complexity Ladder: Knowing When Not to Use a Pattern
+- **Status:** `draft`
+- **Scheduled:** 2030-08-04
+- **Source:** `docs/article-ideas/49-architecture-complexity-ladder.md`
+- **File:** `src/posts/2030-08-04-architecture-complexity-ladder-revisited.md`
+- **Pitch:** We have spent two volumes learning patterns.
+- **Angle:** Adapted from the fully-drafted source at `docs/article-ideas/49-architecture-complexity-ladder.md` - frontmatter converted to house style (author/date/image/image_alt/image_prompt/layout/site_title/summary/tags/title), duplicate H1 title stripped from the body where present (articles 37 onward in this volume do not open with a duplicate H1), and source em-dash formatting artifacts (literal `---` mid-sentence, which this site's markdown pipeline doesn't convert to a typographic dash) fixed to the house ` - ` convention. Pattern content, C# examples, and structure are otherwise unchanged from the original draft.
+- **Tags:** `dotnet`, `architecture`, `design-patterns`, `software-design`
+
+---
+
 ## 📅 November-December 2026 - AI Agents in Practice
 
 Eight posts on building, deploying, and operating AI agents in production. Foundation for the Azure/AWS/GCP AI tracks that follow.

--- a/src/posts/2029-09-02-modern-dotnet-architecture-after-poeaa.md
+++ b/src/posts/2029-09-02-modern-dotnet-architecture-after-poeaa.md
@@ -1,0 +1,405 @@
+---
+author: Steve Kaschimer
+date: 2029-09-02
+image: /images/posts/2029-09-02-hero.webp
+image_alt: "A four-rung ladder glyph rising from a layered blueprint base, implying a new volume of ideas built directly on top of an established foundation."
+image_prompt: "A dark-mode technical editorial illustration on a near-black background with electric teal, amber, and off-white accents. Composition centers on a teal four-rung ladder glyph rising out of a faint amber layered blueprint base beneath it, implying a new body of ideas built directly on top of an established foundation rather than replacing it. Mood is continuous and additive. Avoid: vendor logos, brand colors, circuit-board textures, gears, or generic clip art as the dominant motif."
+layout: post.njk
+site_title: Tech Notes
+summary: "Volume II begins where Patterns of Enterprise Application Architecture leaves off: the network, cloud, messaging, DDD, CQRS, resilience, and feature-oriented architecture changed the problems we routinely solve."
+tags: ["dotnet", "architecture", "design-patterns", "software-design"]
+title: "Modern .NET Architecture: What Changed After PoEAA?"
+---
+
+*Patterns of Enterprise Application Architecture* gave us a vocabulary
+for enterprise software: Domain Model, Service Layer, Unit of Work, Data
+Mapper, Gateway, DTO, Value Object, and many more.
+
+Those patterns did not disappear.
+
+They became the foundation.
+
+A modern ASP.NET Core application using EF Core may already contain Data
+Mapper, Unit of Work, Identity Map, Gateway, DTO, Mapper, Value Object,
+and Service Layer ideas - even if nobody on the team uses those names.
+
+But enterprise software changed.
+
+We now routinely build systems where:
+
+-   one business operation crosses process boundaries;
+-   messages can be delivered more than once;
+-   dependencies fail independently;
+-   reads and writes have radically different requirements;
+-   deployments scale horizontally;
+-   services must be observable in production;
+-   retries can make an outage worse;
+-   one database transaction cannot protect the whole workflow.
+
+That creates a new set of recurring architectural problems.
+
+This volume is about those problems.
+
+## This Is Not a Replacement for Volume I
+
+A useful way to think about the two volumes is:
+
+``` text
+Volume I
+Object and application architecture
+        |
+        v
+Domain Model
+Service Layer
+Data Mapper
+Unit of Work
+Gateway
+DTO
+Value Object
+        |
+        v
+Volume II
+Modern application and distributed architecture
+```
+
+Volume II builds on Volume I rather than superseding it.
+
+A Transactional Outbox still needs a transaction.
+
+An Anti-Corruption Layer often contains Gateways and Mappers.
+
+Clean Architecture depends heavily on dependency inversion and Separated
+Interface.
+
+CQRS frequently combines Transaction Script, Domain Model, Service
+Layer, DTO, and Query Object ideas.
+
+The old vocabulary remains useful because the new patterns are composed
+from smaller architectural ideas.
+
+## The Architecture Complexity Ladder
+
+The central principle of this volume is simple:
+
+> Complexity should pull patterns into the architecture. Patterns should
+> not push complexity into it.
+
+Start with the smallest architecture that solves the actual problem.
+
+``` text
+CRUD
+  |
+  v
+Transaction Script
+  |
+  v
+Domain Model
+  |
+  v
+Vertical Slices / CQRS
+  |
+  v
+Domain Events
+  |
+  v
+Integration Events
+  |
+  v
+Outbox / Idempotency
+  |
+  v
+Saga / Compensation
+```
+
+You do not earn architectural points for reaching the bottom.
+
+A system that needs only CRUD is better when it remains simple.
+
+## Modern .NET Makes Simple Architecture Very Good
+
+.NET 10, ASP.NET Core, EF Core, and C# 14 let us build a surprisingly
+capable application with very little machinery.
+
+``` csharp
+app.MapPost(
+    "/orders",
+    async (
+        CreateOrderRequest request,
+        OrdersDbContext db,
+        CancellationToken cancellationToken) =>
+    {
+        var order = new Order
+        {
+            CustomerId = request.CustomerId,
+            CreatedAt = DateTimeOffset.UtcNow
+        };
+
+        db.Orders.Add(order);
+
+        await db.SaveChangesAsync(cancellationToken);
+
+        return Results.Created(
+            $"/orders/{order.Id}",
+            new { order.Id });
+    });
+```
+
+There is nothing inherently wrong with this.
+
+If the business rule is simple, the code should probably be simple too.
+
+Architecture becomes interesting when the forces acting on this code
+begin to change.
+
+## Force #1: Business Complexity
+
+Suppose creating an order now requires:
+
+-   credit rules;
+-   inventory constraints;
+-   pricing policies;
+-   promotions;
+-   shipping restrictions;
+-   approval limits.
+
+The endpoint should not become the domain model.
+
+We may introduce:
+
+``` text
+Endpoint
+   |
+Application Use Case
+   |
+Aggregate
+   |
+Value Objects
+```
+
+Now DDD concepts begin earning their cost.
+
+## Force #2: Different Read and Write Needs
+
+A transactional model may be excellent for enforcing invariants but
+terrible for building a dashboard.
+
+That tension leads naturally toward CQRS:
+
+``` text
+              Application
+             /                   Commands         Queries
+           |                |
+     Domain Model       Projection
+           |                |
+           +---- Data ------+
+```
+
+CQRS begins as separation of responsibility.
+
+It does not begin with two databases.
+
+## Force #3: The Network
+
+Once an operation crosses a network boundary, new facts become
+unavoidable:
+
+``` text
+The network can fail.
+The response can be lost.
+The request may have succeeded anyway.
+The caller may retry.
+The retry may duplicate the operation.
+```
+
+Now Gateway is not enough.
+
+We need to reason about:
+
+-   timeouts;
+-   retry;
+-   circuit breakers;
+-   idempotency;
+-   observability.
+
+## Force #4: Multiple Transactions
+
+Suppose placing an order requires:
+
+``` text
+Order Database
+Payment Provider
+Inventory Service
+Shipping Service
+```
+
+There is no single EF Core transaction around all four.
+
+Now we enter distributed systems.
+
+Patterns such as:
+
+-   Transactional Outbox;
+-   Idempotent Consumer;
+-   Saga;
+-   Compensating Transaction;
+
+exist because the guarantees we enjoyed inside one database transaction
+no longer apply.
+
+## Force #5: Independent Scale
+
+A queue lets producers and consumers operate at different rates:
+
+``` text
+Producer
+   |
+   v
+ Queue
+   |
+   +----> Consumer
+   +----> Consumer
+   +----> Consumer
+```
+
+That creates opportunities for Queue-Based Load Leveling and Competing
+Consumers.
+
+It also creates duplicate delivery, ordering, poison-message, and
+observability problems.
+
+Every architectural capability has a cost.
+
+## Architecture Styles Are Not Patterns
+
+Modern architecture discussions often mix several kinds of ideas:
+
+``` text
+Clean Architecture       architecture style
+Vertical Slice           organization strategy
+DDD                      design approach
+CQRS                     architectural pattern
+Outbox                   reliability pattern
+Retry                    resilience pattern
+Dependency Injection     design technique
+```
+
+That is fine in ordinary conversation, but this volume will be precise
+about what each idea actually changes.
+
+The question is never:
+
+> Which architecture is best?
+
+The useful question is:
+
+> Which problem are we solving, and what new trade-offs does this
+> solution introduce?
+
+## The Modern .NET Toolbox
+
+We will work through several layers of the toolbox.
+
+### Application structure
+
+-   Dependency Injection
+-   Clean Architecture
+-   Hexagonal Architecture
+-   Vertical Slice Architecture
+-   Mediator
+
+### Domain modeling
+
+-   Entity
+-   Aggregate
+-   Domain Service
+-   Domain Event
+-   Specification
+-   Anti-Corruption Layer
+
+### Commands and queries
+
+-   Command
+-   Query
+-   CQRS
+-   Result
+-   Idempotency
+
+### Messaging
+
+-   Publish/Subscribe
+-   Competing Consumers
+-   Transactional Outbox
+-   Inbox / Idempotent Consumer
+-   Dead Letter Queue
+-   Queue-Based Load Leveling
+-   Event Sourcing
+
+### Distributed workflows
+
+-   Saga
+-   Compensating Transaction
+-   Backend for Frontend
+-   API Gateway
+
+### Resilience
+
+-   Retry
+-   Circuit Breaker
+-   Bulkhead
+-   Cache-Aside
+
+And we will add patterns when the journey reveals a gap rather than
+forcing the catalog to remain artificially fixed.
+
+## Production Is Part of Architecture
+
+Volume I could often demonstrate a pattern inside one process.
+
+Volume II cannot stop there.
+
+For each pattern we will ask:
+
+``` text
+How does it fail?
+How do we observe it?
+How do we test it?
+How does it behave under concurrency?
+What happens during deployment?
+What happens when a dependency is unavailable?
+What does retry do?
+What happens twice?
+```
+
+That means production concerns such as OpenTelemetry, structured
+logging, health checks, cancellation, resilience, and failure recovery
+will appear throughout the series.
+
+## The Rule for Every Pattern
+
+Every article will answer two equally important questions:
+
+> When should I use this?
+
+and:
+
+> When should I absolutely not use this?
+
+A pattern is not a badge of architectural maturity.
+
+It is a trade.
+
+You accept additional structure or operational complexity in exchange
+for solving a specific recurring problem.
+
+If you do not have the problem, you should probably decline the trade.
+
+## Where We Start
+
+We begin with the most important architectural skill of all:
+
+**recognizing how much architecture the problem deserves.**
+
+Before Clean Architecture, DDD, CQRS, messaging, or microservices, we
+need a way to distinguish useful structure from accidental complexity.
+
+That is the subject of the next article.

--- a/src/posts/2029-09-09-patterns-principles-styles-practices.md
+++ b/src/posts/2029-09-09-patterns-principles-styles-practices.md
@@ -1,0 +1,269 @@
+---
+author: Steve Kaschimer
+date: 2029-09-09
+image: /images/posts/2029-09-09-hero.webp
+image_alt: "Five small distinctly shaped label tags arranged in a row, implying separate categories of idea rather than one interchangeable label."
+image_prompt: "A dark-mode technical editorial illustration on a near-black background with electric teal, amber, and off-white accents. Composition centers on five small distinctly shaped teal and amber label-tag glyphs arranged in an evenly spaced row, implying separate categories of architectural idea rather than one interchangeable label. Mood is precise and taxonomic. Avoid: vendor logos, brand colors, circuit-board textures, gears, or generic clip art as the dominant motif."
+layout: post.njk
+site_title: Tech Notes
+summary: "Separate architectural styles, design patterns, principles, practices, and technologies so architecture discussions become about decisions rather than labels."
+tags: ["dotnet", "architecture", "design-patterns", "software-design"]
+title: "Patterns, Principles, Styles, and Practices: Know What You're Choosing"
+---
+
+Software architecture conversations become confusing when every useful
+idea is called a pattern.
+
+Clean Architecture, SOLID, CQRS, dependency injection, microservices,
+Retry, DDD, and Kubernetes are not the same kind of thing.
+
+Knowing the difference makes architectural decisions easier to reason
+about.
+
+## Five Different Kinds of Decision
+
+A practical classification is:
+
+  Kind                 Question
+  -------------------- -------------------------------------------
+  Principle            What should guide our decisions?
+  Architecture style   How is the system broadly organized?
+  Pattern              How do we solve this recurring problem?
+  Practice             How do we work or implement consistently?
+  Technology           What concrete tool provides capabilities?
+
+For example:
+
+``` text
+Dependency Inversion      Principle
+Hexagonal Architecture    Style
+Gateway                   Pattern
+Constructor Injection     Practice/technique
+ASP.NET Core DI            Technology
+```
+
+These ideas can reinforce one another without being interchangeable.
+
+## Why This Matters
+
+If somebody says:
+
+> We use Clean Architecture.
+
+you still do not know:
+
+-   whether the system uses DDD;
+-   whether it uses CQRS;
+-   whether it uses repositories;
+-   whether features are vertical slices;
+-   whether messaging exists;
+-   whether the application is a monolith.
+
+Labels are summaries, not designs.
+
+## Principles
+
+Principles constrain choices.
+
+Examples include:
+
+-   dependency inversion;
+-   separation of concerns;
+-   high cohesion;
+-   low coupling;
+-   information hiding;
+-   favoring explicit boundaries.
+
+A principle does not normally tell you exactly what classes to create.
+
+It helps you evaluate alternatives.
+
+## Styles
+
+An architecture style shapes the system at a broad level.
+
+Examples include:
+
+``` text
+Layered
+Hexagonal
+Event-Driven
+Microservices
+Modular Monolith
+```
+
+A style creates a family of constraints.
+
+Hexagonal architecture, for example, emphasizes an application core
+separated from external adapters through ports.
+
+That does not tell you whether your persistence adapter should use EF
+Core or Dapper.
+
+## Patterns
+
+A pattern addresses a recurring problem in a context and brings
+trade-offs.
+
+For example:
+
+``` text
+Problem:
+A remote dependency repeatedly fails.
+
+Pattern:
+Circuit Breaker.
+
+Trade:
+Fail fast and protect resources,
+but temporarily reject calls that
+might otherwise have succeeded.
+```
+
+That is much more specific than an architecture style.
+
+## Practices
+
+Practices are repeatable ways of working.
+
+Examples:
+
+-   constructor injection;
+-   automated migrations;
+-   structured logging;
+-   contract testing;
+-   code review;
+-   trunk-based development.
+
+Practices can support patterns without being patterns themselves.
+
+## Technologies
+
+Technologies implement capabilities.
+
+Examples:
+
+``` text
+ASP.NET Core
+EF Core
+PostgreSQL
+Azure Service Bus
+OpenTelemetry
+Redis
+```
+
+A technology does not determine the architecture.
+
+You can build an excellent or terrible architecture with any of them.
+
+## CQRS Is a Good Test
+
+CQRS means separating responsibility for commands and queries.
+
+That is the architectural idea.
+
+This:
+
+``` text
+Commands -> EF Core
+Queries  -> Dapper
+```
+
+is one implementation.
+
+This:
+
+``` text
+Write DB -> events -> Read DB
+```
+
+is a more advanced implementation.
+
+The second is not required for the first to be CQRS.
+
+Separating the idea from one popular implementation prevents needless
+complexity.
+
+## DDD Is Another Good Test
+
+Domain-Driven Design is not:
+
+``` text
+EntityBase
+AggregateRootBase
+Repository<T>
+ValueObjectBase
+```
+
+DDD is an approach to managing complex business domains through
+modeling, language, boundaries, and collaboration with domain experts.
+
+Those classes may support that approach.
+
+They are not the approach.
+
+## Microservices Are an Architecture Style
+
+A microservice architecture introduces independent process and
+deployment boundaries.
+
+That means the network becomes part of normal application behavior.
+
+It creates benefits:
+
+-   independent deployment;
+-   independent scaling;
+-   technology autonomy;
+-   stronger ownership boundaries.
+
+It also creates costs:
+
+-   distributed transactions;
+-   latency;
+-   failure modes;
+-   observability requirements;
+-   deployment coordination;
+-   message/API versioning.
+
+Calling something a "microservice pattern" can hide the fact that
+choosing microservices changes the system's fundamental operating model.
+
+## Use Labels After the Decision
+
+A healthier sequence is:
+
+``` text
+1. Identify the problem.
+2. Identify the forces.
+3. Compare options.
+4. Accept a trade-off.
+5. Give the resulting design a useful name.
+```
+
+The unhealthy sequence is:
+
+``` text
+1. Choose "Clean Architecture."
+2. Copy a folder structure.
+3. Invent interfaces.
+4. Discover what problem they were meant to solve.
+```
+
+## Summary
+
+Architecture vocabulary is useful only when it makes decisions clearer.
+
+Principles guide us.
+
+Styles organize systems.
+
+Patterns solve recurring problems.
+
+Practices make implementation repeatable.
+
+Technologies provide concrete capabilities.
+
+Throughout Volume II, we will keep those categories separate enough to
+ask the question that matters:
+
+**What problem does this choice solve, and what does it cost us?**

--- a/src/posts/2029-09-16-architecture-complexity-ladder.md
+++ b/src/posts/2029-09-16-architecture-complexity-ladder.md
@@ -1,0 +1,297 @@
+---
+author: Steve Kaschimer
+date: 2029-09-16
+image: /images/posts/2029-09-16-hero.webp
+image_alt: "A vertical ladder of eight rungs, the lower rungs bold and solid and the upper rungs progressively fainter toward the top."
+image_prompt: "A dark-mode technical editorial illustration on a near-black background with electric teal, amber, and off-white accents. Composition centers on a single vertical teal ladder glyph of eight rungs, the bottom three rungs rendered bold and solid amber and each rung above progressively fainter until the top rung is a barely visible outline, implying escalating cost the higher a design climbs. Mood is cautionary and measured. Avoid: vendor logos, brand colors, circuit-board textures, gears, or generic clip art as the dominant motif."
+layout: post.njk
+site_title: Tech Notes
+summary: "Learn when a .NET application has earned additional architecture, from straightforward CRUD through domain modeling, CQRS, messaging, and distributed workflows."
+tags: ["dotnet", "architecture", "design-patterns", "software-design"]
+title: "The Architecture Complexity Ladder"
+---
+
+The most expensive architecture is not always the most sophisticated
+one.
+
+It is the architecture that solves problems you do not have.
+
+This article gives us a ladder for deciding when a .NET application has
+earned additional structure.
+
+## Level 0: CRUD
+
+Start here when the application primarily stores and retrieves data.
+
+``` text
+HTTP
+ |
+Endpoint
+ |
+EF Core
+ |
+Database
+```
+
+A Minimal API endpoint plus EF Core may be enough.
+
+``` csharp
+app.MapGet(
+    "/customers/{id:guid}",
+    async (
+        Guid id,
+        AppDbContext db,
+        CancellationToken ct) =>
+        await db.Customers.FindAsync([id], ct)
+            is { } customer
+                ? Results.Ok(customer)
+                : Results.NotFound());
+```
+
+Do not create four projects and twelve interfaces merely because the
+application might become complicated someday.
+
+## Level 1: Use Cases
+
+The endpoint begins accumulating workflow.
+
+Extract an application operation:
+
+``` text
+Endpoint
+   |
+Use Case
+   |
+DbContext
+```
+
+Now HTTP concerns and application behavior can evolve independently.
+
+This may look like a Service Layer, Transaction Script, command handler,
+or vertical slice handler.
+
+The name matters less than the boundary.
+
+## Level 2: Domain Model
+
+Business rules become interconnected.
+
+``` text
+if customer is preferred
+and order total exceeds...
+unless product category...
+except when region...
+```
+
+Now a rich model can protect invariants.
+
+``` text
+Endpoint
+   |
+Application
+   |
+Order Aggregate
+   |
+Persistence
+```
+
+The complexity of the domain has earned domain modeling.
+
+## Level 3: Separate Reads and Writes
+
+The model that protects invariants is not necessarily the model that
+answers:
+
+> Show the last 100 orders with customer name, shipment state, and
+> total.
+
+Do not torture the aggregate into becoming a report engine.
+
+Separate commands and queries.
+
+That is the beginning of CQRS.
+
+## Level 4: Internal Events
+
+One business action triggers several reactions:
+
+``` text
+OrderPlaced
+   |
+   +--> award loyalty points
+   +--> update internal metrics
+   +--> create fulfillment task
+```
+
+Domain events can decouple reactions inside the same bounded context
+while keeping the domain language explicit.
+
+## Level 5: External Integration
+
+Now another process must hear about the order.
+
+``` text
+Orders
+   |
+Integration Event
+   |
+Broker
+   |
+Fulfillment
+```
+
+A method call has become distributed communication.
+
+We must now care about delivery, duplication, ordering, and
+compatibility.
+
+## Level 6: Reliable Messaging
+
+The classic dual-write appears:
+
+``` text
+Save database
+Publish message
+```
+
+Those are two independent operations.
+
+If one succeeds and the other fails, the system becomes inconsistent.
+
+The Transactional Outbox becomes relevant.
+
+On the receiving side, at-least-once delivery makes idempotent
+consumption relevant.
+
+## Level 7: Distributed Workflow
+
+A business transaction now spans:
+
+``` text
+Orders
+Payments
+Inventory
+Shipping
+```
+
+No single local transaction owns the workflow.
+
+Saga and Compensating Transaction become candidates.
+
+At this point, architecture is as much about failure recovery as
+happy-path execution.
+
+## Level 8: Independent Scale and Failure
+
+Traffic is bursty.
+
+A queue buffers work.
+
+Multiple consumers process it.
+
+Remote services fail.
+
+Now patterns such as:
+
+-   Queue-Based Load Leveling;
+-   Competing Consumers;
+-   Retry;
+-   Circuit Breaker;
+-   Bulkhead;
+
+address concrete operational forces.
+
+## You Can Stop Anywhere
+
+This is the most important part of the ladder.
+
+``` text
+Level 0  CRUD
+Level 1  Use Cases
+Level 2  Domain Model
+Level 3  CQRS
+Level 4  Domain Events
+Level 5  Messaging
+Level 6  Reliable Messaging
+Level 7  Distributed Workflow
+Level 8  Resilience and Scale
+```
+
+There is no prize for Level 8.
+
+A well-designed Level 1 system is better than a Level 8 architecture
+built for a Level 1 problem.
+
+## Different Parts Can Sit on Different Rungs
+
+A single application may contain:
+
+``` text
+Admin settings       -> CRUD
+Checkout              -> Domain Model
+Reporting             -> Query projections
+Email notifications   -> Queue
+Payments              -> Idempotency + resilience
+```
+
+Architecture does not need to be uniform.
+
+Consistency is useful, but forcing every subsystem to use the most
+complex pattern required anywhere in the system is expensive.
+
+## The Escalation Question
+
+Before adding a pattern, ask:
+
+> What happened that made the current design insufficient?
+
+Good answers sound like:
+
+``` text
+"We are losing events between the database and broker."
+
+"We need to protect an invariant across these entities."
+
+"This dependency is causing cascading failures."
+
+"The read model requires joins that don't belong in the aggregate."
+
+"Duplicate messages are charging customers twice."
+```
+
+Weak answers sound like:
+
+``` text
+"It's best practice."
+
+"Big systems use it."
+
+"We might need it later."
+
+"The template had it."
+```
+
+## Architecture Debt vs. Architecture Speculation
+
+Under-design can create architecture debt.
+
+Over-design creates architecture speculation.
+
+Both are expensive.
+
+The goal is evolutionary architecture: introduce boundaries early enough
+that change remains possible, but introduce machinery only when the
+forces justify it.
+
+## Summary
+
+The Architecture Complexity Ladder is not a maturity model.
+
+It is a cost model.
+
+Each step buys capabilities and introduces new failure modes, concepts,
+code, tests, and operational responsibilities.
+
+Move upward because the software has encountered a problem that the next
+pattern solves - not because sophisticated architecture looks
+impressive.

--- a/src/posts/2029-09-23-modular-monolith-or-microservices.md
+++ b/src/posts/2029-09-23-modular-monolith-or-microservices.md
@@ -1,0 +1,229 @@
+---
+author: Steve Kaschimer
+date: 2029-09-23
+image: /images/posts/2029-09-23-hero.webp
+image_alt: "One bounded rectangle with internal partitions on the left, and the same rectangle split into separate floating boxes on the right, joined by a faint fork line."
+image_prompt: "A dark-mode technical editorial illustration on a near-black background with electric teal, amber, and off-white accents. Composition centers on a single teal rectangle with internal partition lines on the left half, forking via a faint off-white line into several separate small amber boxes floating apart on the right half, implying the same boundaries either kept inside one process or split into independent ones. Mood is deliberative and forked. Avoid: vendor logos, brand colors, circuit-board textures, gears, or generic clip art as the dominant motif."
+layout: post.njk
+site_title: Tech Notes
+summary: "Choose deployment boundaries after identifying business boundaries, and understand why a modular monolith is often the strongest starting point for a modern .NET system."
+tags: ["dotnet", "architecture", "design-patterns", "microservices"]
+title: "Modular Monolith or Microservices? Start With the Boundary"
+---
+
+One of the easiest ways to make a new system unnecessarily difficult is
+to begin with:
+
+> How many microservices should we have?
+
+That question is premature.
+
+Start with:
+
+> Where are the business boundaries?
+
+## Logical Boundaries Before Deployment Boundaries
+
+Imagine an application with:
+
+``` text
+Catalog
+Ordering
+Billing
+Fulfillment
+Identity
+```
+
+Those may be meaningful modules or bounded contexts.
+
+They do not automatically need to be separate processes.
+
+A modular monolith can preserve boundaries inside one deployment:
+
+``` text
+┌───────────────────────────────┐
+│        ASP.NET Core App       │
+│                               │
+│ Catalog   Ordering   Billing  │
+│                               │
+│ Fulfillment       Identity    │
+└───────────────────────────────┘
+```
+
+The important property is that modules do not become one
+undifferentiated codebase.
+
+## What a Modular Monolith Buys You
+
+Inside one process, you retain:
+
+-   simple deployment;
+-   local calls;
+-   straightforward debugging;
+-   inexpensive transactions;
+-   simpler testing;
+-   fewer operational components.
+
+At the same time, strong module boundaries can preserve:
+
+-   ownership;
+-   encapsulation;
+-   separate domain models;
+-   explicit contracts;
+-   future extraction options.
+
+That is an excellent trade for many systems.
+
+## What Microservices Change
+
+Split Billing into another service:
+
+``` text
+Ordering ----HTTP/message----> Billing
+```
+
+The call is no longer a method call.
+
+Now:
+
+``` text
+Billing can be unavailable.
+The request can time out.
+The operation may succeed after the timeout.
+Ordering may retry.
+The retry may duplicate the operation.
+The contract must be versioned.
+Both services need distributed tracing.
+```
+
+Microservices do not merely rearrange projects.
+
+They convert in-process coupling into distributed-systems problems.
+
+## The Database Boundary
+
+A useful microservice boundary generally includes ownership of data.
+
+This:
+
+``` text
+Order Service ----Billing Service ---+--> Shared Database
+Shipping Service -/
+```
+
+may provide independent processes without meaningful autonomy.
+
+Shared schemas create coupling through:
+
+-   migrations;
+-   transactions;
+-   queries;
+-   data semantics;
+-   deployment coordination.
+
+If services cannot change their data independently, the service boundary
+may be weaker than it appears.
+
+## Module Contracts
+
+A modular monolith can prohibit arbitrary cross-module access.
+
+For example:
+
+``` text
+Ordering
+   |
+   v
+IBillingModule
+   |
+Billing
+```
+
+or communicate through internal events.
+
+The exact mechanism matters less than preserving the rule:
+
+> A module owns its internals.
+
+## Extraction Later
+
+If Billing later needs independent deployment:
+
+``` text
+Before:
+Ordering -> IBillingModule -> Billing module
+
+After:
+Ordering -> IBillingGateway -> Billing service
+```
+
+A well-designed logical boundary can make the physical split less
+traumatic.
+
+It does not make extraction free.
+
+Distributed communication still changes consistency and failure
+semantics.
+
+## When Microservices Earn Their Cost
+
+Good reasons include:
+
+-   independent deployment is genuinely valuable;
+-   different scaling characteristics matter;
+-   organizational ownership is strong;
+-   regulatory or security isolation requires it;
+-   failure isolation is important;
+-   technology independence provides real value.
+
+"We expect lots of users" is not enough by itself.
+
+A monolith can scale horizontally too.
+
+## Organizational Architecture
+
+Service boundaries often become team boundaries.
+
+That means architecture and organization interact.
+
+If five teams constantly modify the same service, the service may not
+represent a useful ownership boundary.
+
+Conversely, creating twenty services for a five-person team can impose
+operational coordination the organization cannot sustain.
+
+## Start With the Boundary
+
+A practical progression is:
+
+``` text
+Business capability
+      |
+Bounded context / module
+      |
+Explicit contract
+      |
+Independent ownership
+      |
+Independent deployment?
+      |
+Maybe microservice
+```
+
+Notice that "microservice" comes last.
+
+## Summary
+
+Modularity and microservices solve different problems.
+
+Modularity is about boundaries.
+
+Microservices add process and deployment independence.
+
+A modular monolith often gives a system the first benefit without
+immediately accepting the network, consistency, observability, and
+operational costs of the second.
+
+Find the boundary first.
+
+Then decide whether that boundary deserves its own process.

--- a/src/posts/2029-09-30-start-with-problems-not-patterns.md
+++ b/src/posts/2029-09-30-start-with-problems-not-patterns.md
@@ -1,0 +1,232 @@
+---
+author: Steve Kaschimer
+date: 2029-09-30
+image: /images/posts/2029-09-30-hero.webp
+image_alt: "A magnifying lens hovering over a single question-mark shape, with faint unused pattern shapes pushed off to one side."
+image_prompt: "A dark-mode technical editorial illustration on a near-black background with electric teal, amber, and off-white accents. Composition centers on a teal magnifying-lens glyph hovering directly over a single amber question-mark shape at the frame's center, with three faint, unused geometric pattern shapes pushed off to one side, implying the problem is examined first and the pattern catalog waits. Mood is diagnostic and disciplined. Avoid: vendor logos, brand colors, circuit-board textures, gears, or generic clip art as the dominant motif."
+layout: post.njk
+site_title: Tech Notes
+summary: "Use forces, failure modes, and explicit trade-offs to decide whether a pattern belongs in a .NET architecture instead of applying patterns by reputation."
+tags: ["dotnet", "architecture", "design-patterns", "software-design"]
+title: "Don't Start With Patterns: Start With Problems"
+---
+
+A pattern catalog can accidentally encourage the worst possible way to
+use patterns.
+
+You read about Outbox.
+
+Outbox sounds robust.
+
+So every application gets an Outbox.
+
+That is backwards.
+
+## Pattern Selection Is Diagnosis
+
+A doctor does not begin with:
+
+> I really like casts. Which part of you can I put one on?
+
+Architecture should work the same way.
+
+Start with symptoms.
+
+For example:
+
+``` text
+Symptom:
+Customers are occasionally charged twice.
+
+Evidence:
+Requests are retried after timeout.
+
+Constraint:
+Payment provider accepts idempotency keys.
+
+Candidate:
+Idempotency.
+```
+
+That is a pattern earning its way into the design.
+
+## Write the Problem Statement First
+
+Before adopting a pattern, write one paragraph answering:
+
+``` text
+What is happening?
+Why is the current design insufficient?
+What constraint prevents the obvious solution?
+What failure are we trying to prevent?
+```
+
+If the team cannot answer those questions, it probably cannot evaluate
+the pattern's trade-offs either.
+
+## Patterns Have Costs
+
+Consider CQRS.
+
+Benefits may include:
+
+-   independent read models;
+-   simpler queries;
+-   clearer command semantics;
+-   separate optimization.
+
+Costs may include:
+
+-   more types;
+-   more code paths;
+-   eventual consistency if stores separate;
+-   duplicated models;
+-   more testing.
+
+The decision is not:
+
+``` text
+CQRS = good
+```
+
+It is:
+
+``` text
+Benefits in our context
+>
+Costs in our context
+```
+
+## Patterns Compose
+
+Real systems rarely use one pattern in isolation.
+
+A reliable messaging flow might become:
+
+``` text
+Command
+   |
+Domain Model
+   |
+Unit of Work
+   |
+Transactional Outbox
+   |
+Broker
+   |
+Competing Consumer
+   |
+Idempotent Consumer
+```
+
+Each pattern addresses a different failure mode.
+
+Adding only one can leave the system with false confidence.
+
+## Patterns Can Conflict
+
+A rich Domain Model favors behavior close to state.
+
+A highly optimized reporting model favors direct projections.
+
+Trying to make one model satisfy both forces can make both worse.
+
+CQRS can let us use different patterns on each side.
+
+Pattern literacy is partly the ability to recognize tensions between
+forces.
+
+## Prefer the Smallest Sufficient Pattern
+
+Suppose an API calls a remote weather service.
+
+One occasional transient failure does not automatically justify:
+
+``` text
+Retry
+Circuit Breaker
+Bulkhead
+Fallback
+Hedging
+Queue
+Cache
+```
+
+Maybe a timeout plus a carefully bounded retry is enough.
+
+Add mechanisms when measurements and failure modes justify them.
+
+## Architecture Decision Records
+
+For consequential choices, capture the reasoning.
+
+A lightweight ADR can contain:
+
+``` markdown
+# Use Transactional Outbox for Order Events
+
+## Context
+Database commit and broker publish can fail independently.
+
+## Decision
+Persist integration events in the order database transaction.
+
+## Consequences
+Requires dispatcher, cleanup, monitoring, and idempotent consumers.
+```
+
+The consequence section prevents a pattern from looking free.
+
+## Measure the Problem
+
+Production architecture should be informed by evidence.
+
+Useful signals include:
+
+-   latency percentiles;
+-   error rates;
+-   retry counts;
+-   queue depth;
+-   dead-letter count;
+-   cache hit rate;
+-   database contention;
+-   dependency failure rate.
+
+Observability helps us discover when a pattern is needed - and whether
+it actually worked.
+
+## The Pattern Review Checklist
+
+Before adopting a pattern, ask:
+
+1.  What specific problem does it solve?
+2.  Do we have that problem now?
+3.  What is the simplest alternative?
+4.  What new failure modes does it introduce?
+5.  What operational machinery does it require?
+6.  How will we test it?
+7.  How will we observe it?
+8.  How will we know it succeeded?
+9.  Can we remove it later?
+10. Does the team understand it?
+
+That checklist will appear repeatedly throughout Volume II.
+
+## A Pattern Is a Trade
+
+This is the philosophy of the entire volume:
+
+> A pattern is a named trade-off that has worked repeatedly in a
+> particular context.
+
+That is more useful than treating patterns as architectural
+commandments.
+
+## Next
+
+With the foundations established, we can begin structuring a modern .NET
+application.
+
+The first subject is Dependency Injection - not because `AddScoped` is
+difficult, but because dependency direction, lifetime, composition, and
+replaceability shape almost every pattern that follows.

--- a/src/posts/2029-10-07-dependency-injection.md
+++ b/src/posts/2029-10-07-dependency-injection.md
@@ -1,0 +1,451 @@
+---
+author: Steve Kaschimer
+date: 2029-10-07
+image: /images/posts/2029-10-07-hero.webp
+image_alt: "A socket-and-plug pair being wired into place by a separate composition-root box positioned outside both."
+image_prompt: "A dark-mode technical editorial illustration on a near-black background with electric teal, amber, and off-white accents. Composition centers on a teal socket glyph and an amber plug glyph not yet touching, with a small off-white composition-root box positioned above both, a thin line reaching down to connect them, implying an external boundary that assembles dependencies rather than the pieces wiring themselves. Mood is externalized and orderly. Avoid: vendor logos, brand colors, circuit-board textures, gears, or generic clip art as the dominant motif."
+layout: post.njk
+site_title: Tech Notes
+summary: "Use dependency injection as an architectural composition technique in modern .NET, with explicit dependencies, correct lifetimes, keyed services, factories, decorators, and a disciplined composition root."
+tags: ["dotnet", "architecture", "design-patterns", "software-design"]
+title: "Dependency Injection Beyond AddScoped"
+---
+
+Dependency Injection is so normal in modern .NET that it is easy to
+mistake the container API for the pattern.
+
+``` csharp
+builder.Services.AddScoped<IOrderRepository, EfOrderRepository>();
+```
+
+That line is useful.
+
+But Dependency Injection is not primarily about registering services.
+
+It is about **making dependencies explicit and moving object composition
+to the edge of the application**.
+
+## The Problem
+
+Without DI, a class may construct its own infrastructure:
+
+``` csharp
+public sealed class PlaceOrder
+{
+    private readonly SqlOrderRepository _orders =
+        new(new SqlConnection(...));
+
+    private readonly VendorPaymentGateway _payments =
+        new(new HttpClient());
+
+    public async Task ExecuteAsync(...)
+    {
+        // ...
+    }
+}
+```
+
+`PlaceOrder` now knows:
+
+-   which database technology is used;
+-   how the repository is constructed;
+-   which payment vendor is used;
+-   how HTTP infrastructure is constructed.
+
+Business workflow and composition are tangled together.
+
+## Invert Construction
+
+Instead:
+
+``` csharp
+public sealed class PlaceOrder(
+    IOrderRepository orders,
+    IPaymentGateway payments,
+    TimeProvider timeProvider)
+{
+    public async Task ExecuteAsync(
+        PlaceOrderCommand command,
+        CancellationToken cancellationToken)
+    {
+        // Application behavior.
+    }
+}
+```
+
+The class says what it needs.
+
+Something else decides what satisfies those needs.
+
+That "something else" is the composition root.
+
+## The Composition Root
+
+In a small ASP.NET Core application, `Program.cs` is often the
+composition root:
+
+``` csharp
+var builder = WebApplication.CreateBuilder(args);
+
+builder.Services.AddDbContext<OrdersDbContext>(...);
+
+builder.Services.AddScoped<
+    IOrderRepository,
+    EfOrderRepository>();
+
+builder.Services.AddHttpClient<
+    IPaymentGateway,
+    VendorPaymentGateway>();
+
+builder.Services.AddScoped<PlaceOrder>();
+
+var app = builder.Build();
+```
+
+The rest of the application should rarely need to know that the DI
+container exists.
+
+## Explicit Dependencies
+
+Constructor injection gives a class an honest API:
+
+``` csharp
+public sealed class ShippingService(
+    IShippingGateway gateway,
+    ILogger<ShippingService> logger)
+{
+}
+```
+
+A developer can inspect the constructor and understand what the service
+needs.
+
+Compare that with:
+
+``` csharp
+public sealed class ShippingService(
+    IServiceProvider services)
+{
+    public async Task ShipAsync(...)
+    {
+        var gateway =
+            services.GetRequiredService<IShippingGateway>();
+    }
+}
+```
+
+The second version hides the real dependency.
+
+The DI container has become a Service Locator.
+
+## Lifetimes Are Architecture
+
+The built-in container gives us three fundamental lifetimes:
+
+``` text
+Transient
+Scoped
+Singleton
+```
+
+They are not merely performance settings.
+
+They define ownership and sharing.
+
+### Transient
+
+A new instance is created each time the service is requested.
+
+Good candidates are usually lightweight, stateless services.
+
+### Scoped
+
+One instance exists within a scope.
+
+In ASP.NET Core, the normal request scope means one scoped instance per
+request.
+
+EF Core `DbContext` is scoped by default.
+
+That aligns naturally with a request-oriented Unit of Work.
+
+### Singleton
+
+One instance is shared for the application's lifetime.
+
+Singletons must be safe for concurrent use.
+
+They should not capture request-specific state.
+
+## The Captive Dependency Problem
+
+This is dangerous:
+
+``` text
+Singleton
+   |
+   v
+Scoped DbContext
+```
+
+A long-lived object has captured a short-lived dependency.
+
+The scope semantics are now broken.
+
+If a singleton genuinely needs to perform scoped work, create an
+explicit scope at the appropriate operation boundary rather than
+capturing a scoped service indefinitely.
+
+## Do Not Make Everything an Interface
+
+This:
+
+``` csharp
+public interface IPriceCalculator
+{
+    Money Calculate(Order order);
+}
+
+public sealed class PriceCalculator
+    : IPriceCalculator
+{
+}
+```
+
+may be useful.
+
+But if `PriceCalculator` is an internal application component with one
+implementation and no boundary role, injecting the concrete class may be
+perfectly reasonable:
+
+``` csharp
+builder.Services.AddScoped<PriceCalculator>();
+```
+
+Interfaces are valuable when they express:
+
+-   polymorphism;
+-   a dependency inversion boundary;
+-   a plugin contract;
+-   a replaceable external capability.
+
+They are not an entrance fee for DI.
+
+## Keyed Services
+
+Sometimes several implementations are intentionally available:
+
+``` csharp
+builder.Services.AddKeyedSingleton<
+    INotificationSender,
+    EmailNotificationSender>("email");
+
+builder.Services.AddKeyedSingleton<
+    INotificationSender,
+    SmsNotificationSender>("sms");
+```
+
+Keyed services can be useful when selection is part of composition.
+
+But if business logic is choosing among implementations dynamically, a
+domain-specific strategy registry or factory may communicate the intent
+better than scattering container keys through application code.
+
+## Factories
+
+Some dependencies cannot be selected until runtime.
+
+A factory makes that explicit:
+
+``` csharp
+public interface IPaymentGatewayFactory
+{
+    IPaymentGateway Get(PaymentProvider provider);
+}
+```
+
+The factory can receive all available implementations and choose among
+them.
+
+This keeps `IServiceProvider` out of the business workflow.
+
+## Decorators
+
+DI works particularly well with Decorator:
+
+``` text
+PaymentGateway
+      ^
+      |
+LoggingPaymentGateway
+      ^
+      |
+RetryingPaymentGateway
+```
+
+Each decorator implements the same contract and wraps another
+implementation.
+
+This is useful for cross-cutting behavior such as:
+
+-   metrics;
+-   tracing;
+-   caching;
+-   authorization;
+-   idempotency.
+
+Do not automatically build a decorator pipeline for every service.
+Middleware, interceptors, and framework-native resilience may be better
+at some boundaries.
+
+## Registration by Feature
+
+A large `Program.cs` can become unreadable.
+
+Group registrations by capability:
+
+``` csharp
+builder.Services
+    .AddOrdering(builder.Configuration)
+    .AddPayments(builder.Configuration)
+    .AddFulfillment(builder.Configuration);
+```
+
+Inside:
+
+``` csharp
+public static IServiceCollection AddOrdering(
+    this IServiceCollection services,
+    IConfiguration configuration)
+{
+    services.AddScoped<PlaceOrder>();
+    services.AddScoped<CancelOrder>();
+
+    return services;
+}
+```
+
+The composition root remains centralized while details remain navigable.
+
+## DI Does Not Eliminate `new`
+
+This is a common misconception.
+
+Domain code should happily create ordinary objects:
+
+``` csharp
+var order = Order.Create(
+    customerId,
+    shippingAddress);
+```
+
+Do not resolve entities or value objects from DI.
+
+The container is best for services whose construction requires
+dependency management or lifecycle control.
+
+## Too Many Dependencies Are Information
+
+Consider:
+
+``` csharp
+public sealed class OrderService(
+    IOrderRepository orders,
+    ICustomerRepository customers,
+    IPaymentGateway payments,
+    IShippingGateway shipping,
+    IEmailSender email,
+    IInventoryGateway inventory,
+    ILogger<OrderService> logger,
+    TimeProvider timeProvider,
+    IEventPublisher events)
+```
+
+The container can resolve this.
+
+That does not make the design good.
+
+A huge constructor often tells us that the class has accumulated too
+many responsibilities.
+
+DI makes coupling visible. Listen to what it is telling you.
+
+## Testing
+
+Constructor injection makes focused tests straightforward:
+
+``` csharp
+var handler = new PlaceOrder(
+    orders: new InMemoryOrderRepository(),
+    payments: new ApprovedPaymentGatewayStub(),
+    timeProvider: fakeTimeProvider);
+```
+
+But do not create interfaces solely to mock every internal method call.
+
+Tests should generally substitute meaningful boundaries, not
+implementation trivia.
+
+## Production Considerations
+
+Validate the container during startup where appropriate.
+
+Watch for:
+
+-   captive dependencies;
+-   thread-unsafe singletons;
+-   disposable transient services;
+-   expensive construction;
+-   hidden Service Locator usage;
+-   excessive reflection scanning.
+
+DI configuration is production code.
+
+## How It Relates to Fowler
+
+Dependency Injection connects directly to several Volume I patterns:
+
+``` text
+Registry
+   -> often replaced by explicit DI
+
+Separated Interface
+   -> defines the inward-facing contract
+
+Gateway
+   -> implementation injected at the edge
+
+Plugin
+   -> implementations selected through composition
+```
+
+The biggest shift is that modern .NET gives us a first-class composition
+mechanism built into the platform.
+
+## When It Helps
+
+Use DI when dependencies have lifetimes, implementations, configuration,
+or boundaries that should be composed externally.
+
+## When It Hurts
+
+DI becomes harmful when:
+
+-   everything gets an interface for no reason;
+-   the container is used as a global registry;
+-   runtime service lookup hides dependencies;
+-   object construction that should be ordinary C# becomes container
+    magic;
+-   teams confuse "resolvable" with "well designed."
+
+## Summary
+
+Dependency Injection is not `AddScoped`.
+
+It is the architectural decision to make dependencies explicit and move
+composition out of business behavior.
+
+ASP.NET Core's container makes the mechanics easy.
+
+The design skill is deciding what should be composed, what lifetime it
+owns, and where the dependency boundary belongs.

--- a/src/posts/2029-10-14-clean-architecture.md
+++ b/src/posts/2029-10-14-clean-architecture.md
@@ -1,0 +1,411 @@
+---
+author: Steve Kaschimer
+date: 2029-10-14
+image: /images/posts/2029-10-14-hero.webp
+image_alt: "Concentric rings with a small solid core circle at the center, thin arrows pointing inward from the outer ring toward the core."
+image_prompt: "A dark-mode technical editorial illustration on a near-black background with electric teal, amber, and off-white accents. Composition centers on three teal concentric rings surrounding one small solid amber core circle, with three thin off-white arrows positioned around the outer ring all pointing inward toward the core, implying dependencies directed toward a protected center. Mood is protected and inward-facing. Avoid: vendor logos, brand colors, circuit-board textures, gears, or generic clip art as the dominant motif."
+layout: post.njk
+site_title: Tech Notes
+summary: "Apply Clean Architecture's dependency rule in .NET without blindly copying layers, interfaces, repositories, and project templates that the application does not need."
+tags: ["dotnet", "architecture", "design-patterns", "software-design"]
+title: "Clean Architecture in Modern .NET Without the Ceremony"
+---
+
+Clean Architecture is one of the most recognizable architecture styles
+in modern .NET.
+
+It is also one of the easiest to imitate superficially.
+
+A solution with projects named:
+
+``` text
+Domain
+Application
+Infrastructure
+Web
+```
+
+is not automatically clean.
+
+The important idea is the **direction of dependency**.
+
+## The Dependency Rule
+
+Business policy should not depend on infrastructure details.
+
+Conceptually:
+
+``` text
+       Infrastructure
+             |
+             v
+Application / Domain
+             ^
+             |
+          Web Host
+```
+
+The database adapter can know about the application's repository
+contract.
+
+The application should not know that SQL Server or EF Core satisfies it.
+
+## Traditional Layering
+
+A traditional dependency chain often looks like:
+
+``` text
+UI
+ |
+ v
+Business
+ |
+ v
+Data Access
+ |
+ v
+Database
+```
+
+The business layer depends downward on persistence abstractions or
+implementations.
+
+Clean Architecture turns important dependencies inward.
+
+## A Practical .NET Solution
+
+A reasonable structure might be:
+
+``` text
+Store.Domain
+Store.Application
+Store.Infrastructure
+Store.Api
+```
+
+### Domain
+
+Contains concepts such as:
+
+``` text
+Order
+OrderItem
+Money
+Business rules
+Domain events
+```
+
+### Application
+
+Contains use cases:
+
+``` text
+PlaceOrder
+CancelOrder
+GetOrderDetails
+```
+
+and contracts required by those use cases:
+
+``` text
+IOrderRepository
+IPaymentAuthorizer
+IUnitOfWork
+```
+
+### Infrastructure
+
+Implements outer-world details:
+
+``` text
+EF Core
+SQL
+HTTP gateways
+message brokers
+file storage
+```
+
+### API
+
+Hosts the application:
+
+``` text
+ASP.NET Core
+authentication
+HTTP endpoints
+composition root
+```
+
+## Project References Matter
+
+The architecture becomes enforceable through project references.
+
+For example:
+
+``` text
+Application -> Domain
+Infrastructure -> Application
+Infrastructure -> Domain
+Api -> Application
+Api -> Infrastructure
+```
+
+Domain does not reference Infrastructure.
+
+Application does not reference the API.
+
+That is more meaningful than folder names.
+
+## A Use Case
+
+Application:
+
+``` csharp
+public sealed class PlaceOrder(
+    IOrderRepository orders,
+    IUnitOfWork unitOfWork)
+{
+    public async Task<OrderId> ExecuteAsync(
+        PlaceOrderCommand command,
+        CancellationToken cancellationToken)
+    {
+        var order = Order.Place(
+            command.CustomerId,
+            command.Items);
+
+        orders.Add(order);
+
+        await unitOfWork.SaveChangesAsync(
+            cancellationToken);
+
+        return order.Id;
+    }
+}
+```
+
+Infrastructure:
+
+``` csharp
+public sealed class EfOrderRepository(
+    OrdersDbContext db)
+    : IOrderRepository
+{
+    public void Add(Order order)
+        => db.Orders.Add(order);
+}
+```
+
+The use case knows what persistence capability it needs without knowing
+how it is implemented.
+
+## But Do We Need `IUnitOfWork`?
+
+Maybe not.
+
+If the application is intentionally coupled to EF Core as its
+persistence abstraction, injecting `OrdersDbContext` directly may be
+simpler.
+
+Clean Architecture does not require hiding every framework.
+
+The architectural question is:
+
+> Is this dependency a detail we need the core to remain independent
+> from?
+
+For some systems, the answer for EF Core is yes.
+
+For others, the abstraction buys little.
+
+## The Repository Debate
+
+A common Clean Architecture template includes:
+
+``` text
+IRepository<T>
+Repository<T>
+IUnitOfWork
+UnitOfWork
+```
+
+before the application has a single use case.
+
+That can become architecture by template.
+
+A generic repository may hide useful EF Core capabilities while adding
+almost no domain language.
+
+A domain-specific repository:
+
+``` csharp
+public interface IOrderRepository
+{
+    Task<Order?> GetForUpdateAsync(
+        OrderId id,
+        CancellationToken cancellationToken);
+
+    void Add(Order order);
+}
+```
+
+can be valuable when it expresses the aggregate's persistence boundary.
+
+Use abstractions for a reason.
+
+## Clean Architecture Is Not Four Projects
+
+A small application can enforce the dependency rule in one project using
+namespaces and discipline.
+
+A large system may need more assemblies to make boundaries
+compiler-enforced.
+
+Project count is a mechanism.
+
+It is not the architecture.
+
+## Dependency Injection at the Edge
+
+Infrastructure is wired to inward-facing contracts at startup:
+
+``` csharp
+builder.Services.AddScoped<
+    IOrderRepository,
+    EfOrderRepository>();
+
+builder.Services.AddScoped<
+    IPaymentAuthorizer,
+    StripePaymentAuthorizer>();
+```
+
+The composition root is allowed to know concrete implementation types.
+
+That is its job.
+
+## Where DTOs Belong
+
+Do not assume one DTO should flow through every layer.
+
+An HTTP request:
+
+``` csharp
+public sealed record PlaceOrderRequest(...);
+```
+
+belongs to the transport contract.
+
+The application command:
+
+``` csharp
+public sealed record PlaceOrderCommand(...);
+```
+
+belongs to the use case.
+
+Sometimes those shapes are identical.
+
+Whether to separate them depends on whether their reasons to change
+differ.
+
+## Clean Architecture and DDD
+
+They are not the same thing.
+
+You can have:
+
+``` text
+Clean Architecture + CRUD
+Clean Architecture + Transaction Scripts
+Clean Architecture + DDD
+```
+
+DDD addresses domain complexity.
+
+Clean Architecture primarily addresses dependency direction and
+separation of policy from detail.
+
+## Clean Architecture and Vertical Slices
+
+They can coexist.
+
+One option:
+
+``` text
+Application/
+  Orders/
+    Place/
+      Command.cs
+      Handler.cs
+    Cancel/
+      Command.cs
+      Handler.cs
+```
+
+The outer dependency rule remains intact while the application is
+organized by feature rather than technical type.
+
+## Testing
+
+A core benefit is that application behavior can often be tested without
+starting the web host or real infrastructure.
+
+But avoid creating fake abstractions for every implementation detail
+merely to achieve isolated tests.
+
+Architecture exists for production change, not just mocking convenience.
+
+## When It Helps
+
+Clean Architecture is valuable when:
+
+-   business rules matter;
+-   infrastructure changes independently;
+-   several delivery mechanisms use the same application;
+-   compiler-enforced boundaries improve team ownership;
+-   the system is expected to evolve for years.
+
+## When It Hurts
+
+It hurts when a simple CRUD application becomes:
+
+``` text
+Controller
+ -> IRequest
+ -> Handler
+ -> IService
+ -> Repository
+ -> UnitOfWork
+ -> DbContext
+```
+
+with every layer simply forwarding the same data.
+
+Indirection is not architecture by itself.
+
+## How It Relates to Fowler
+
+Clean Architecture composes many Volume I ideas:
+
+-   Separated Interface;
+-   Gateway;
+-   Mapper;
+-   Service Layer;
+-   Repository;
+-   Domain Model.
+
+Fowler gave us many of the pieces.
+
+Clean Architecture emphasizes how dependencies among those pieces should
+point.
+
+## Summary
+
+Clean Architecture is not a folder template.
+
+It is a dependency rule:
+
+**business policy should not be forced to depend on replaceable
+technical details.**
+
+Use projects, interfaces, DI, and adapters only to the degree needed to
+make that rule valuable and enforceable.

--- a/src/posts/2029-10-21-hexagonal-architecture-ports-adapters.md
+++ b/src/posts/2029-10-21-hexagonal-architecture-ports-adapters.md
@@ -1,0 +1,348 @@
+---
+author: Steve Kaschimer
+date: 2029-10-21
+image: /images/posts/2029-10-21-hero.webp
+image_alt: "A hexagon core with several small port notches around its perimeter, each approached by a separate adapter shape."
+image_prompt: "A dark-mode technical editorial illustration on a near-black background with electric teal, amber, and off-white accents. Composition centers on a single teal hexagon glyph with three small notch openings spaced around its perimeter, each approached from outside by a small distinct amber adapter shape not quite touching, implying a core reached only through deliberate ports. Mood is bounded and adaptable. Avoid: vendor logos, brand colors, circuit-board textures, gears, or generic clip art as the dominant motif."
+layout: post.njk
+site_title: Tech Notes
+summary: "Design a .NET application around use-case ports and replaceable adapters so HTTP, databases, brokers, and external APIs remain outside the application core."
+tags: ["dotnet", "architecture", "design-patterns", "software-design"]
+title: "Hexagonal Architecture and Ports & Adapters in Modern .NET"
+---
+
+Hexagonal Architecture gives us a powerful mental model:
+
+> The application is the center. Everything that talks to it is an
+> adapter.
+
+The hexagon is not important.
+
+The boundary is.
+
+## Stop Thinking in Top and Bottom
+
+Layer diagrams encourage:
+
+``` text
+Presentation
+Business
+Data
+```
+
+Hexagonal Architecture encourages:
+
+``` text
+             HTTP Adapter
+                  |
+                  v
+        +-------------------+
+        |                   |
+Queue ->|    Application    |-> Payment API
+        |                   |
+        +-------------------+
+                  |
+                  v
+             Database
+```
+
+External technology surrounds the application rather than sitting
+"below" it.
+
+## Ports
+
+A port describes how the application can be used or what capability it
+requires.
+
+There are two useful directions.
+
+### Driving ports
+
+They expose application capabilities:
+
+``` csharp
+public interface IPlaceOrder
+{
+    Task<PlaceOrderResult> ExecuteAsync(
+        PlaceOrderCommand command,
+        CancellationToken cancellationToken);
+}
+```
+
+An HTTP endpoint, CLI, test, or message consumer can drive that port.
+
+### Driven ports
+
+They describe capabilities the application needs:
+
+``` csharp
+public interface IPaymentAuthorizer
+{
+    Task<AuthorizationResult> AuthorizeAsync(
+        Money amount,
+        PaymentMethod method,
+        CancellationToken cancellationToken);
+}
+```
+
+Infrastructure provides an adapter.
+
+## Adapters
+
+An HTTP adapter translates HTTP into an application call:
+
+``` csharp
+app.MapPost(
+    "/orders",
+    async (
+        PlaceOrderRequest request,
+        IPlaceOrder useCase,
+        CancellationToken ct) =>
+    {
+        var command = request.ToCommand();
+
+        var result =
+            await useCase.ExecuteAsync(command, ct);
+
+        return result.ToHttpResult();
+    });
+```
+
+A payment adapter translates the application's port into a vendor
+protocol:
+
+``` csharp
+public sealed class VendorPaymentAdapter(
+    HttpClient client)
+    : IPaymentAuthorizer
+{
+    public async Task<AuthorizationResult>
+        AuthorizeAsync(
+            Money amount,
+            PaymentMethod method,
+            CancellationToken cancellationToken)
+    {
+        // Translate and call vendor.
+    }
+}
+```
+
+## The Application Owns the Port
+
+This is crucial.
+
+Do not define:
+
+``` csharp
+public interface IVendorPaymentClient
+```
+
+inside the application merely because the vendor has an API.
+
+Define what the application needs:
+
+``` csharp
+public interface IPaymentAuthorizer
+```
+
+The adapter translates between the two worlds.
+
+That protects the application's language.
+
+## Database as an Adapter
+
+Persistence is also outside the application core.
+
+A port might be:
+
+``` csharp
+public interface IOrderRepository
+{
+    Task<Order?> GetAsync(
+        OrderId id,
+        CancellationToken cancellationToken);
+
+    void Add(Order order);
+}
+```
+
+The EF Core adapter implements it.
+
+``` text
+Application -> IOrderRepository
+                    ^
+                    |
+              EF Core Adapter
+```
+
+## Message Broker as an Adapter
+
+The same architecture works asynchronously.
+
+Inbound:
+
+``` text
+Service Bus message
+       |
+Message Consumer Adapter
+       |
+Application Use Case
+```
+
+Outbound:
+
+``` text
+Application
+   |
+IIntegrationEventPublisher
+   |
+Service Bus Adapter
+```
+
+The core should not require Azure Service Bus concepts merely because
+one deployment uses it.
+
+## Testing Through Ports
+
+Ports create excellent testing seams.
+
+An application test can call:
+
+``` csharp
+await placeOrder.ExecuteAsync(
+    command,
+    cancellationToken);
+```
+
+with fake driven adapters.
+
+An adapter test can independently verify that HTTP or broker messages
+translate correctly.
+
+## Hexagonal vs. Clean Architecture
+
+They are close relatives.
+
+Both emphasize:
+
+-   application/domain at the center;
+-   dependency inversion;
+-   infrastructure at the edge;
+-   replaceable adapters.
+
+Clean Architecture often emphasizes concentric policy layers.
+
+Hexagonal Architecture emphasizes ports and adapters around the
+application boundary.
+
+In practice, modern .NET systems often blend the two.
+
+## Do Not Create a Port for Every Class
+
+This is not:
+
+``` text
+Class
+Interface
+Class
+Interface
+Class
+Interface
+```
+
+Ports exist at meaningful boundaries.
+
+An internal price calculator may simply be:
+
+``` csharp
+public sealed class PriceCalculator
+{
+}
+```
+
+No adapter is required if there is no external boundary.
+
+## Adapter Granularity
+
+One vendor integration may contain several internal classes:
+
+``` text
+Payment Adapter
+  |- HttpClient
+  |- DTOs
+  |- Mapper
+  |- Authentication handler
+  |- Error translator
+```
+
+The application sees one meaningful port.
+
+Do not leak the adapter's internal structure into the core.
+
+## Observability at the Adapter Boundary
+
+Adapters are excellent places to measure:
+
+-   external latency;
+-   dependency errors;
+-   message handling duration;
+-   retry attempts;
+-   serialization failures.
+
+Trace context should cross adapter boundaries so a request can be
+followed through the system.
+
+## When It Helps
+
+Ports & Adapters is particularly useful when:
+
+-   several technologies can drive the same use cases;
+-   external systems change independently;
+-   business language must remain isolated from vendors;
+-   integration testing boundaries matter;
+-   the application has a meaningful core.
+
+## When It Hurts
+
+It becomes ceremony when every trivial framework interaction gets
+wrapped behind a custom abstraction.
+
+You do not need:
+
+``` text
+ILoggerAdapter
+IConfigurationAdapter
+IJsonSerializerPort
+```
+
+simply because they are framework types.
+
+Protect meaningful volatility and architectural boundaries.
+
+## How It Relates to Fowler
+
+Hexagonal architecture heavily reuses Volume I concepts:
+
+``` text
+Separated Interface -> Port
+Gateway             -> outbound adapter boundary
+Mapper              -> translation
+Service Layer       -> application-facing port
+DTO                 -> boundary data
+```
+
+The architecture style organizes those patterns around an inside/outside
+model.
+
+## Summary
+
+Hexagonal Architecture says the application should not be shaped around
+HTTP, SQL, queues, or vendors.
+
+Those are adapters.
+
+The core exposes and consumes intentional ports expressed in application
+language.
+
+That simple inversion becomes extremely valuable as a system accumulates
+more ways to enter and leave the application.

--- a/src/posts/2029-10-28-vertical-slice-architecture.md
+++ b/src/posts/2029-10-28-vertical-slice-architecture.md
@@ -1,0 +1,355 @@
+---
+author: Steve Kaschimer
+date: 2029-10-28
+image: /images/posts/2029-10-28-hero.webp
+image_alt: "Several vertical bars of different heights standing side by side, each containing its own distinct internal texture."
+image_prompt: "A dark-mode technical editorial illustration on a near-black background with electric teal, amber, and off-white accents. Composition centers on four vertical teal bars of varying heights standing side by side, each bar containing its own distinct small amber internal texture pattern rather than sharing one, implying independent feature slices instead of shared horizontal layers. Mood is independent and feature-oriented. Avoid: vendor logos, brand colors, circuit-board textures, gears, or generic clip art as the dominant motif."
+layout: post.njk
+site_title: Tech Notes
+summary: "Organize modern .NET applications around features and use cases instead of technical layers, while keeping shared domain and infrastructure boundaries deliberate."
+tags: ["dotnet", "architecture", "design-patterns", "software-design"]
+title: "Vertical Slice Architecture in Modern .NET"
+---
+
+Many .NET applications begin with folders like:
+
+``` text
+Controllers/
+Services/
+Repositories/
+Models/
+```
+
+That organization looks tidy.
+
+But implementing one feature often means editing every folder.
+
+Vertical Slice Architecture changes the primary unit of organization
+from **technical type** to **business capability or use case**.
+
+## Horizontal Organization
+
+Consider creating an order:
+
+``` text
+Controllers/
+  OrdersController.cs
+
+Services/
+  OrderService.cs
+
+Repositories/
+  OrderRepository.cs
+
+Dtos/
+  CreateOrderRequest.cs
+```
+
+The feature is physically scattered.
+
+As the application grows, each technical folder becomes a catalog of
+unrelated business concepts.
+
+## Vertical Organization
+
+Instead:
+
+``` text
+Features/
+  Orders/
+    Create/
+      Endpoint.cs
+      Command.cs
+      Handler.cs
+      Validator.cs
+      Response.cs
+
+    Cancel/
+      Endpoint.cs
+      Command.cs
+      Handler.cs
+```
+
+Everything primarily relevant to one use case lives together.
+
+## The Slice
+
+A slice often spans the whole application path:
+
+``` text
+HTTP
+ |
+CreateOrder Endpoint
+ |
+CreateOrder Handler
+ |
+Domain / EF Core
+ |
+Database
+```
+
+The slice owns the implementation necessary to satisfy the use case.
+
+That does not mean every slice must reinvent every shared concern.
+
+## A Minimal Slice
+
+``` csharp
+public static class CreateOrderEndpoint
+{
+    public static void Map(RouteGroupBuilder group)
+    {
+        group.MapPost(
+            "/",
+            async (
+                CreateOrderRequest request,
+                CreateOrderHandler handler,
+                CancellationToken ct) =>
+            {
+                var result =
+                    await handler.HandleAsync(
+                        request,
+                        ct);
+
+                return Results.Created(
+                    $"/orders/{result.Id}",
+                    result);
+            });
+    }
+}
+```
+
+Handler:
+
+``` csharp
+public sealed class CreateOrderHandler(
+    OrdersDbContext db)
+{
+    public async Task<CreateOrderResponse>
+        HandleAsync(
+            CreateOrderRequest request,
+            CancellationToken cancellationToken)
+    {
+        // Use-case implementation.
+    }
+}
+```
+
+This may be enough.
+
+No repository is mandatory.
+
+No mediator is mandatory.
+
+No separate application project is mandatory.
+
+## Vertical Slices and CQRS
+
+The two fit naturally because commands and queries are use cases.
+
+``` text
+Orders/
+  Create/       Command
+  Cancel/       Command
+  GetDetails/   Query
+  Search/       Query
+```
+
+A query can use a direct projection while a command uses a Domain Model.
+
+That freedom is one of the strongest benefits.
+
+## Different Slices Can Use Different Patterns
+
+Imagine:
+
+``` text
+GetOrderList
+    -> direct EF projection
+
+PlaceOrder
+    -> aggregate + repository
+
+ExportOrders
+    -> streaming query
+
+ImportOrders
+    -> batch pipeline
+```
+
+A traditional architecture often pressures every operation through the
+same generic service/repository structure.
+
+Vertical slices let the implementation match the problem.
+
+## Shared Domain Model
+
+Vertical Slice does not mean duplicating domain rules.
+
+If several order commands must preserve the same invariant, that
+behavior belongs in the Order aggregate or another shared domain
+concept.
+
+``` text
+Slices
+  |
+  +--> Order Aggregate
+  +--> Money
+  +--> Pricing Policy
+```
+
+Organize use cases vertically while sharing genuine domain concepts
+horizontally where appropriate.
+
+## Shared Infrastructure
+
+Likewise:
+
+``` text
+Database configuration
+Telemetry
+Authentication
+Messaging
+```
+
+remain cross-cutting infrastructure.
+
+Do not duplicate them per feature merely to preserve a folder aesthetic.
+
+## Feature Coupling
+
+The danger is replacing layered coupling with feature-to-feature
+coupling:
+
+``` text
+CreateOrderHandler
+   calls
+UpdateCustomerHandler
+   calls
+SendEmailHandler
+```
+
+Now slices form an implicit service graph.
+
+Prefer explicit domain/application capabilities or events when one
+feature must trigger another responsibility.
+
+## Vertical Slice vs. Clean Architecture
+
+They answer different questions.
+
+Clean Architecture asks:
+
+> Which direction may dependencies point?
+
+Vertical Slice asks:
+
+> What should be the primary unit of code organization?
+
+You can combine them:
+
+``` text
+Application/
+  Orders/
+    Create/
+    Cancel/
+  Customers/
+    Register/
+
+Domain/
+Infrastructure/
+Api/
+```
+
+Or use slices in a simpler single-project architecture.
+
+## Vertical Slice vs. Layered Architecture
+
+Layering groups code by technical responsibility.
+
+Slices group code by change affinity.
+
+If `CreateOrder` changes, we want most related code close together.
+
+That can reduce the "shotgun surgery" of modifying five technical layers
+for one feature.
+
+## Testing
+
+Slice-oriented tests can focus on behavior at the use-case boundary.
+
+For example:
+
+``` text
+Given inventory exists
+When CreateOrder executes
+Then order is persisted
+And response contains order id
+```
+
+Some teams test slices through the HTTP endpoint using an in-memory test
+host.
+
+Others test handlers directly.
+
+Choose the level that proves the behavior without excessive coupling to
+implementation.
+
+## When It Helps
+
+Vertical Slice Architecture works well when:
+
+-   the application has many independent use cases;
+-   feature teams own capabilities;
+-   reads and writes need different implementations;
+-   horizontal service classes are becoming large;
+-   changes routinely cross many technical folders.
+
+## When It Hurts
+
+It can hurt when:
+
+-   slices duplicate domain rules;
+-   every endpoint invents its own conventions;
+-   cross-cutting concerns are copied everywhere;
+-   feature isolation becomes an excuse for no shared model;
+-   tiny applications gain dozens of files per endpoint.
+
+A vertical slice can be three files.
+
+It does not need to be thirteen.
+
+## How It Relates to Fowler
+
+A slice may contain several Fowler patterns:
+
+``` text
+Endpoint
+  -> Page/Front Controller ideas
+
+Handler
+  -> Transaction Script or Service Layer
+
+Aggregate
+  -> Domain Model
+
+DbContext
+  -> Data Mapper / Unit of Work
+
+Response
+  -> DTO
+```
+
+Vertical Slice changes how those pieces are grouped.
+
+It does not erase them.
+
+## Summary
+
+Vertical Slice Architecture organizes software around the things users
+and the business actually ask the system to do.
+
+It gives each use case freedom to use the simplest appropriate
+implementation while keeping related code close together.
+
+The key is vertical **cohesion**, not maximum file count.

--- a/src/posts/2029-11-04-mediator.md
+++ b/src/posts/2029-11-04-mediator.md
@@ -1,0 +1,385 @@
+---
+author: Steve Kaschimer
+date: 2029-11-04
+image: /images/posts/2029-11-04-hero.webp
+image_alt: "A central hub node with several spokes radiating outward to smaller nodes, one spoke rendered bolder to imply active dispatch."
+image_prompt: "A dark-mode technical editorial illustration on a near-black background with electric teal, amber, and off-white accents. Composition centers on a single amber hub node at the frame's center with four thin teal spokes radiating outward to smaller nodes, one spoke rendered bolder than the rest, implying one request currently being dispatched through a shared coordination point. Mood is coordinated and momentary. Avoid: vendor logos, brand colors, circuit-board textures, gears, or generic clip art as the dominant motif."
+layout: post.njk
+site_title: Tech Notes
+summary: "Use mediator-style dispatch deliberately for command/query pipelines and cross-cutting behaviors, and recognize when direct method calls are the simpler .NET design."
+tags: ["dotnet", "architecture", "design-patterns", "software-design"]
+title: "Mediator in Modern .NET: Useful Boundary or Expensive Method Call?"
+---
+
+Mediator has become closely associated with modern .NET architecture.
+
+A typical application may contain:
+
+``` text
+Endpoint
+   |
+IMediator.Send(command)
+   |
+Handler
+```
+
+This can be useful.
+
+It can also turn a perfectly understandable method call into an
+invisible dispatch pipeline.
+
+The question is not whether Mediator is fashionable.
+
+The question is what problem the indirection solves.
+
+## The Basic Idea
+
+Instead of an endpoint knowing the concrete use case:
+
+``` csharp
+public static async Task<IResult> Create(
+    CreateOrderRequest request,
+    CreateOrderHandler handler,
+    CancellationToken cancellationToken)
+{
+    var result =
+        await handler.HandleAsync(
+            request,
+            cancellationToken);
+
+    return Results.Ok(result);
+}
+```
+
+it sends a message:
+
+``` csharp
+var result =
+    await mediator.Send(
+        new CreateOrderCommand(...),
+        cancellationToken);
+```
+
+The mediator finds the appropriate handler.
+
+## What We Gained
+
+The sender no longer knows the handler type.
+
+That enables centralized dispatch behavior such as:
+
+``` text
+Command
+  |
+Logging
+  |
+Validation
+  |
+Authorization
+  |
+Transaction
+  |
+Handler
+```
+
+The pipeline is often the real reason to use a mediator.
+
+## Commands and Queries
+
+Mediator fits naturally with message-oriented application APIs:
+
+``` csharp
+public sealed record CreateOrderCommand(
+    CustomerId CustomerId,
+    IReadOnlyList<OrderLineRequest> Lines);
+
+public sealed class CreateOrderHandler
+{
+    public Task<OrderId> HandleAsync(
+        CreateOrderCommand command,
+        CancellationToken cancellationToken)
+    {
+        // ...
+    }
+}
+```
+
+Likewise:
+
+``` csharp
+public sealed record GetOrderQuery(
+    OrderId OrderId);
+```
+
+The application surface becomes a collection of explicit requests.
+
+## You Do Not Need a Library to Use Mediator
+
+A small mediator abstraction is conceptually simple:
+
+``` csharp
+public interface ISender
+{
+    Task<TResponse> SendAsync<TResponse>(
+        IRequest<TResponse> request,
+        CancellationToken cancellationToken);
+}
+```
+
+Libraries can provide polished dispatch and pipeline infrastructure.
+
+But the architecture should not depend on a library's vocabulary more
+than necessary.
+
+Understand the pattern before choosing the implementation.
+
+## Pipeline Behaviors
+
+Suppose every command requires validation.
+
+A pipeline can apply it consistently:
+
+``` text
+Request
+  |
+ValidationBehavior
+  |
+TracingBehavior
+  |
+TransactionBehavior
+  |
+Handler
+```
+
+This avoids repeating boilerplate in every handler.
+
+But hidden behavior has a cost.
+
+A developer reading:
+
+``` csharp
+await sender.SendAsync(command, ct);
+```
+
+cannot see from that line that a transaction, three validators,
+authorization, and retries might execute.
+
+Pipelines should remain intentional, observable, and limited.
+
+## Do Not Put Everything in the Pipeline
+
+Some concerns belong elsewhere.
+
+HTTP authentication belongs naturally in ASP.NET Core authentication.
+
+Endpoint authorization may belong in authorization policies.
+
+Remote HTTP resilience may belong in the HTTP client pipeline.
+
+Database behavior may belong in EF Core interceptors.
+
+Mediator middleware is not the universal home for cross-cutting
+concerns.
+
+## Notifications
+
+Mediator implementations often support publish/notification semantics:
+
+``` csharp
+await publisher.Publish(
+    new OrderPlaced(...),
+    cancellationToken);
+```
+
+Be careful with terminology.
+
+An in-process notification is not automatically a durable integration
+event.
+
+``` text
+In-process mediator notification
+!=
+message broker
+!=
+reliable delivery
+```
+
+If the process crashes, an in-memory notification is gone.
+
+Later in this volume we will separate Domain Events, Integration Events,
+Publish/Subscribe, and Outbox precisely.
+
+## Direct Calls Are Good
+
+This:
+
+``` csharp
+await createOrder.HandleAsync(request, ct);
+```
+
+has significant virtues:
+
+-   obvious control flow;
+-   easy navigation;
+-   no runtime handler lookup;
+-   dependencies remain visible;
+-   fewer abstractions.
+
+If you do not need dispatch indirection or a shared pipeline, direct
+calls may be better.
+
+## The "MediatR Architecture" Trap
+
+A mediator library is not an architecture.
+
+This:
+
+``` text
+Controllers -> Mediator -> Handlers
+```
+
+does not tell us:
+
+-   whether domain logic is rich or anemic;
+-   whether persistence is isolated;
+-   whether commands and queries are separated;
+-   whether module boundaries exist;
+-   whether external integrations are reliable.
+
+Mediator is one mechanism inside a larger design.
+
+## Handler Explosion
+
+A large system may have hundreds of handlers.
+
+That can be fine if each maps to a meaningful use case.
+
+It becomes problematic when trivial operations are fragmented into tiny
+messages merely to satisfy a convention.
+
+Ask whether the handler gives the operation a useful boundary.
+
+## Transactions
+
+A command pipeline can wrap handlers in a transaction.
+
+Conceptually:
+
+``` text
+Begin transaction
+     |
+Execute handler
+     |
+Save changes
+     |
+Commit
+```
+
+That can be elegant when all commands share the same transactional
+model.
+
+It is less appropriate when handlers have different transaction
+semantics or interact with external systems that cannot participate in
+the transaction.
+
+Do not let pipeline convenience obscure transaction boundaries.
+
+## Validation
+
+Validation pipelines are similarly useful for request-shape rules.
+
+But domain invariants must remain protected by the domain itself.
+
+A validator saying:
+
+``` text
+Quantity > 0
+```
+
+does not justify allowing:
+
+``` csharp
+order.AddItem(quantity: -5);
+```
+
+inside the domain.
+
+Boundary validation and domain invariants have different jobs.
+
+## Observability
+
+If a mediator is the application dispatch boundary, instrument it.
+
+Useful telemetry includes:
+
+-   request type;
+-   duration;
+-   failure count;
+-   validation failure count;
+-   trace correlation.
+
+Avoid logging entire request objects indiscriminately; they may contain
+sensitive data.
+
+## Testing
+
+A handler can usually be tested directly:
+
+``` csharp
+var handler =
+    new CreateOrderHandler(...);
+
+var result =
+    await handler.HandleAsync(command, ct);
+```
+
+Pipeline behavior should have its own tests.
+
+Do not force every unit test through the mediator unless dispatch itself
+is what the test needs to prove.
+
+## When It Helps
+
+Mediator is useful when:
+
+-   the application has many request handlers;
+-   dispatch decoupling is valuable;
+-   consistent application-level pipelines are useful;
+-   commands and queries form a meaningful application API.
+
+## When It Hurts
+
+It hurts when:
+
+-   every method call becomes a message;
+-   control flow becomes difficult to follow;
+-   pipeline behavior becomes magical;
+-   the library dictates architecture;
+-   direct injection would be clearer.
+
+## How It Relates to Fowler
+
+Mediator frequently sits in front of patterns from Volume I:
+
+``` text
+Mediator
+   |
+Handler -> Transaction Script / Service Layer
+   |
+Domain Model
+   |
+Repository / Unit of Work
+```
+
+It changes dispatch, not the fundamental responsibility of those
+patterns.
+
+## Summary
+
+Mediator is valuable when application requests benefit from decoupled
+dispatch and a consistent pipeline.
+
+It is unnecessary when all you need is a method call.
+
+Use it because the indirection buys something measurable - not because a
+modern .NET architecture diagram seems incomplete without `Send()`.

--- a/src/posts/2029-11-11-entity-ddd.md
+++ b/src/posts/2029-11-11-entity-ddd.md
@@ -1,0 +1,298 @@
+---
+author: Steve Kaschimer
+date: 2029-11-11
+image: /images/posts/2029-11-11-hero.webp
+image_alt: "A circle with a small persistent identity tag attached, and a faint trail of past positions behind it."
+image_prompt: "A dark-mode technical editorial illustration on a near-black background with electric teal, amber, and off-white accents. Composition centers on one solid teal circle with a small amber identity-tag glyph attached to its edge, trailed by two faint fading outline copies of the same circle behind it, implying one continuous identity persisting while its state changes over time. Mood is continuous and persistent. Avoid: vendor logos, brand colors, circuit-board textures, gears, or generic clip art as the dominant motif."
+layout: post.njk
+site_title: Tech Notes
+summary: "Model domain concepts whose identity and continuity matter more than their current attribute values, while protecting invariants with ordinary modern C#."
+tags: ["dotnet", "architecture", "design-patterns", "domain-driven-design"]
+title: "Entity in Domain-Driven Design"
+---
+
+An Entity is a domain object defined primarily by **identity and
+continuity**, not by the values of all its properties.
+
+Two customers can have the same name.
+
+They are still different customers.
+
+One customer can change their name.
+
+They are still the same customer.
+
+That distinction is the heart of Entity.
+
+## Identity Before Data
+
+A tempting model is:
+
+``` csharp
+public sealed record Customer(
+    Guid Id,
+    string Name,
+    string Email);
+```
+
+Records provide value-based equality.
+
+That can be exactly wrong for an entity.
+
+If two independently created customers happen to contain the same
+values, they do not become the same customer.
+
+Entity equality is usually about identity.
+
+## Strongly Typed Identity
+
+Modern C# makes identity types inexpensive:
+
+``` csharp
+public readonly record struct CustomerId(Guid Value)
+{
+    public static CustomerId New()
+        => new(Guid.NewGuid());
+}
+```
+
+Then:
+
+``` csharp
+public sealed class Customer
+{
+    public CustomerId Id { get; private set; }
+
+    public string Name { get; private set; }
+
+    private Customer()
+    {
+    }
+
+    private Customer(
+        CustomerId id,
+        string name)
+    {
+        Id = id;
+        Rename(name);
+    }
+
+    public static Customer Register(string name)
+        => new(CustomerId.New(), name);
+
+    public void Rename(string name)
+    {
+        if (string.IsNullOrWhiteSpace(name))
+            throw new DomainException(
+                "Customer name is required.");
+
+        Name = name.Trim();
+    }
+}
+```
+
+The entity owns the state transition.
+
+## An Entity Is Not a Database Row
+
+This distinction matters.
+
+A database table may contain:
+
+``` text
+Customers
+---------
+Id
+Name
+Email
+CreatedAt
+```
+
+That does not mean the domain needs a `Customer` entity.
+
+If the application simply edits rows with no meaningful identity-driven
+behavior, a CRUD model may be enough.
+
+DDD entities earn their cost when identity, lifecycle, and business
+rules matter.
+
+## Protect Valid State
+
+Avoid public setters:
+
+``` csharp
+customer.CreditLimit = -1_000_000;
+customer.Status = CustomerStatus.Platinum;
+```
+
+Prefer behavior:
+
+``` csharp
+customer.ChangeCreditLimit(newLimit);
+customer.QualifyForPreferredStatus();
+```
+
+Methods should express domain language and preserve invariants.
+
+## Identity Across Time
+
+An entity's attributes change:
+
+``` text
+Customer #42
+
+2024 -> Steven, old@example.com
+2026 -> Steven, new@example.com
+```
+
+The entity remains Customer #42.
+
+That continuity is what makes identity significant.
+
+## Entity vs. Value Object
+
+Compare:
+
+``` text
+Customer
+  identity matters
+
+ShippingAddress
+  values usually matter
+```
+
+If a customer changes address, the old address value can be replaced by
+a new value.
+
+If the customer changes email, we normally do not replace the customer
+with another customer.
+
+## Equality
+
+If domain entities need equality semantics, base them on stable
+identity.
+
+Do not blindly implement equality across every property.
+
+Also be careful with newly constructed entities whose database-generated
+identity does not yet exist.
+
+Strongly typed IDs created by the domain can simplify this considerably.
+
+## Persistence
+
+EF Core can map encapsulated entities.
+
+Persistence requirements should not force the domain into:
+
+``` csharp
+public string Name { get; set; }
+```
+
+everywhere.
+
+Private setters, backing fields, owned/complex values, and explicit
+configuration allow a domain model to remain behavior-oriented.
+
+## Do Not Put Infrastructure in the Entity
+
+This is a warning sign:
+
+``` csharp
+public async Task SaveAsync()
+{
+    await _dbContext.SaveChangesAsync();
+}
+```
+
+The entity should model the domain.
+
+Persistence, HTTP calls, logging, and message-broker APIs belong outside
+it.
+
+## Lifecycle
+
+Entities often have meaningful lifecycle transitions:
+
+``` text
+Draft
+  |
+Submit
+  |
+Approved
+  |
+Fulfilled
+```
+
+Model those transitions rather than exposing arbitrary status
+assignment.
+
+``` csharp
+public void Submit()
+{
+    if (Status != OrderStatus.Draft)
+        throw new DomainException(
+            "Only draft orders can be submitted.");
+
+    Status = OrderStatus.Submitted;
+}
+```
+
+The method explains why the state can change.
+
+## Testing
+
+Entity tests should focus on business behavior:
+
+``` csharp
+[Fact]
+public void Draft_order_can_be_submitted()
+{
+    var order = Order.Create(...);
+
+    order.Submit();
+
+    Assert.Equal(
+        OrderStatus.Submitted,
+        order.Status);
+}
+```
+
+Also test prohibited transitions.
+
+The important tests prove invariants, not getters and setters.
+
+## When It Helps
+
+Use an Entity when:
+
+-   identity matters across time;
+-   lifecycle matters;
+-   behavior belongs with the state;
+-   invariants must survive every mutation.
+
+## When It Hurts
+
+Do not turn every table into a DDD Entity.
+
+If the application is straightforward data maintenance, a simpler
+persistence or DTO model may communicate the design better.
+
+## How It Relates to Fowler
+
+Volume I's Domain Model established the broader pattern.
+
+DDD's Entity gives us one of the fundamental building blocks inside that
+model.
+
+The next article introduces the boundary that makes entities especially
+useful: the Aggregate.
+
+## Summary
+
+An Entity is not "a class with an ID."
+
+It is a domain concept whose identity persists while its state changes.
+
+Modern C# lets us model that identity explicitly while keeping behavior
+and invariants where they belong: inside the domain.

--- a/src/posts/2029-11-18-aggregate-aggregate-root.md
+++ b/src/posts/2029-11-18-aggregate-aggregate-root.md
@@ -1,0 +1,425 @@
+---
+author: Steve Kaschimer
+date: 2029-11-18
+image: /images/posts/2029-11-18-hero.webp
+image_alt: "One bold outer boundary circle enclosing several smaller shapes, with a single distinct root shape at the center controlling them."
+image_prompt: "A dark-mode technical editorial illustration on a near-black background with electric teal, amber, and off-white accents. Composition centers on one bold teal boundary circle enclosing three small amber shapes clustered inside it, with one distinct off-white root shape positioned at the exact center connected to each of the others, implying a single controlled entry point into a protected consistency boundary. Mood is guarded and singular. Avoid: vendor logos, brand colors, circuit-board textures, gears, or generic clip art as the dominant motif."
+layout: post.njk
+site_title: Tech Notes
+summary: "Design DDD aggregates around transactional consistency and business invariants instead of object graphs or database relationships."
+tags: ["dotnet", "architecture", "design-patterns", "domain-driven-design"]
+title: "Aggregate and Aggregate Root: The Consistency Boundary"
+---
+
+Aggregate is one of the most important - and most frequently
+misunderstood - patterns in Domain-Driven Design.
+
+An aggregate is not:
+
+> a parent object with some child collections.
+
+The useful definition is:
+
+> **A boundary around state that must remain consistent together.**
+
+The Aggregate Root controls that boundary.
+
+## Start With the Invariant
+
+Suppose an order has a maximum of 100 units.
+
+``` text
+Order
+  |
+  +-- OrderItem
+  +-- OrderItem
+```
+
+If callers can independently change each item:
+
+``` csharp
+item.Quantity = 500;
+```
+
+the Order cannot guarantee its invariant.
+
+Instead:
+
+``` csharp
+order.ChangeQuantity(
+    productId,
+    quantity);
+```
+
+The root controls the mutation.
+
+## A Modern C# Aggregate
+
+``` csharp
+public sealed class Order
+{
+    private readonly List<OrderItem> _items = [];
+
+    public OrderId Id { get; private set; }
+
+    public OrderStatus Status { get; private set; }
+
+    public IReadOnlyCollection<OrderItem> Items
+        => _items.AsReadOnly();
+
+    private Order()
+    {
+    }
+
+    public static Order Create(OrderId id)
+        => new()
+        {
+            Id = id,
+            Status = OrderStatus.Draft
+        };
+
+    public void AddItem(
+        ProductId productId,
+        Money unitPrice,
+        int quantity)
+    {
+        if (Status != OrderStatus.Draft)
+            throw new DomainException(
+                "Items can only be changed while draft.");
+
+        if (quantity <= 0)
+            throw new DomainException(
+                "Quantity must be positive.");
+
+        var totalQuantity =
+            _items.Sum(x => x.Quantity) + quantity;
+
+        if (totalQuantity > 100)
+            throw new DomainException(
+                "An order cannot exceed 100 units.");
+
+        _items.Add(
+            new OrderItem(
+                productId,
+                unitPrice,
+                quantity));
+    }
+}
+```
+
+The collection is not directly mutable from outside.
+
+The root is the consistency guardian.
+
+## Aggregate Root
+
+Every aggregate has one root entity.
+
+External code references the aggregate through that root.
+
+Conceptually:
+
+``` text
+Application
+    |
+    v
+  Order        <- Aggregate Root
+  /   \
+Item  Item     <- internal entities
+```
+
+Do not expose repositories for `OrderItem` if `OrderItem` belongs inside
+the Order aggregate.
+
+Doing so lets callers bypass the root.
+
+## Aggregate Is a Transaction Boundary
+
+This is the most useful heuristic.
+
+Ask:
+
+> Which state must be immediately consistent when this business
+> operation commits?
+
+That state is a candidate aggregate boundary.
+
+If an operation changes one aggregate:
+
+``` text
+Load Order
+Change Order
+Save Order
+COMMIT
+```
+
+we have a clear transaction.
+
+## Do Not Build Giant Aggregates
+
+Suppose Order contains:
+
+``` text
+Order
+ Customer
+ CustomerAddresses
+ PaymentMethods
+ Product
+ Inventory
+ Shipment
+```
+
+because those objects are "related."
+
+Now loading an Order may pull half the business into memory.
+
+Worse, unrelated operations contend on the same consistency boundary.
+
+Relationship does not imply aggregate membership.
+
+## Reference Other Aggregates by Identity
+
+If Customer is a separate aggregate:
+
+``` csharp
+public CustomerId CustomerId { get; private set; }
+```
+
+is often preferable to:
+
+``` csharp
+public Customer Customer { get; private set; }
+```
+
+inside the domain model.
+
+This makes the boundary visible.
+
+``` text
+Order Aggregate ---- CustomerId ----> Customer Aggregate
+```
+
+## One Transaction, One Aggregate?
+
+It is a strong design heuristic, not a law of physics.
+
+If a business invariant genuinely requires atomic consistency across two
+objects on every operation, ask whether they belong in one aggregate.
+
+But occasionally application transactions touch multiple aggregates.
+
+The important thing is to make the consistency requirement intentional
+rather than accidentally relying on a giant object graph.
+
+## Cross-Aggregate Behavior
+
+Suppose placing an order should update loyalty status.
+
+``` text
+Order Aggregate
+      |
+OrderPlaced
+      |
+      v
+Customer Aggregate
+```
+
+A Domain Event can coordinate that reaction.
+
+Whether the reaction occurs in the same transaction or eventually
+depends on the business consistency requirement.
+
+That is exactly why aggregate boundaries matter.
+
+## Concurrency
+
+Aggregates are also natural optimistic-concurrency boundaries.
+
+``` csharp
+public byte[] Version { get; private set; } = [];
+```
+
+EF Core can use a concurrency token.
+
+Two requests:
+
+``` text
+Request A loads Order v7
+Request B loads Order v7
+
+A commits -> v8
+B commits -> conflict
+```
+
+The application can decide whether to retry, merge, or reject.
+
+## Repositories
+
+A repository usually exists per aggregate root, not per database table.
+
+Good:
+
+``` csharp
+public interface IOrderRepository
+{
+    Task<Order?> GetAsync(
+        OrderId id,
+        CancellationToken cancellationToken);
+
+    void Add(Order order);
+}
+```
+
+Suspicious:
+
+``` text
+OrderRepository
+OrderItemRepository
+ShippingAddressRepository
+```
+
+if all three objects are one aggregate.
+
+## Persistence Mapping Is Secondary
+
+Do not derive aggregate boundaries from EF Core navigation properties.
+
+The domain says:
+
+``` text
+What must remain consistent?
+```
+
+Persistence asks:
+
+``` text
+How do we store that?
+```
+
+The second question should not answer the first.
+
+## Aggregate Size
+
+Smaller aggregates usually improve:
+
+-   concurrency;
+-   load size;
+-   transaction duration;
+-   ownership clarity.
+
+But making them too small pushes invariants across boundaries and may
+require excessive coordination.
+
+The correct size is determined by consistency rules.
+
+## A Design Exercise
+
+Suppose an e-commerce system contains:
+
+``` text
+Customer
+Order
+Inventory
+Payment
+Shipment
+```
+
+Ask of every relationship:
+
+> Must these objects be atomically consistent for the business to remain
+> valid?
+
+If no, they probably do not belong in the same aggregate.
+
+This question is more useful than drawing class diagrams first.
+
+## Aggregate Factories
+
+Complex creation may belong in a named factory method:
+
+``` csharp
+var order = Order.Place(
+    customerId,
+    items,
+    pricingPolicy);
+```
+
+The aggregate should never begin life in an invalid state.
+
+## Domain Events
+
+An aggregate can record facts that occurred:
+
+``` csharp
+AddDomainEvent(
+    new OrderPlaced(
+        Id,
+        CustomerId,
+        Total));
+```
+
+Recording the event is domain behavior.
+
+Dispatching it is normally an application/infrastructure concern.
+
+We will cover that distinction deeply in the Domain Event article.
+
+## Testing Aggregates
+
+Aggregate tests should be rich in business language.
+
+``` text
+Given a submitted order
+When an item is added
+Then the operation is rejected
+```
+
+Test invariants at the root.
+
+If a child entity can violate the aggregate without going through the
+root, the boundary is porous.
+
+## When It Helps
+
+Aggregates become valuable when:
+
+-   multiple state changes form one invariant;
+-   concurrency matters;
+-   business transitions need protection;
+-   a domain model has meaningful transactional boundaries.
+
+## When It Hurts
+
+Aggregate modeling hurts when teams:
+
+-   wrap every entity in an `AggregateRoot` base class;
+-   make aggregates enormous;
+-   mirror database foreign keys mechanically;
+-   load entire graphs for simple queries;
+-   require all reads to go through aggregates.
+
+Aggregates are primarily write-side consistency models.
+
+Queries can use projections.
+
+## How It Relates to Fowler
+
+Aggregate builds on Fowler's Domain Model, Repository, Unit of Work,
+Identity Field, and Optimistic Offline Lock.
+
+It adds an explicit answer to:
+
+> What is the unit of consistency?
+
+## Summary
+
+An Aggregate is a consistency boundary.
+
+The Aggregate Root is the only entry point for changes inside that
+boundary.
+
+Do not discover aggregates by looking at database relationships.
+
+Discover them by asking which invariants must survive a transaction.
+
+That single idea will shape almost everything that follows in Volume II.

--- a/src/posts/2029-11-25-domain-service.md
+++ b/src/posts/2029-11-25-domain-service.md
@@ -1,0 +1,261 @@
+---
+author: Steve Kaschimer
+date: 2029-11-25
+image: /images/posts/2029-11-25-hero.webp
+image_alt: "Two separate entity shapes connected only through a small intermediary node positioned between them."
+image_prompt: "A dark-mode technical editorial illustration on a near-black background with electric teal, amber, and off-white accents. Composition centers on two distinct teal entity shapes positioned apart, each connected by a thin line to one small amber intermediary node placed exactly between them, implying an operation that belongs to neither shape alone. Mood is mediating and precise. Avoid: vendor logos, brand colors, circuit-board textures, gears, or generic clip art as the dominant motif."
+layout: post.njk
+site_title: Tech Notes
+summary: "Model domain operations that require domain knowledge but do not naturally belong to one entity or value object, without turning services into an anemic-domain dumping ground."
+tags: ["dotnet", "architecture", "design-patterns", "domain-driven-design"]
+title: "Domain Service: Behavior That Doesn't Belong to an Entity"
+---
+
+Domain behavior should usually live with the state it governs.
+
+But sometimes an important business operation does not naturally belong
+to one Entity or Value Object.
+
+That is where a Domain Service can help.
+
+## The Smell That Comes First
+
+Suppose transferring money requires two accounts:
+
+``` text
+Source Account
+Destination Account
+Transfer Policy
+```
+
+Putting the whole operation on the source account feels wrong.
+
+Putting it on the destination feels equally wrong.
+
+The operation is meaningful to the domain but not naturally owned by
+either entity.
+
+## A Domain Service
+
+``` csharp
+public sealed class FundsTransferService
+{
+    public TransferResult Transfer(
+        Account source,
+        Account destination,
+        Money amount)
+    {
+        if (source.Currency != destination.Currency)
+            return TransferResult.Rejected(
+                "Currencies must match.");
+
+        source.Withdraw(amount);
+        destination.Deposit(amount);
+
+        return TransferResult.Success();
+    }
+}
+```
+
+The service contains domain logic.
+
+It works with domain objects.
+
+It does not know about HTTP, EF Core, logging, or message brokers.
+
+## Domain Service vs. Application Service
+
+This distinction matters.
+
+Application Service:
+
+``` text
+Load account
+Load destination
+Call domain behavior
+Save transaction
+Publish consequences
+```
+
+Domain Service:
+
+``` text
+Decide whether/how the transfer is valid
+```
+
+The application service orchestrates.
+
+The domain service models business meaning.
+
+## Do Not Move Entity Behavior Out
+
+This is an anemic design:
+
+``` csharp
+public sealed class OrderService
+{
+    public void Cancel(Order order)
+    {
+        if (order.Status == ...)
+            order.Status = ...;
+    }
+}
+```
+
+If cancellation depends only on Order's own state, it belongs on Order:
+
+``` csharp
+order.Cancel();
+```
+
+A Domain Service is not a place to put logic because methods on entities
+feel impure.
+
+## Stateless by Default
+
+Domain services are commonly stateless:
+
+``` csharp
+public sealed class PricingPolicy
+{
+    public Money Calculate(
+        CustomerSegment segment,
+        Cart cart)
+    {
+        // ...
+    }
+}
+```
+
+Dependencies can themselves be domain abstractions when necessary.
+
+But be cautious if the service starts needing:
+
+``` text
+DbContext
+HttpClient
+ILogger
+IMessageBus
+```
+
+You may have crossed into application or infrastructure concerns.
+
+## External Information
+
+Sometimes a domain decision needs external information.
+
+For example:
+
+``` text
+Can this currency conversion occur?
+```
+
+A domain abstraction might provide rates:
+
+``` csharp
+public interface IExchangeRateProvider
+{
+    ExchangeRate Get(
+        Currency from,
+        Currency to);
+}
+```
+
+But if retrieving that rate requires async HTTP and retry policies, a
+cleaner application flow may fetch the information first and pass a
+domain value into the domain service.
+
+Keep network behavior out of the model where practical.
+
+## Naming Matters
+
+Avoid generic names:
+
+``` text
+OrderDomainService
+CustomerDomainService
+```
+
+Prefer domain language:
+
+``` text
+PricingPolicy
+FundsTransferService
+EligibilityPolicy
+AllocationService
+```
+
+The name should tell a domain expert what the service does.
+
+## Policy Objects
+
+Many "domain services" are really policies.
+
+``` csharp
+public sealed class RefundEligibilityPolicy
+{
+    public bool CanRefund(
+        Order order,
+        DateTimeOffset now)
+    {
+        // ...
+    }
+}
+```
+
+That is useful because the business concept itself has a name.
+
+## Testing
+
+Domain service tests should need no application host.
+
+``` csharp
+var result = policy.CanRefund(
+    order,
+    now);
+
+Assert.True(result);
+```
+
+If every test needs a database and web server, the service probably
+contains more than domain logic.
+
+## When It Helps
+
+Use a Domain Service when:
+
+-   the operation is part of the ubiquitous language;
+-   it contains meaningful business rules;
+-   it involves several domain objects;
+-   no single entity/value object naturally owns it.
+
+## When It Hurts
+
+It hurts when it becomes:
+
+``` text
+OrderService
+  4,000 lines
+  all order behavior
+```
+
+That is often an anemic domain disguised as DDD.
+
+## How It Relates to Fowler
+
+Fowler's Service Layer organizes application operations.
+
+Domain Service operates **inside** the domain model.
+
+The names sound similar; their responsibilities are different.
+
+## Summary
+
+Start by putting behavior on the Entity or Value Object that owns it.
+
+When an important domain operation genuinely spans concepts and has no
+natural owner, give that operation a domain name and model it as a
+Domain Service.
+
+Do not use Domain Service as an escape hatch from object-oriented domain
+modeling.

--- a/src/posts/2029-12-02-domain-events.md
+++ b/src/posts/2029-12-02-domain-events.md
@@ -1,0 +1,363 @@
+---
+author: Steve Kaschimer
+date: 2029-12-02
+image: /images/posts/2029-12-02-hero.webp
+image_alt: "A small burst shape emanating outward from one entity toward several other separate shapes."
+image_prompt: "A dark-mode technical editorial illustration on a near-black background with electric teal, amber, and off-white accents. Composition centers on one solid teal entity shape with a small amber burst glyph radiating outward from its edge toward three separate off-white shapes positioned around it, implying a fact that occurred and rippled outward to interested observers. Mood is expressive and consequential. Avoid: vendor logos, brand colors, circuit-board textures, gears, or generic clip art as the dominant motif."
+layout: post.njk
+site_title: Tech Notes
+summary: "Model meaningful facts that have already happened inside a bounded context, defer their dispatch safely, and distinguish domain events from durable integration messages."
+tags: ["dotnet", "architecture", "design-patterns", "domain-driven-design"]
+title: "Domain Events: Making Business Consequences Explicit"
+---
+
+Something happened.
+
+The business cares.
+
+Other behavior should react.
+
+That is the natural territory of a Domain Event.
+
+``` csharp
+public sealed record OrderPlaced(
+    OrderId OrderId,
+    CustomerId CustomerId,
+    Money Total);
+```
+
+The tense matters.
+
+It is `OrderPlaced`, not `PlaceOrder`.
+
+An event is a fact.
+
+## The Hidden Side Effect Problem
+
+Imagine:
+
+``` csharp
+public async Task PlaceOrderAsync(...)
+{
+    // create order
+    // save order
+    // update loyalty
+    // create fulfillment work
+    // send internal notification
+    // update sales statistics
+}
+```
+
+One use case gradually becomes the place where every consequence is
+wired together.
+
+The business rule:
+
+> When an order is placed, update loyalty status.
+
+exists only as procedural glue.
+
+Domain Events make that relationship explicit.
+
+## Raise the Fact in the Domain
+
+The aggregate knows what happened:
+
+``` csharp
+public void Place()
+{
+    if (Status != OrderStatus.Draft)
+        throw new DomainException(...);
+
+    Status = OrderStatus.Placed;
+
+    AddDomainEvent(
+        new OrderPlaced(
+            Id,
+            CustomerId,
+            Total));
+}
+```
+
+The aggregate records the fact.
+
+It does not need to know every reaction.
+
+## Deferred Dispatch
+
+Avoid immediately invoking arbitrary handlers from inside the aggregate.
+
+Instead, collect events:
+
+``` csharp
+private readonly List<IDomainEvent>
+    _domainEvents = [];
+
+public IReadOnlyCollection<IDomainEvent>
+    DomainEvents => _domainEvents;
+
+protected void AddDomainEvent(
+    IDomainEvent domainEvent)
+    => _domainEvents.Add(domainEvent);
+```
+
+The application can dispatch them around the Unit of Work boundary.
+
+This keeps domain behavior testable and makes transaction semantics
+explicit.
+
+## Before or After Commit?
+
+This is a real architectural decision.
+
+### Dispatch before commit
+
+``` text
+Change aggregate
+Raise event
+Handle event
+Save everything
+Commit
+```
+
+Handlers can participate in the same transaction.
+
+Failure can roll back the whole operation.
+
+But the transaction may grow and handlers become part of the command's
+consistency boundary.
+
+### Dispatch after commit
+
+``` text
+Change aggregate
+Save
+Commit
+Dispatch event
+```
+
+The original aggregate is committed first.
+
+Now handler failure cannot roll back the original change.
+
+That may require eventual consistency or durable messaging.
+
+Neither option is universally correct.
+
+The business consistency requirement decides.
+
+## Domain Event vs. Integration Event
+
+This distinction is critical.
+
+``` text
+DOMAIN EVENT
+OrderPlaced
+   |
+same bounded context
+usually in-process
+   |
+loyalty / policy / local reaction
+```
+
+versus:
+
+``` text
+INTEGRATION EVENT
+OrderPlacedIntegrationEvent
+   |
+durable broker
+crosses process/bounded-context boundary
+   |
+Fulfillment Service
+Analytics Service
+```
+
+A domain event is not automatically a message on a broker.
+
+## Why Not Publish the Domain Event Directly?
+
+Because internal domain representation and external contracts have
+different reasons to change.
+
+A handler can translate:
+
+``` text
+Domain Event
+    |
+    v
+Integration Event
+```
+
+The integration contract can be versioned and stabilized independently.
+
+Later, Transactional Outbox will make that publication reliable.
+
+## Events Should Carry Useful Facts
+
+Avoid events that merely expose implementation mechanics:
+
+``` text
+OrderRowInserted
+OrderEntityModified
+```
+
+Prefer domain language:
+
+``` text
+OrderPlaced
+PaymentAuthorized
+ShipmentDispatched
+CustomerQualifiedForPreferredStatus
+```
+
+A domain expert should recognize the occurrence.
+
+## Events Are Immutable Facts
+
+Records are a natural representation:
+
+``` csharp
+public sealed record PaymentAuthorized(
+    PaymentId PaymentId,
+    OrderId OrderId,
+    Money Amount,
+    DateTimeOffset OccurredAt)
+    : IDomainEvent;
+```
+
+Once something happened, the historical fact should not be mutated.
+
+## Handler Responsibilities
+
+A handler may coordinate a reaction:
+
+``` csharp
+public sealed class UpdateLoyaltyWhenOrderPlaced(
+    ICustomerRepository customers)
+{
+    public async Task HandleAsync(
+        OrderPlaced domainEvent,
+        CancellationToken cancellationToken)
+    {
+        // Load customer aggregate and apply rule.
+    }
+}
+```
+
+Handlers belong naturally in the application layer when they need
+repositories or infrastructure abstractions.
+
+## Avoid Event Spaghetti
+
+Domain Events introduce indirection.
+
+If:
+
+``` text
+A -> event -> B
+B -> event -> C
+C -> event -> D
+```
+
+understanding one command may require exploring a hidden graph.
+
+Use events when decoupled reactions are genuinely valuable.
+
+Use direct calls when the behavior is one obvious synchronous operation.
+
+## Failure Semantics
+
+An in-process event dispatcher is not durable.
+
+If the process crashes after commit but before dispatch:
+
+``` text
+Database commit ✓
+Domain event handling ✗
+```
+
+the reaction may be lost.
+
+If that reaction must survive crashes, we need a durable mechanism.
+
+That is where Integration Events + Transactional Outbox enter the story.
+
+## Domain Events and Aggregates
+
+Events are especially useful across aggregate boundaries.
+
+Inside one aggregate, direct method calls normally keep behavior
+clearer.
+
+Across aggregates, events can express:
+
+> this fact occurred; interested domain/application behavior may react.
+
+## Testing the Aggregate
+
+A domain test can assert both state and fact:
+
+``` csharp
+order.Place();
+
+Assert.Equal(
+    OrderStatus.Placed,
+    order.Status);
+
+Assert.Contains(
+    order.DomainEvents,
+    x => x is OrderPlaced);
+```
+
+Handler tests then verify reactions separately.
+
+## Observability
+
+Do not confuse domain events with telemetry events.
+
+A domain event represents business meaning.
+
+A trace span or log entry represents operational observation.
+
+You may instrument domain-event dispatch, but the concepts should remain
+distinct.
+
+## When It Helps
+
+Domain Events help when:
+
+-   one domain occurrence has multiple reactions;
+-   cross-aggregate consequences need explicit modeling;
+-   you want business side effects to be discoverable;
+-   the number of reactions may evolve independently.
+
+## When It Hurts
+
+Avoid them when:
+
+-   one method call communicates the workflow better;
+-   events are used to hide ordinary control flow;
+-   teams assume in-memory dispatch is durable;
+-   every property change becomes an event.
+
+## How It Relates to Fowler
+
+Domain Events build naturally on Domain Model, Unit of Work, Service
+Layer, and Observer-style ideas.
+
+They become the bridge from our object-oriented architecture into the
+messaging patterns later in Volume II.
+
+## Summary
+
+A Domain Event is a meaningful fact that has already happened inside the
+domain.
+
+The aggregate records the fact.
+
+Application handlers coordinate reactions.
+
+And when that fact must cross a process boundary reliably, we will
+deliberately transform it into a durable integration message rather than
+pretending an in-process event dispatcher is a message broker.

--- a/src/posts/2029-12-09-specification.md
+++ b/src/posts/2029-12-09-specification.md
@@ -1,0 +1,273 @@
+---
+author: Steve Kaschimer
+date: 2029-12-09
+image: /images/posts/2029-12-09-hero.webp
+image_alt: "A checkmark inside a small named tag shape, overlaid on a filtered subset highlighted within a larger set."
+image_prompt: "A dark-mode technical editorial illustration on a near-black background with electric teal, amber, and off-white accents. Composition centers on a small amber tag glyph containing a teal checkmark, positioned above a loose cluster of shapes where only a filtered subset is highlighted solid and the rest remain faint outlines, implying a named predicate selecting exactly the members that satisfy it. Mood is selective and named. Avoid: vendor logos, brand colors, circuit-board textures, gears, or generic clip art as the dominant motif."
+layout: post.njk
+site_title: Tech Notes
+summary: "Encapsulate reusable business predicates and composable selection rules without turning every LINQ expression into an abstraction or coupling the domain to persistence mechanics."
+tags: ["dotnet", "architecture", "design-patterns", "domain-driven-design"]
+title: "Specification: Giving Business Predicates a Name"
+---
+
+Business rules often begin as conditionals.
+
+``` csharp
+if (customer.IsActive &&
+    customer.TotalSpend >= 10_000m &&
+    !customer.IsDelinquent)
+{
+    // ...
+}
+```
+
+Then the same rule appears elsewhere.
+
+Specification gives that rule a name.
+
+## A Domain Specification
+
+``` csharp
+public sealed class PreferredCustomerSpecification
+{
+    public bool IsSatisfiedBy(Customer customer)
+        => customer.IsActive
+           && customer.TotalSpend >= Money.Usd(10_000)
+           && !customer.IsDelinquent;
+}
+```
+
+Now code can say:
+
+``` csharp
+if (preferredCustomers.IsSatisfiedBy(customer))
+{
+}
+```
+
+The business concept is explicit.
+
+## The Value Is the Language
+
+Specification is most useful when the predicate itself is meaningful:
+
+``` text
+CustomerIsEligibleForRefund
+OrderRequiresManualReview
+ShipmentCanBeExpedited
+```
+
+A specification named:
+
+``` text
+CustomerNameStartsWithS
+```
+
+may simply be a LINQ predicate wearing formal clothing.
+
+## Composing Specifications
+
+Specifications are often composable:
+
+``` text
+PreferredCustomer
+AND
+AccountInGoodStanding
+AND NOT
+RestrictedRegion
+```
+
+That can be modeled with combinators.
+
+But composition machinery can quickly become more complicated than the
+business rule.
+
+Start simple.
+
+## In-Memory vs. Queryable Specifications
+
+There are two different problems hiding behind the same name.
+
+### Domain predicate
+
+``` csharp
+bool IsSatisfiedBy(Customer customer)
+```
+
+evaluates an existing domain object.
+
+### Query specification
+
+``` csharp
+Expression<Func<Customer, bool>>
+```
+
+can potentially be translated by EF Core into SQL.
+
+These are related but not identical responsibilities.
+
+## Query Specification Example
+
+``` csharp
+public sealed class ActiveCustomers
+{
+    public Expression<Func<Customer, bool>>
+        ToExpression()
+        => customer => customer.IsActive;
+}
+```
+
+Then:
+
+``` csharp
+var customers = await db.Customers
+    .Where(spec.ToExpression())
+    .ToListAsync(cancellationToken);
+```
+
+This can reduce duplicated query rules.
+
+But it also means the specification knows about expression trees and
+query-provider constraints.
+
+That may be acceptable in an application/query layer and undesirable in
+a pure domain layer.
+
+## The Translation Trap
+
+A perfectly valid C# method:
+
+``` csharp
+customer.IsPreferred()
+```
+
+may not translate into SQL.
+
+Trying to make every domain specification both:
+
+``` text
+rich domain behavior
+and
+database-translatable expression
+```
+
+can distort the model.
+
+Do not force one abstraction to satisfy incompatible concerns.
+
+## Specification and CQRS
+
+CQRS gives us an elegant escape hatch.
+
+Command-side specifications can operate on aggregates.
+
+Query-side filters can use efficient SQL-oriented expressions.
+
+They do not have to be the same object.
+
+``` text
+Write Model
+  -> domain specification
+
+Read Model
+  -> query filter/projection
+```
+
+## Specification vs. Validation
+
+Validation asks whether input/state is valid.
+
+Specification often asks whether an object satisfies a business
+criterion.
+
+``` text
+Email syntax valid?
+    -> validation
+
+Customer eligible for premium shipping?
+    -> specification/policy
+```
+
+The boundary can overlap, but the intent differs.
+
+## Specification vs. Policy
+
+The names are often close.
+
+A Policy may decide or calculate behavior.
+
+A Specification traditionally answers whether something satisfies a
+criterion.
+
+``` csharp
+bool IsSatisfiedBy(T candidate)
+```
+
+Do not become doctrinaire about terminology. Prefer the domain's
+language.
+
+## Repository Specifications
+
+Some architectures expose:
+
+``` csharp
+Task<IReadOnlyList<T>> ListAsync(
+    ISpecification<T> specification);
+```
+
+This can centralize filtering, includes, ordering, and pagination.
+
+It can also turn the repository into a custom LINQ provider.
+
+Evaluate whether the abstraction is buying clarity or hiding EF Core
+behind a less capable API.
+
+## Testing
+
+Specifications should have table-driven examples:
+
+``` text
+active + high spend + good standing -> true
+inactive                         -> false
+delinquent                       -> false
+low spend                        -> false
+```
+
+Tests become executable examples of the business term.
+
+## When It Helps
+
+Specification is valuable when:
+
+-   a business predicate has a meaningful name;
+-   the rule is reused;
+-   rules compose;
+-   the concept belongs in the ubiquitous language.
+
+## When It Hurts
+
+It hurts when:
+
+-   every `Where` clause becomes a class;
+-   generic infrastructure overwhelms simple predicates;
+-   domain code is distorted to satisfy SQL translation;
+-   repository abstractions become query languages.
+
+## How It Relates to Fowler
+
+Specification complements Domain Model, Query Object, Repository, and
+Value Object.
+
+It gives recurring selection/business criteria first-class
+representation.
+
+## Summary
+
+Specification is powerful because it turns a recurring business question
+into an explicit concept.
+
+Use it for predicates worth naming.
+
+Do not create a class hierarchy merely to avoid writing a readable LINQ
+expression.

--- a/src/posts/2029-12-16-anti-corruption-layer.md
+++ b/src/posts/2029-12-16-anti-corruption-layer.md
@@ -1,0 +1,379 @@
+---
+author: Steve Kaschimer
+date: 2029-12-16
+image: /images/posts/2029-12-16-hero.webp
+image_alt: "A wall glyph at a boundary line, translating an angular foreign shape on one side into a clean native shape on the other."
+image_prompt: "A dark-mode technical editorial illustration on a near-black background with electric teal, amber, and off-white accents. Composition centers on a single amber wall glyph positioned on a vertical off-white boundary line, with a jagged angular teal shape approaching from the left and a clean, simple teal shape emerging on the right, implying foreign vocabulary translated before it reaches the protected side. Mood is protective and translating. Avoid: vendor logos, brand colors, circuit-board textures, gears, or generic clip art as the dominant motif."
+layout: post.njk
+site_title: Tech Notes
+summary: "Protect a modern .NET domain from legacy systems, vendor APIs, and foreign bounded contexts by translating protocols, data, errors, and semantics at an explicit boundary."
+tags: ["dotnet", "architecture", "design-patterns", "domain-driven-design"]
+title: "Anti-Corruption Layer: Protecting Your Domain From Someone Else's Model"
+---
+
+Every integration tries to teach your application somebody else's
+language.
+
+A legacy ERP calls customers `ACCOUNT_MASTER`.
+
+A payment provider calls authorization a `PaymentIntent`.
+
+A shipping vendor has seven status codes that do not match your
+fulfillment lifecycle.
+
+If those concepts leak everywhere, the external model begins designing
+your application.
+
+An Anti-Corruption Layer stops that spread.
+
+## The Problem
+
+Without a translation boundary:
+
+``` csharp
+public sealed class Order
+{
+    public string SapCustomerNumber { get; set; }
+
+    public VendorPaymentIntentStatus
+        PaymentStatus { get; set; }
+
+    public LegacyFulfillmentCode
+        FulfillmentCode { get; set; }
+}
+```
+
+The domain now speaks three foreign languages.
+
+Vendor changes become domain changes.
+
+## Put Translation at the Boundary
+
+``` text
+Our Domain
+    |
+    v
+Anti-Corruption Layer
+    |
+    +-- Gateway
+    +-- Translator
+    +-- DTOs
+    +-- Error mapping
+    |
+    v
+External System
+```
+
+Inside:
+
+``` csharp
+public interface ICreditService
+{
+    Task<CreditDecision> EvaluateAsync(
+        Customer customer,
+        CancellationToken cancellationToken);
+}
+```
+
+The domain/application asks for a **credit decision**.
+
+It does not ask for `LegacyRiskResponseV4`.
+
+## External DTO
+
+The adapter may receive:
+
+``` csharp
+internal sealed record LegacyRiskResponse(
+    string RiskCode,
+    decimal ApprovedExposure,
+    string AccountState);
+```
+
+That type stays inside the integration boundary.
+
+Translate it:
+
+``` csharp
+private static CreditDecision Translate(
+    LegacyRiskResponse response)
+    => response.RiskCode switch
+    {
+        "A1" => CreditDecision.Approved(
+            Money.Usd(response.ApprovedExposure)),
+
+        "D7" => CreditDecision.Declined(
+            CreditDeclineReason.HighRisk),
+
+        _ => CreditDecision.Unknown()
+    };
+```
+
+The ugly vocabulary stops there.
+
+## Semantic Translation
+
+An ACL is more than object mapping.
+
+Suppose the external system says:
+
+``` text
+Status = 4
+```
+
+and its documentation means:
+
+> payment accepted but subject to asynchronous fraud reversal for 24
+> hours.
+
+Mapping `4` to:
+
+``` csharp
+PaymentStatus.Paid
+```
+
+may be semantically wrong.
+
+The ACL must translate **meaning**, not just fields.
+
+## Error Translation
+
+External errors should also be translated.
+
+Vendor:
+
+``` text
+HTTP 409
+code = ACCOUNT_FROZEN_X17
+```
+
+Our application:
+
+``` csharp
+CreditDecision.Unavailable(
+    CreditUnavailableReason.AccountRestricted)
+```
+
+or an intentional application error.
+
+Do not make every caller understand vendor error catalogs.
+
+## Protocol Translation
+
+The boundary can translate more than models:
+
+``` text
+Our application
+    |
+HTTP/JSON adapter
+    |
+SOAP/XML legacy system
+```
+
+or:
+
+``` text
+Domain event
+    |
+ACL
+    |
+vendor-specific message
+```
+
+The goal is semantic isolation.
+
+## ACL vs. Gateway
+
+A Gateway provides a clean entry point to an external capability.
+
+An Anti-Corruption Layer is broader.
+
+It may contain:
+
+-   one or more Gateways;
+-   Mappers;
+-   DTOs;
+-   protocol adapters;
+-   error translation;
+-   semantic normalization.
+
+A simple vendor integration may need only a Gateway.
+
+Use the ACL framing when protecting one model from another is the real
+architectural concern.
+
+## ACL vs. API Gateway
+
+They solve different problems.
+
+``` text
+API Gateway
+  -> routing/security/aggregation at API edge
+
+Anti-Corruption Layer
+  -> semantic translation between models
+```
+
+An API gateway can participate in an ACL, but it does not automatically
+provide one.
+
+## ACL and Legacy Modernization
+
+The pattern is particularly valuable during incremental replacement:
+
+``` text
+New Ordering Domain
+       |
+       v
+       ACL
+       |
+       v
+Legacy Order System
+```
+
+As functionality moves into the new domain, the ACL contains the
+remaining legacy semantics.
+
+Eventually it may shrink or disappear.
+
+## Third-Party SaaS Is "Legacy" Too
+
+The external system does not need to be old.
+
+A modern vendor still owns:
+
+-   its terminology;
+-   its lifecycle;
+-   its identifiers;
+-   its release schedule.
+
+Your domain should not be forced to adopt those decisions.
+
+Anti-corruption is about **model ownership**, not age.
+
+## Placement
+
+An ACL can be:
+
+``` text
+in-process adapter
+```
+
+or:
+
+``` text
+separate service
+```
+
+A separate process may be useful when:
+
+-   several applications share the translation;
+-   protocol isolation is substantial;
+-   scaling differs;
+-   security boundaries matter.
+
+But it adds latency, deployment, monitoring, and another failure point.
+
+Do not create a service merely because the pattern has "layer" in its
+name.
+
+## Resilience
+
+Because the ACL sits on an external boundary, it is also where we often
+apply:
+
+-   timeout;
+-   Retry;
+-   Circuit Breaker;
+-   Bulkhead;
+-   rate limiting.
+
+These mechanisms protect availability.
+
+They do not replace semantic translation.
+
+## Observability
+
+Instrument the boundary.
+
+Useful signals include:
+
+``` text
+external operation
+latency
+translated error category
+vendor status
+retry count
+correlation ID
+translation failure
+```
+
+Do not leak secrets or sensitive payloads into logs.
+
+Translation failures are especially important because they often
+indicate contract drift.
+
+## Contract Testing
+
+The ACL is an ideal target for contract tests.
+
+Verify that real or representative external payloads still translate
+into the expected internal concepts.
+
+This catches the dangerous situation where:
+
+``` text
+our stub passes
+vendor contract changed
+production breaks
+```
+
+## When It Helps
+
+Use an Anti-Corruption Layer when:
+
+-   integrating a legacy system;
+-   integrating a vendor with a foreign domain model;
+-   bounded contexts use different semantics;
+-   migration is incremental;
+-   external concepts are contaminating internal code.
+
+Current Azure architecture guidance describes the same core use: put a
+facade/adapter boundary between systems with different semantics so the
+outside system does not constrain the application's design.
+
+## When It Hurts
+
+It can become harmful when:
+
+-   the systems already share compatible semantics;
+-   the layer merely forwards every field;
+-   business orchestration accumulates inside the translator;
+-   a separate ACL service is created without operational justification.
+
+## How It Relates to Fowler
+
+This pattern is almost a composition of Volume I patterns:
+
+``` text
+Gateway
++ Mapper
++ DTO
++ Separated Interface
++ Service Layer concepts
+```
+
+DDD gives the composition a strategic purpose:
+
+**protect the integrity of the model.**
+
+## Summary
+
+An Anti-Corruption Layer is a semantic firewall.
+
+It lets your application integrate with another system without allowing
+that system's language, errors, protocols, and assumptions to spread
+through your domain.
+
+At a meaningful external boundary, that protection can be worth far more
+than the mapping code it requires.

--- a/src/posts/2029-12-23-command.md
+++ b/src/posts/2029-12-23-command.md
@@ -1,0 +1,359 @@
+---
+author: Steve Kaschimer
+date: 2029-12-23
+image: /images/posts/2029-12-23-hero.webp
+image_alt: "A bold arrow entering a gate marked with an imperative exclamation mark."
+image_prompt: "A dark-mode technical editorial illustration on a near-black background with electric teal, amber, and off-white accents. Composition centers on a single bold teal arrow moving toward a small amber gate glyph marked with one exclamation-point notch, implying a deliberate request to make something happen rather than a passive data update. Mood is intentional and direct. Avoid: vendor logos, brand colors, circuit-board textures, gears, or generic clip art as the dominant motif."
+layout: post.njk
+site_title: Tech Notes
+summary: "Model application requests as explicit business intentions, distinguish commands from events and CRUD updates, and design command handling around validation, invariants, transactions, and idempotency."
+tags: ["dotnet", "architecture", "design-patterns", "cqrs"]
+title: "Command: Modeling an Intent to Change the System"
+---
+
+A Command is a request to make something happen.
+
+```csharp
+public sealed record PlaceOrder(
+    CustomerId CustomerId,
+    IReadOnlyList<OrderLineRequest> Lines);
+```
+
+That sounds simple.
+
+But treating commands as explicit business intentions changes how we think about application APIs.
+
+## Commands Are Imperative
+
+Good command names sound like actions:
+
+```text
+PlaceOrder
+CancelOrder
+AuthorizePayment
+ChangeShippingAddress
+ApproveExpense
+```
+
+Compare them with:
+
+```text
+UpdateOrder
+SaveCustomer
+SetStatus
+```
+
+The second group describes data manipulation.
+
+The first group describes **business intent**.
+
+That difference matters because the application can evaluate whether the requested action is allowed.
+
+## A Command Is Not an Event
+
+A command says:
+
+> Please do this.
+
+An event says:
+
+> This happened.
+
+```text
+PlaceOrder      Command
+OrderPlaced     Event
+
+AuthorizePayment   Command
+PaymentAuthorized  Event
+```
+
+A command can be rejected.
+
+An event represents a fact that has already occurred.
+
+Microsoft's .NET architecture guidance makes this same distinction: commands are requests and may be refused, while events describe occurrences. It also emphasizes that a command normally has one intended receiver.
+
+## Commands Are Messages, Not Necessarily Broker Messages
+
+This is a command:
+
+```csharp
+public sealed record CancelOrder(
+    OrderId OrderId,
+    string Reason);
+```
+
+even if it is dispatched with an ordinary method call:
+
+```csharp
+await handler.HandleAsync(command, ct);
+```
+
+A mediator can dispatch it.
+
+A message broker can transport it.
+
+Neither mechanism defines the pattern.
+
+## Commands Should Express the Use Case
+
+Suppose the UI wants to reserve a hotel room.
+
+Prefer:
+
+```csharp
+BookRoom
+```
+
+over:
+
+```csharp
+UpdateReservationStatus(
+    ReservationStatus.Reserved)
+```
+
+Why?
+
+Because `BookRoom` gives the application a place to enforce:
+
+- availability;
+- guest eligibility;
+- payment requirements;
+- cancellation policy;
+- pricing rules.
+
+A generic update command leaks storage-oriented thinking into the application contract.
+
+## Commands Usually Return Small Results
+
+A command may return:
+
+```text
+nothing
+identifier
+success/failure
+small operation result
+```
+
+For example:
+
+```csharp
+public sealed record PlaceOrderResult(
+    OrderId OrderId);
+```
+
+Avoid making command handlers double as arbitrary query endpoints.
+
+If the caller needs a complex read model after the operation, it can issue a query.
+
+## Command Handler
+
+```csharp
+public sealed class PlaceOrderHandler(
+    IOrderRepository orders,
+    IUnitOfWork unitOfWork)
+{
+    public async Task<PlaceOrderResult> HandleAsync(
+        PlaceOrder command,
+        CancellationToken cancellationToken)
+    {
+        var order = Order.Create(
+            OrderId.New(),
+            command.CustomerId);
+
+        foreach (var line in command.Lines)
+        {
+            order.AddItem(
+                line.ProductId,
+                line.UnitPrice,
+                line.Quantity);
+        }
+
+        order.Place();
+
+        orders.Add(order);
+
+        await unitOfWork.SaveChangesAsync(
+            cancellationToken);
+
+        return new(order.Id);
+    }
+}
+```
+
+The handler coordinates the use case.
+
+The aggregate owns domain invariants.
+
+## Boundary Validation vs. Domain Validation
+
+The command boundary can reject malformed input:
+
+```text
+CustomerId missing
+No lines supplied
+String too long
+```
+
+The domain protects business invariants:
+
+```text
+Order cannot be placed twice
+Quantity must be positive
+Credit limit cannot be exceeded
+```
+
+Do not rely solely on command validation for invariants.
+
+Someone may invoke the domain from another use case later.
+
+## Transaction Boundary
+
+A command is often a natural transaction boundary:
+
+```text
+Receive command
+      |
+Load aggregate
+      |
+Execute behavior
+      |
+Persist
+      |
+Commit
+```
+
+This does not mean every command requires a database transaction.
+
+It means the use case should have intentional consistency semantics.
+
+## Command Identity
+
+Network retries introduce a dangerous question:
+
+```text
+Did the command fail,
+or did the response fail?
+```
+
+Imagine:
+
+```text
+POST /orders
+   |
+server creates order
+   |
+response lost
+   |
+client retries
+```
+
+Without command identity, the application may create two orders.
+
+An idempotency key can associate retries with the same logical operation.
+
+We will treat that as its own pattern in Article 21.
+
+## Commands and Authorization
+
+Task-based commands create useful authorization boundaries.
+
+```text
+Can user edit Order?
+```
+
+is often less meaningful than:
+
+```text
+Can user CancelOrder?
+Can user ApproveOrder?
+Can user RefundOrder?
+```
+
+Authorization can align with actual business capabilities.
+
+## Commands and Vertical Slices
+
+Commands fit naturally into feature-oriented organization:
+
+```text
+Orders/
+  Place/
+    Command.cs
+    Handler.cs
+    Endpoint.cs
+
+  Cancel/
+    Command.cs
+    Handler.cs
+    Endpoint.cs
+```
+
+Each command represents one meaningful application operation.
+
+## Commands and Mediator
+
+A mediator can dispatch:
+
+```csharp
+await sender.SendAsync(
+    new PlaceOrder(...),
+    cancellationToken);
+```
+
+That can enable pipelines for validation, transactions, or telemetry.
+
+But the command pattern does not require mediator infrastructure.
+
+Direct handler injection remains perfectly valid.
+
+## Testing
+
+Command-handler tests should prove the use case.
+
+```text
+Given a draft order
+When PlaceOrder executes
+Then the order becomes placed
+And the unit of work commits
+```
+
+Avoid tests that merely verify every collaborator method was called in a particular order unless that order is part of the behavior.
+
+## When It Helps
+
+Commands are useful when:
+
+- application operations have meaningful intent;
+- writes have business rules;
+- task-based APIs communicate better than CRUD;
+- authorization maps to actions;
+- command identity or pipelines matter.
+
+## When It Hurts
+
+Commands add little when a screen truly performs simple data maintenance.
+
+Do not turn:
+
+```text
+Change display preference
+```
+
+into an elaborate command hierarchy if a straightforward update communicates the system better.
+
+## How It Relates to Fowler
+
+A command handler often implements Fowler's Transaction Script or Service Layer.
+
+With DDD it may coordinate an Aggregate.
+
+With CQRS, Command becomes the explicit write-side vocabulary.
+
+## Summary
+
+A Command is not just a DTO headed toward a handler.
+
+It names an intention to change the system.
+
+That gives the application a clear place to authorize the action, validate its shape, invoke domain behavior, define transaction semantics, and eventually make retries safe.

--- a/src/posts/2029-12-30-query.md
+++ b/src/posts/2029-12-30-query.md
@@ -1,0 +1,303 @@
+---
+author: Steve Kaschimer
+date: 2029-12-30
+image: /images/posts/2029-12-30-hero.webp
+image_alt: "A magnifying lens hovering over a grid, projecting one small distilled shape out through the other side."
+image_prompt: "A dark-mode technical editorial illustration on a near-black background with electric teal, amber, and off-white accents. Composition centers on an amber magnifying-lens glyph positioned over a teal grid, with one small distilled off-white shape emerging from the lens on the opposite side, implying a question answered with exactly the shape the caller needs. Mood is efficient and purpose-built. Avoid: vendor logos, brand colors, circuit-board textures, gears, or generic clip art as the dominant motif."
+layout: post.njk
+site_title: Tech Notes
+summary: "Design read operations independently from write-side domain models, project directly into caller-oriented DTOs, and optimize query paths without weakening domain invariants."
+tags: ["dotnet", "architecture", "design-patterns", "cqrs"]
+title: "Query: Designing Reads for What the Caller Actually Needs"
+---
+
+The model that is excellent at changing business state is often a poor model for reading it.
+
+That is not a defect.
+
+It is a clue.
+
+A Query asks for information without intending to change the system.
+
+```csharp
+public sealed record GetOrderDetails(
+    OrderId OrderId);
+```
+
+## Queries Are Questions
+
+Useful query names describe what the caller needs:
+
+```text
+GetOrderDetails
+SearchCustomers
+GetOpenInvoices
+GetDashboardSummary
+```
+
+They are not commands with read-only handlers.
+
+Their optimization goals are different.
+
+## Do Not Load an Aggregate Just to Display It
+
+Suppose the UI needs:
+
+```text
+Order number
+Customer name
+Total
+Shipping status
+Five most recent events
+```
+
+Loading an Order aggregate, Customer aggregate, Shipment aggregate, and event collection simply to construct a screen may be wasteful.
+
+Instead, project the exact shape:
+
+```csharp
+var result = await db.Orders
+    .Where(x => x.Id == query.OrderId)
+    .Select(x => new OrderDetailsDto(
+        x.Id,
+        x.OrderNumber,
+        x.Customer.Name,
+        x.Total,
+        x.Shipment.Status))
+    .SingleOrDefaultAsync(cancellationToken);
+```
+
+The query model exists to answer the question efficiently.
+
+## Reads Do Not Need Domain Behavior
+
+A DTO:
+
+```csharp
+public sealed record OrderDetailsDto(
+    Guid Id,
+    string OrderNumber,
+    string CustomerName,
+    decimal Total,
+    string ShippingStatus);
+```
+
+does not need:
+
+```csharp
+Cancel()
+Place()
+AddItem()
+```
+
+because it is not responsible for preserving write-side invariants.
+
+This is one of CQRS's most useful insights.
+
+## Query Handler
+
+```csharp
+public sealed class GetOrderDetailsHandler(
+    OrdersDbContext db)
+{
+    public Task<OrderDetailsDto?> HandleAsync(
+        GetOrderDetails query,
+        CancellationToken cancellationToken)
+        => db.Orders
+            .AsNoTracking()
+            .Where(x => x.Id == query.OrderId)
+            .Select(x => new OrderDetailsDto(
+                x.Id.Value,
+                x.OrderNumber,
+                x.Customer.Name,
+                x.Total.Amount,
+                x.Shipment.Status))
+            .SingleOrDefaultAsync(
+                cancellationToken);
+}
+```
+
+No repository is automatically required.
+
+No aggregate needs to be materialized.
+
+## Query Models Can Be Caller-Specific
+
+The mobile UI and finance export may need different representations of the same underlying data.
+
+That is fine.
+
+```text
+OrderMobileSummary
+OrderFinanceExportRow
+OrderOperationsDashboardRow
+```
+
+A universal enterprise DTO often becomes a bloated contract satisfying nobody particularly well.
+
+## Query Optimization Is Allowed
+
+Read models may use:
+
+- direct SQL;
+- Dapper;
+- EF Core projections;
+- database views;
+- materialized views;
+- read replicas;
+- search indexes;
+- caches.
+
+The write model should not dictate the most efficient read technology.
+
+Microsoft's .NET CQRS guidance explicitly demonstrates reads bypassing the transactional DDD model and projecting directly into UI-oriented view models.
+
+## Queries Should Be Side-Effect Free
+
+A query should not unexpectedly:
+
+```text
+charge a card
+send an email
+advance workflow
+change status
+```
+
+This is the Command-Query Separation principle in practical application design.
+
+Operational side effects such as telemetry are different; observing a query is not domain mutation.
+
+## Query Idempotence
+
+Reading the same unchanged state repeatedly should produce the same logical answer.
+
+That property makes retries far safer than retrying commands.
+
+But beware of time-sensitive queries:
+
+```text
+GetCurrentPrice
+GetAvailableInventory
+```
+
+The underlying world may change between calls.
+
+"Read-only" does not mean "eternally stable."
+
+## Pagination
+
+Do not let query articles remain toy examples.
+
+Production reads need:
+
+- filtering;
+- sorting;
+- pagination;
+- authorization;
+- cancellation;
+- timeout awareness.
+
+For large changing datasets, cursor/keyset pagination can be preferable to increasingly expensive offsets.
+
+## Authorization
+
+A direct projection must still respect security boundaries.
+
+Do not accidentally bypass authorization merely because the query bypasses the domain model.
+
+For example:
+
+```csharp
+.Where(x => x.TenantId == currentTenant.Id)
+```
+
+may be essential.
+
+Query optimization never outranks data isolation.
+
+## N+1 Problems
+
+Projection helps avoid accidentally loading graphs, but queries still need measurement.
+
+Watch:
+
+- SQL count;
+- execution plans;
+- indexes;
+- returned columns;
+- cardinality;
+- serialization size.
+
+A beautiful query object can still produce terrible SQL.
+
+## Caching
+
+Queries are natural cache candidates because they do not mutate state.
+
+But caching introduces:
+
+```text
+invalidation
+staleness
+memory pressure
+stampedes
+```
+
+Later we will cover Cache-Aside as a dedicated pattern.
+
+## Query vs. Repository
+
+Repositories are typically useful around aggregate persistence.
+
+Queries often need shapes that do not correspond to aggregates.
+
+Forcing every read through:
+
+```csharp
+IRepository<Order>
+```
+
+can make reporting and projection awkward.
+
+CQRS gives reads permission to use a purpose-built path.
+
+## Testing
+
+Query tests should prove:
+
+- correct filtering;
+- authorization boundaries;
+- projection semantics;
+- pagination;
+- missing-result behavior.
+
+For EF Core queries, integration tests against the actual relational provider are often more valuable than mocking `IQueryable`.
+
+## When It Helps
+
+Explicit queries help when:
+
+- callers need specialized read shapes;
+- domain aggregates are expensive or inappropriate for reads;
+- reads need independent optimization;
+- the application has many task-oriented use cases.
+
+## When It Hurts
+
+Do not create a query handler, query service, repository, mapper, and DTO for a trivial lookup unless those boundaries buy something.
+
+Simple reads should remain simple.
+
+## How It Relates to Fowler
+
+Queries connect strongly to Query Object, DTO, Mapper, Data Mapper, and various presentation patterns from Volume I.
+
+CQRS gives these read-side patterns permission to evolve independently from the write model.
+
+## Summary
+
+A Query is optimized for answering a question.
+
+It does not need to reconstruct the write-side domain model to do that.
+
+Project what the caller needs, protect security boundaries, measure the generated data access, and allow the read path to evolve independently when the problem justifies it.

--- a/src/posts/2030-01-06-cqrs.md
+++ b/src/posts/2030-01-06-cqrs.md
@@ -1,0 +1,405 @@
+---
+author: Steve Kaschimer
+date: 2030-01-06
+image: /images/posts/2030-01-06-hero.webp
+image_alt: "One path forking into two distinct paths, one leading to a pencil-shaped write glyph and the other to a lens-shaped read glyph."
+image_prompt: "A dark-mode technical editorial illustration on a near-black background with electric teal, amber, and off-white accents. Composition centers on a single teal path forking into two distinct branches, the upper branch ending in a small amber pencil-shaped glyph and the lower branch ending in a small off-white lens-shaped glyph, implying one responsibility deliberately separated into two independent paths. Mood is separated and intentional. Avoid: vendor logos, brand colors, circuit-board textures, gears, or generic clip art as the dominant motif."
+layout: post.njk
+site_title: Tech Notes
+summary: "Apply Command Query Responsibility Segregation incrementally in .NET, beginning with separate application models and progressing to independent stores only when scaling, consistency, or query needs justify the cost."
+tags: ["dotnet", "architecture", "design-patterns", "cqrs"]
+title: "CQRS: Separate Reads and Writes Before You Separate Databases"
+---
+
+CQRS is frequently introduced with a diagram containing:
+
+```text
+Command Bus
+Event Bus
+Write Database
+Read Database
+Projection Workers
+```
+
+That is one possible destination.
+
+It is not the starting point.
+
+Command Query Responsibility Segregation begins with one idea:
+
+> **The model used to change state does not have to be the model used to read state.**
+
+## Level 1: Separate Code Paths
+
+Start here:
+
+```text
+             Application
+             /         \
+        Commands       Queries
+           |              |
+       Domain/EF       Projection
+           \              /
+            Same Database
+```
+
+Commands perform business operations.
+
+Queries return caller-oriented data.
+
+That is already useful CQRS.
+
+## Why Separate Them?
+
+Write-side concerns:
+
+```text
+invariants
+transactions
+concurrency
+authorization
+domain behavior
+```
+
+Read-side concerns:
+
+```text
+filtering
+joining
+sorting
+pagination
+projection
+latency
+```
+
+Trying to make one model perfect at both creates tension.
+
+## Write Side
+
+```csharp
+public sealed class PlaceOrderHandler(
+    IOrderRepository orders,
+    IUnitOfWork unitOfWork)
+{
+    public async Task<OrderId> HandleAsync(
+        PlaceOrder command,
+        CancellationToken cancellationToken)
+    {
+        var order = Order.Create(...);
+
+        order.Place();
+
+        orders.Add(order);
+
+        await unitOfWork.SaveChangesAsync(
+            cancellationToken);
+
+        return order.Id;
+    }
+}
+```
+
+The write model protects business consistency.
+
+## Read Side
+
+```csharp
+public sealed class SearchOrdersHandler(
+    OrdersDbContext db)
+{
+    public Task<List<OrderListItem>> HandleAsync(
+        SearchOrders query,
+        CancellationToken cancellationToken)
+        => db.Orders
+            .AsNoTracking()
+            .Where(...)
+            .OrderByDescending(x => x.CreatedAt)
+            .Select(x => new OrderListItem(
+                x.Id.Value,
+                x.OrderNumber,
+                x.Customer.Name,
+                x.Total.Amount))
+            .ToListAsync(cancellationToken);
+}
+```
+
+The read side answers efficiently.
+
+## Same Database Is Fine
+
+This architecture:
+
+```text
+Commands ----\
+              -> PostgreSQL
+Queries -----/
+```
+
+can provide most of CQRS's design benefit.
+
+There is no rule requiring separate stores.
+
+Current Azure Architecture Center guidance defines CQRS as separating read and update operations using distinct interfaces; separate stores are an optional evolution with additional synchronization concerns.
+
+## Level 2: Different Read Technology
+
+Maybe reporting needs direct SQL:
+
+```text
+Commands -> EF Core
+Queries  -> Dapper
+             |
+          Same DB
+```
+
+Still simple.
+
+The write side remains domain-oriented.
+
+The read side gets precise control over SQL.
+
+## Level 3: Read Replica
+
+Read volume becomes large:
+
+```text
+Commands -> Primary DB
+                |
+           replication
+                |
+Queries ----> Replica
+```
+
+Now reads and writes can scale somewhat independently.
+
+But replication lag introduces staleness.
+
+The consistency model changed.
+
+## Level 4: Separate Read Model
+
+Eventually:
+
+```text
+Commands
+   |
+Write Model
+   |
+Write DB
+   |
+events
+   |
+Projection
+   |
+Read DB
+   |
+Queries
+```
+
+Now the read schema can be completely optimized for its consumers.
+
+But we have accepted eventual consistency.
+
+## Eventual Consistency Is a Product Decision
+
+Suppose the user changes their shipping address and immediately reloads the page.
+
+If the read projection has not caught up:
+
+```text
+Command succeeded
+Read returns old address
+```
+
+Is that acceptable?
+
+That is not merely an engineering detail.
+
+The UI may need:
+
+- optimistic updates;
+- "processing" states;
+- read-your-own-write mechanisms;
+- polling;
+- version tokens.
+
+Architecture affects user experience.
+
+## CQRS Does Not Require Event Sourcing
+
+This is a persistent misconception.
+
+```text
+CQRS != Event Sourcing
+```
+
+You can use:
+
+```text
+CQRS + ordinary relational persistence
+```
+
+or:
+
+```text
+CQRS + Event Sourcing
+```
+
+Event Sourcing is a separate pattern that often pairs well with CQRS because event streams naturally produce projections.
+
+We will cover it later.
+
+## CQRS Does Not Require Mediator
+
+Likewise:
+
+```text
+CQRS != MediatR
+```
+
+You can inject:
+
+```csharp
+PlaceOrderHandler
+```
+
+directly.
+
+Mediator is a dispatch mechanism.
+
+CQRS is separation of read and write responsibility.
+
+## CQRS and DDD
+
+They complement each other particularly well.
+
+```text
+Command Side
+   |
+Aggregate
+Domain Model
+Repository
+
+Query Side
+   |
+DTO
+Projection
+SQL
+```
+
+The rich model is used where invariants matter.
+
+The read model remains simple.
+
+## CQRS and Vertical Slices
+
+This combination is extremely natural:
+
+```text
+Orders/
+  Place/       command
+  Cancel/      command
+  Details/     query
+  Search/      query
+```
+
+Each use case can choose its own implementation strategy.
+
+## The Synchronization Problem
+
+Once stores separate, you need a reliable way to move changes:
+
+```text
+Write DB commit
+Publish event
+```
+
+Those operations can fail independently.
+
+That leads directly to the Transactional Outbox pattern.
+
+Notice the Architecture Complexity Ladder at work:
+
+```text
+CQRS
+   |
+separate stores
+   |
+need synchronization
+   |
+Outbox
+   |
+duplicate delivery
+   |
+Idempotent Consumer
+```
+
+Complexity creates the need for the next pattern.
+
+## Observability
+
+With separate read models, measure:
+
+- projection lag;
+- failed projections;
+- event throughput;
+- read freshness;
+- command latency;
+- query latency.
+
+"Eventually consistent" is not permission to be unknowably stale.
+
+## When It Helps
+
+CQRS is useful when:
+
+- write logic is substantially different from read logic;
+- domain modeling complicates reporting;
+- reads and writes need different scaling;
+- specialized projections improve performance;
+- task-based commands clarify business behavior.
+
+## When It Hurts
+
+Avoid escalating CQRS when:
+
+- CRUD models already fit both sides;
+- the team cannot operate eventual consistency;
+- separate stores are added only because diagrams show them;
+- every property update becomes a command class without business value.
+
+## How It Relates to Fowler
+
+CQRS composes Volume I patterns differently on each side.
+
+```text
+WRITE
+Domain Model
+Repository
+Unit of Work
+Service Layer
+
+READ
+Query Object
+DTO
+Mapper
+Data Mapper
+```
+
+The breakthrough is not a new database technology.
+
+It is allowing the two responsibilities to stop compromising each other.
+
+## Summary
+
+Start CQRS by separating commands from queries in code.
+
+Keep one database until you have a reason not to.
+
+Add specialized query technology when needed.
+
+Add replicas when needed.
+
+Add independent read stores only when their benefits justify synchronization and eventual consistency.
+
+CQRS should grow with the problem—not arrive fully distributed on day one.

--- a/src/posts/2030-01-13-result-pattern.md
+++ b/src/posts/2030-01-13-result-pattern.md
@@ -1,0 +1,316 @@
+---
+author: Steve Kaschimer
+date: 2030-01-13
+image: /images/posts/2030-01-13-hero.webp
+image_alt: "A forked path with one branch ending in a checkmark and the other ending in a small labeled tag rather than a dead end."
+image_prompt: "A dark-mode technical editorial illustration on a near-black background with electric teal, amber, and off-white accents. Composition centers on a single teal path forking into two branches, one ending in a solid amber checkmark and the other ending in a small labeled off-white tag shape rather than simply stopping, implying failure modeled as an explicit, examinable outcome. Mood is explicit and unafraid of failure. Avoid: vendor logos, brand colors, circuit-board textures, gears, or generic clip art as the dominant motif."
+layout: post.njk
+site_title: Tech Notes
+summary: "Represent expected application outcomes explicitly in modern C#, distinguish business failure from exceptional failure, and map results cleanly to HTTP without replacing exceptions indiscriminately."
+tags: ["dotnet", "architecture", "design-patterns", "software-design"]
+title: "Result Pattern: Making Expected Failure Explicit"
+---
+
+Applications fail in different ways.
+
+These are not the same:
+
+```text
+Order does not exist.
+Coupon is expired.
+Payment is declined.
+Database connection disappeared.
+Invariant was violated because of a bug.
+```
+
+The Result pattern is useful when failure is an **expected part of the application's contract**.
+
+## The Null Problem
+
+Suppose:
+
+```csharp
+public Task<Order?> GetOrderAsync(OrderId id);
+```
+
+`null` tells us only that there is no Order.
+
+It cannot naturally distinguish:
+
+```text
+not found
+not authorized
+temporarily unavailable
+```
+
+## The Exception Problem
+
+We could throw:
+
+```csharp
+throw new OrderNotFoundException(id);
+```
+
+But if "order not found" is an ordinary expected outcome, exception-driven control flow may obscure the contract.
+
+## An Explicit Result
+
+A minimal model:
+
+```csharp
+public abstract record Result<T>
+{
+    private Result() { }
+
+    public sealed record Success(T Value)
+        : Result<T>;
+
+    public sealed record Failure(Error Error)
+        : Result<T>;
+}
+
+public sealed record Error(
+    string Code,
+    string Message);
+```
+
+Then:
+
+```csharp
+public Task<Result<OrderId>> HandleAsync(...);
+```
+
+The signature says failure is expected.
+
+## Domain-Specific Results Can Be Better
+
+Generic `Result<T>` is not mandatory.
+
+Sometimes:
+
+```csharp
+public abstract record PaymentAuthorization
+{
+    public sealed record Approved(
+        AuthorizationId Id)
+        : PaymentAuthorization;
+
+    public sealed record Declined(
+        DeclineReason Reason)
+        : PaymentAuthorization;
+}
+```
+
+communicates the domain far better than:
+
+```text
+Result<AuthorizationId>
+```
+
+Use the smallest abstraction that improves clarity.
+
+## Expected vs. Exceptional
+
+A useful distinction:
+
+```text
+Expected business/application outcome
+    -> Result
+
+Unexpected infrastructure/programming failure
+    -> Exception
+```
+
+Examples:
+
+```text
+Coupon expired       Result
+Card declined        Result
+Order not found      Result/optional, context dependent
+
+SQL connection lost  Exception
+NullReferenceException Exception
+Broken invariant     Exception
+```
+
+Do not convert every exception into:
+
+```text
+Result.Fail("Something went wrong")
+```
+
+That can erase diagnostic information.
+
+## Result and Domain Exceptions
+
+Some domain models protect invariants by throwing domain exceptions.
+
+Others return domain results.
+
+Both can work.
+
+For example:
+
+```csharp
+public CancelOrderResult Cancel()
+{
+    if (Status == OrderStatus.Shipped)
+        return CancelOrderResult.Rejected(
+            CancelReason.AlreadyShipped);
+
+    Status = OrderStatus.Cancelled;
+
+    return CancelOrderResult.Success;
+}
+```
+
+The choice depends on whether the rejected operation is a normal domain branch or represents programmer misuse.
+
+## Pattern Matching
+
+Modern C# makes discriminated-style results pleasant:
+
+```csharp
+return result switch
+{
+    PlaceOrderResult.Success success =>
+        Results.Created(
+            $"/orders/{success.OrderId}",
+            success),
+
+    PlaceOrderResult.Invalid invalid =>
+        Results.ValidationProblem(
+            invalid.Errors),
+
+    PlaceOrderResult.Conflict conflict =>
+        Results.Conflict(conflict.Message),
+
+    _ => throw new UnreachableException()
+};
+```
+
+The endpoint translates application outcomes into transport semantics.
+
+The application does not need to return `IResult`.
+
+## HTTP Mapping Belongs at the Edge
+
+Avoid:
+
+```csharp
+public Task<IResult> PlaceOrderAsync(...)
+```
+
+inside the application layer.
+
+HTTP is an adapter concern.
+
+Instead:
+
+```text
+Application Result
+       |
+HTTP Adapter
+       |
+ProblemDetails / status code
+```
+
+The same application operation can then be invoked from a queue or CLI.
+
+## Error Codes
+
+Stable machine-readable codes are useful:
+
+```csharp
+new Error(
+    "orders.already_shipped",
+    "A shipped order cannot be cancelled.");
+```
+
+The human message can change.
+
+The code can remain part of a contract.
+
+Do not expose internal exception type names as public error codes.
+
+## Validation Errors
+
+Validation often deserves structured data:
+
+```csharp
+public sealed record ValidationError(
+    string Field,
+    string Code,
+    string Message);
+```
+
+That lets HTTP adapters produce `ValidationProblemDetails` without coupling the application to ASP.NET Core.
+
+## Result Explosion
+
+This is the danger:
+
+```text
+Result<Result<Option<Either<...>>>>
+```
+
+If understanding the success path requires decoding a type puzzle, the abstraction has failed.
+
+Domain-specific result types and ordinary exceptions are often clearer.
+
+## Logging
+
+Expected failures should not all be logged as errors.
+
+A declined card is business information.
+
+A database outage is an operational error.
+
+Result modeling helps telemetry distinguish them.
+
+## Testing
+
+Results make expected outcomes easy to test:
+
+```csharp
+var result = order.Cancel();
+
+Assert.IsType<
+    CancelOrderResult.Rejected>(result);
+```
+
+No exception assertion is required for ordinary business rejection.
+
+## When It Helps
+
+Use Result when:
+
+- callers are expected to handle several normal outcomes;
+- failure is part of the use-case contract;
+- transport-independent error mapping matters;
+- exceptions would be ordinary control flow.
+
+## When It Hurts
+
+It hurts when:
+
+- every function returns Result regardless of need;
+- exceptions are swallowed into generic failures;
+- stack traces and diagnostics disappear;
+- generic type machinery overwhelms domain language.
+
+## How It Relates to Fowler
+
+Result is a modern application-level companion to patterns such as Special Case and Service Layer.
+
+It also pairs naturally with Commands, Queries, Vertical Slices, and HTTP `ProblemDetails`.
+
+## Summary
+
+Result makes **expected failure** explicit.
+
+It does not eliminate exceptions.
+
+Model ordinary business/application outcomes as values when doing so improves the contract, and preserve exceptions for failures that are genuinely exceptional or operational.
+
+The goal is clarity, not a world in which `throw` is forbidden.

--- a/src/posts/2030-01-20-idempotency.md
+++ b/src/posts/2030-01-20-idempotency.md
@@ -1,0 +1,441 @@
+---
+author: Steve Kaschimer
+date: 2030-01-20
+image: /images/posts/2030-01-20-hero.webp
+image_alt: "Several duplicate stamped marks collapsing into a single stamped outcome mark."
+image_prompt: "A dark-mode technical editorial illustration on a near-black background with electric teal, amber, and off-white accents. Composition centers on three faint duplicate amber stamp-mark glyphs overlapping and converging into one solid teal stamp mark at the center, implying repeated attempts at the same operation producing exactly one effect. Mood is convergent and safe. Avoid: vendor logos, brand colors, circuit-board textures, gears, or generic clip art as the dominant motif."
+layout: post.njk
+site_title: Tech Notes
+summary: "Design HTTP commands and distributed operations so repeated delivery of the same logical request does not repeat harmful effects, using stable operation identity, atomic persistence, replayed responses, and careful expiration."
+tags: ["dotnet", "architecture", "design-patterns", "reliability"]
+title: "Idempotency: Making Retries Safe"
+---
+
+Distributed systems force us to confront an uncomfortable ambiguity:
+
+> A timeout does not tell us whether the operation failed.
+
+Consider:
+
+```text
+Client
+  |
+POST /payments
+  |
+Server charges card
+  |
+response lost
+  |
+TIMEOUT
+```
+
+What should the client do?
+
+Retrying may charge the card twice.
+
+Not retrying may leave the customer uncertain whether payment succeeded.
+
+Idempotency solves the duplicate-effect problem.
+
+## What Idempotent Means
+
+An operation is idempotent when performing the same logical operation multiple times has the same intended effect as performing it once.
+
+```text
+Attempt 1 -> create Order 123
+Attempt 2 -> return Order 123
+Attempt 3 -> return Order 123
+```
+
+not:
+
+```text
+Attempt 1 -> Order 123
+Attempt 2 -> Order 124
+Attempt 3 -> Order 125
+```
+
+## Natural Idempotency
+
+Some operations are naturally idempotent.
+
+```text
+Set shipping preference = Express
+```
+
+Repeated execution produces the same state.
+
+Others are not:
+
+```text
+Increment balance by $10
+Create order
+Charge card
+Send gift card
+```
+
+Those need additional design.
+
+## Idempotency Key
+
+The caller assigns identity to the logical operation:
+
+```text
+Idempotency-Key:
+01JXYZ...
+```
+
+The same retry uses the same key.
+
+A different business operation gets a different key.
+
+The server records the key and outcome.
+
+## Basic Flow
+
+```text
+Request + Key
+     |
+     v
+Key already known?
+   /          \
+ yes           no
+  |             |
+return prior   execute
+result          |
+                v
+            save result
+```
+
+This sounds easy.
+
+Concurrency makes it interesting.
+
+## The Race
+
+Two copies arrive simultaneously:
+
+```text
+Request A -> key not found
+Request B -> key not found
+
+A charges card
+B charges card
+```
+
+A simple "check then insert" is not enough.
+
+The idempotency record needs an atomic uniqueness guarantee.
+
+## Persistence Model
+
+For example:
+
+```text
+IdempotencyRecords
+------------------
+Key             UNIQUE
+Operation
+RequestHash
+Status
+ResponseCode
+ResponseBody
+CreatedAt
+ExpiresAt
+```
+
+The unique key lets the database arbitrate concurrent attempts.
+
+## Scope the Key
+
+An idempotency key should be scoped appropriately.
+
+For example:
+
+```text
+tenant + operation + key
+```
+
+rather than assuming one globally meaningful string forever.
+
+The exact scope is part of the API contract.
+
+## Bind the Key to the Request
+
+What if a caller accidentally reuses the same key for a different payload?
+
+Store a request fingerprint.
+
+```csharp
+public sealed record IdempotencyRecord(
+    string Key,
+    string RequestHash,
+    int ResponseStatus,
+    string ResponseBody);
+```
+
+If the key exists but the hash differs:
+
+```text
+409 Conflict
+```
+
+or another explicit contract response may be appropriate.
+
+Do not silently return a result for a different operation.
+
+## Atomicity
+
+Suppose:
+
+```text
+Charge card ✓
+Save idempotency record ✗
+```
+
+A retry can still charge twice.
+
+The strongest design places the protected side effect and idempotency state inside one atomic boundary where possible.
+
+For database-local operations:
+
+```text
+BEGIN TRANSACTION
+  insert idempotency record
+  create order
+COMMIT
+```
+
+For an external payment provider, use the provider's own idempotency mechanism if available so the remote side effect has stable operation identity too.
+
+## Pending Operations
+
+An idempotency record may need states:
+
+```text
+Processing
+Succeeded
+Failed
+```
+
+If another request sees `Processing`, it can:
+
+- wait briefly;
+- return a processing response;
+- reject concurrent execution.
+
+The correct behavior depends on the API.
+
+## What Response Should Be Replayed?
+
+Often the server stores enough information to reproduce the original logical response:
+
+```text
+status code
+resource identifier
+response body
+selected headers
+```
+
+A retry then receives the same result instead of executing again.
+
+Be cautious about replaying time-sensitive or sensitive headers blindly.
+
+## Expiration
+
+Keeping every key forever is rarely practical.
+
+Choose a retention window based on:
+
+- client retry behavior;
+- business risk;
+- operation lifetime;
+- storage cost.
+
+Document the guarantee.
+
+If keys expire after 24 hours, a retry after 25 hours may be treated as a new operation.
+
+That is part of the semantics.
+
+## HTTP Methods Do Not Solve This Alone
+
+HTTP defines some methods such as PUT and DELETE with idempotent semantics.
+
+But application implementation still matters.
+
+And many important task-based APIs use POST:
+
+```text
+POST /orders
+POST /payments/{id}/capture
+```
+
+An idempotency key can make those logical operations safe to retry.
+
+## Idempotency vs. Correlation ID
+
+They are different.
+
+```text
+Correlation ID
+    -> trace related work
+
+Idempotency Key
+    -> identify one logical operation
+       so effects are not duplicated
+```
+
+A system may carry both.
+
+Current Azure architecture guidance explicitly discusses using correlation IDs for tracing and idempotency keys for safe retries across services.
+
+## Commands
+
+Command identity is a natural fit:
+
+```csharp
+public sealed record CommandEnvelope<T>(
+    Guid OperationId,
+    T Command);
+```
+
+The receiver records processed operation IDs.
+
+Microsoft's .NET architecture guidance similarly demonstrates wrapping commands with an identity so duplicate delivery can be detected.
+
+## Messaging
+
+Idempotency becomes even more important with message brokers because **at-least-once delivery means duplicates are normal**.
+
+```text
+Broker
+ |
+Message #42
+ |
+Consumer processes
+ |
+ack lost
+ |
+Message #42 delivered again
+```
+
+The consumer must safely recognize or tolerate the duplicate.
+
+That becomes the Inbox / Idempotent Consumer pattern later in Volume II.
+
+## Idempotent State Transitions
+
+Sometimes the domain can help.
+
+Instead of:
+
+```text
+Add $100 payment
+```
+
+model:
+
+```text
+Apply PaymentId 784
+```
+
+The aggregate can remember processed payment identities or enforce a unique payment relationship.
+
+Business identity can be stronger than generic technical deduplication.
+
+## Observability
+
+Measure:
+
+- duplicate request count;
+- key conflicts;
+- in-progress collisions;
+- replay count;
+- expired-key retries;
+- idempotency-store failures.
+
+A rising duplicate rate may indicate client timeout or network problems elsewhere.
+
+## Security
+
+Do not let attackers use predictable keys to retrieve another user's prior response.
+
+Scope keys to authenticated principals/tenants and authorize every retry exactly as you would the original request.
+
+Do not treat possession of the key as authorization.
+
+## Testing
+
+Important tests include:
+
+```text
+same key + same request -> one effect
+
+same key + different request -> conflict
+
+two concurrent requests -> one effect
+
+retry after response loss -> same result
+
+expired key -> documented behavior
+```
+
+Concurrency testing matters.
+
+A sequential unit test does not prove atomic deduplication.
+
+## When It Helps
+
+Idempotency is essential when:
+
+- clients retry commands;
+- operations have expensive or dangerous duplicate effects;
+- networks introduce ambiguous outcomes;
+- brokers provide at-least-once delivery;
+- workflows cross service boundaries.
+
+## When It Hurts
+
+Do not add a persistent idempotency subsystem to every trivial operation.
+
+It introduces:
+
+- storage;
+- retention;
+- concurrency;
+- response replay;
+- security;
+- cleanup.
+
+Use it where duplicate execution has meaningful consequences.
+
+## How It Relates to What Comes Next
+
+Idempotency is the hinge between application architecture and distributed architecture.
+
+Soon we will have:
+
+```text
+Transactional Outbox
+      |
+at-least-once publication
+      |
+duplicate message possible
+      |
+Idempotent Consumer / Inbox
+```
+
+That is not an implementation accident.
+
+It is how reliable distributed systems are built when "exactly once" cannot simply be assumed.
+
+## Summary
+
+Retries are unavoidable.
+
+Duplicate effects are not.
+
+Give important operations stable identity, enforce that identity atomically, replay prior outcomes when appropriate, and make the idempotency guarantee part of the contract.
+
+Once the application crosses a network boundary, idempotency stops being an optimization and becomes a core correctness tool.

--- a/src/posts/2030-01-27-publish-subscribe.md
+++ b/src/posts/2030-01-27-publish-subscribe.md
@@ -1,0 +1,285 @@
+---
+author: Steve Kaschimer
+date: 2030-01-27
+image: /images/posts/2030-01-27-hero.webp
+image_alt: "One central broadcast node fanning thin lines out to several independent receiving nodes."
+image_prompt: "A dark-mode technical editorial illustration on a near-black background with electric teal, amber, and off-white accents. Composition centers on a single amber broadcast node at the center with four thin teal lines fanning outward to four small independent receiving nodes at the frame's edges, implying one fact reaching many unrelated observers at once. Mood is broadcast and decoupled. Avoid: vendor logos, brand colors, circuit-board textures, gears, or generic clip art as the dominant motif."
+layout: post.njk
+site_title: Tech Notes
+summary: "Use publish/subscribe to decouple producers from multiple independent consumers, and understand delivery, ordering, durability, and contract-versioning implications in modern .NET systems."
+tags: ["dotnet", "architecture", "design-patterns", "messaging"]
+title: "Publish/Subscribe: Decoupling Producers From Reactions"
+---
+
+Publish/Subscribe lets one producer announce that something happened without knowing every consumer that cares.
+
+```text
+OrderPlaced
+   |
+   +--> Fulfillment
+   +--> Analytics
+   +--> Loyalty
+```
+
+That is very different from:
+
+```text
+PlaceOrder()
+  |
+  +--> Call Fulfillment
+  +--> Call Analytics
+  +--> Call Loyalty
+```
+
+The producer no longer owns the reaction graph.
+
+## The Problem
+
+Direct calls create temporal coupling.
+
+If Loyalty is unavailable, should placing the order fail?
+
+If Analytics is slow, should the customer wait?
+
+If three more consumers are added, should Ordering change every time?
+
+Publish/Subscribe reduces that coupling.
+
+## Topic-Oriented Model
+
+A broker usually introduces a topic or event stream:
+
+```text
+Publisher
+   |
+   v
+OrderPlaced topic
+   |
+   +--> Subscription A
+   +--> Subscription B
+   +--> Subscription C
+```
+
+Each subscription can receive its own copy.
+
+This is not the same as one queue with multiple competing workers. We will cover that next.
+
+## Event Contract
+
+Use explicit integration contracts:
+
+```csharp
+public sealed record OrderPlacedIntegrationEvent(
+    Guid EventId,
+    Guid OrderId,
+    Guid CustomerId,
+    decimal Total,
+    string Currency,
+    DateTimeOffset OccurredAt);
+```
+
+The contract is part of the distributed boundary.
+
+Treat it more like a public API than an internal class.
+
+## Domain Event vs. Integration Event
+
+Recall:
+
+```text
+Domain Event
+  internal model fact
+  same bounded context
+  may be in-process
+
+Integration Event
+  stable distributed contract
+  crosses boundary
+  requires durable delivery semantics
+```
+
+Do not publish internal domain objects directly to the broker.
+
+## Fan-Out
+
+Publish/Subscribe is valuable when multiple consumers react independently.
+
+```text
+OrderPlaced
+  |
+  +--> send receipt
+  +--> reserve fulfillment work
+  +--> update analytics
+```
+
+Each consumer can evolve separately.
+
+That is the main architectural win.
+
+## Delivery Is Not Magic
+
+A broker can improve reliability.
+
+It does not create exactly-once business behavior automatically.
+
+Common delivery models include:
+
+```text
+at-most-once
+at-least-once
+```
+
+At-least-once means duplicates are possible.
+
+Consumers must be idempotent when duplicate effects matter.
+
+## Ordering
+
+Do not assume global ordering.
+
+Many brokers preserve order only within:
+
+```text
+partition
+session
+key
+```
+
+If order matters, define the ordering boundary explicitly.
+
+For example:
+
+```text
+all events for Order 42
+```
+
+may use the same partition key.
+
+## Event Evolution
+
+Contracts live longer than internal code.
+
+Prefer additive evolution:
+
+```json
+{
+  "eventId": "...",
+  "orderId": "...",
+  "total": 100,
+  "currency": "USD",
+  "salesChannel": "web"
+}
+```
+
+Adding optional data is often safer than renaming fields or changing meanings.
+
+## Consumer Independence
+
+A powerful property:
+
+```text
+Ordering does not know who subscribes.
+```
+
+That means adding Analytics should not require redeploying Ordering.
+
+But it also means producers cannot rely on synchronous consumer completion.
+
+If the order must not commit unless inventory reservation succeeds, publish/subscribe may not be the right coordination model for that decision.
+
+## Events vs. Commands
+
+Event:
+
+```text
+OrderPlaced
+```
+
+Command:
+
+```text
+ReserveInventory
+```
+
+The event says:
+
+> this happened; interested parties may react.
+
+The command says:
+
+> this receiver is requested to do something.
+
+Conflating the two creates ambiguous ownership.
+
+## Error Handling
+
+A subscriber can fail independently.
+
+That is a feature and a responsibility.
+
+You need:
+
+- retry policy;
+- dead-letter handling;
+- monitoring;
+- replay strategy;
+- idempotency.
+
+Once you publish asynchronously, failure handling becomes part of architecture.
+
+## Observability
+
+Track:
+
+```text
+publish count
+publish latency
+subscription lag
+consumer failures
+dead-letter count
+duplicate detection
+processing latency
+```
+
+Distributed tracing should carry correlation information across the message boundary.
+
+## Testing
+
+Test:
+
+```text
+publisher emits correct contract
+consumer accepts contract
+duplicate event is safe
+unknown/new fields do not break consumer
+failure routes correctly
+```
+
+Contract tests are especially important for independently deployed publishers and subscribers.
+
+## When It Helps
+
+Use Publish/Subscribe when:
+
+- one fact has multiple independent reactions;
+- producers should not know consumers;
+- asynchronous processing is acceptable;
+- consumer lifecycles differ.
+
+## When It Hurts
+
+It hurts when:
+
+- you need immediate synchronous consistency;
+- event graphs become impossible to follow;
+- teams publish vague events for every internal state change;
+- consumers are not idempotent;
+- operational monitoring is weak.
+
+## Summary
+
+Publish/Subscribe replaces direct reaction coupling with a distributed event contract.
+
+The trade is substantial:
+
+you gain decoupling and independent evolution, while accepting asynchronous failure, duplication, ordering, contract evolution, and operational complexity.

--- a/src/posts/2030-02-03-competing-consumers.md
+++ b/src/posts/2030-02-03-competing-consumers.md
@@ -1,0 +1,297 @@
+---
+author: Steve Kaschimer
+date: 2030-02-03
+image: /images/posts/2030-02-03-hero.webp
+image_alt: "Several worker nodes with arrows converging onto a single queue line, each pulling one item from it."
+image_prompt: "A dark-mode technical editorial illustration on a near-black background with electric teal, amber, and off-white accents. Composition centers on a single horizontal teal queue line with three small amber worker-node glyphs positioned beneath it, each connected by a short upward arrow pulling one item from the line, implying independent workers competing for the same stream of work. Mood is parallel and scalable. Avoid: vendor logos, brand colors, circuit-board textures, gears, or generic clip art as the dominant motif."
+layout: post.njk
+site_title: Tech Notes
+summary: "Process queued work with multiple independent workers, while handling at-least-once delivery, ordering constraints, poison messages, concurrency, and partitioning in modern .NET."
+tags: ["dotnet", "architecture", "design-patterns", "messaging"]
+title: "Competing Consumers: Scaling Work Horizontally"
+---
+
+Competing Consumers lets multiple workers read from the same queue, with each message handled by one available consumer.
+
+```text
+            Queue
+      ┌──────┼──────┐
+      v      v      v
+   Worker  Worker  Worker
+```
+
+This is a fundamental scale-out pattern for asynchronous workloads.
+
+## The Problem
+
+One worker processes:
+
+```text
+100 messages/sec
+```
+
+but producers create:
+
+```text
+600 messages/sec
+```
+
+Backlog grows forever.
+
+Adding consumers can increase throughput without changing the producer.
+
+## One Message, One Consumer
+
+Unlike Publish/Subscribe:
+
+```text
+event -> many subscriptions
+```
+
+Competing Consumers is:
+
+```text
+one queue -> many workers
+one message -> one worker
+```
+
+The workers compete for available messages.
+
+## Horizontal Scaling
+
+If work is independent:
+
+```text
+1 worker  -> 100 msg/s
+3 workers -> ~300 msg/s
+6 workers -> ~600 msg/s
+```
+
+Real scaling is rarely perfectly linear, but the model is straightforward.
+
+## At-Least-Once Delivery
+
+A worker may process a message successfully and crash before acknowledging it.
+
+The broker may deliver it again.
+
+Therefore:
+
+```text
+same message
+can arrive more than once
+```
+
+This is normal.
+
+Idempotent Consumer becomes essential.
+
+## Ordering Trade-Off
+
+Parallelism conflicts with strict ordering.
+
+If:
+
+```text
+Message A
+Message B
+Message C
+```
+
+must be processed in exactly that order, unrestricted competing consumers may violate the requirement.
+
+Partition or session by business key:
+
+```text
+Order 42 -> partition X
+Order 43 -> partition Y
+```
+
+Now different orders process concurrently while preserving per-order sequencing.
+
+## Work Item Identity
+
+Every message should carry stable identity:
+
+```csharp
+public sealed record ProcessShipment(
+    Guid MessageId,
+    Guid ShipmentId);
+```
+
+The identity supports deduplication, tracing, and diagnosis.
+
+## Visibility / Lock Duration
+
+Many brokers temporarily hide or lock a message while a consumer processes it.
+
+If processing exceeds the lock duration:
+
+```text
+worker still processing
+broker thinks lease expired
+message delivered again
+```
+
+Long-running handlers must renew locks or redesign work into smaller units.
+
+## Poison Messages
+
+Some messages fail every time:
+
+```text
+invalid payload
+unsupported version
+missing required reference
+permanent business rejection
+```
+
+Retrying forever wastes capacity.
+
+After a bounded number of attempts, move them to a Dead Letter Queue.
+
+## Concurrency Limits
+
+More workers are not always better.
+
+Downstream systems may have finite capacity.
+
+```text
+100 workers
+   |
+   v
+database melts
+```
+
+Use bounded concurrency based on measured downstream capacity.
+
+## Backpressure
+
+A queue itself provides a form of backpressure.
+
+Producers can continue briefly while consumers lag.
+
+But queue depth is not infinite.
+
+Monitor:
+
+```text
+depth
+oldest-message age
+ingress rate
+egress rate
+```
+
+Queue-Based Load Leveling builds on this idea directly.
+
+## Idempotent Handler
+
+A handler should tolerate duplicate delivery.
+
+```csharp
+if (await inbox.HasProcessedAsync(
+    message.MessageId,
+    cancellationToken))
+{
+    return;
+}
+```
+
+Then perform work and persist deduplication state atomically where possible.
+
+We will cover Inbox / Idempotent Consumer in depth shortly.
+
+## Worker Services in .NET
+
+A modern .NET worker can run as a hosted service:
+
+```csharp
+public sealed class ShipmentWorker(
+    IMessageReceiver receiver)
+    : BackgroundService
+{
+    protected override async Task ExecuteAsync(
+        CancellationToken stoppingToken)
+    {
+        await foreach (var message in receiver.ReadAllAsync(
+            stoppingToken))
+        {
+            await HandleAsync(message, stoppingToken);
+        }
+    }
+}
+```
+
+The transport specifics depend on the broker.
+
+The architectural pattern does not.
+
+## Observability
+
+Measure:
+
+```text
+queue depth
+consumer count
+processing latency
+success/failure rate
+retry rate
+dead-letter rate
+oldest-message age
+```
+
+Throughput without latency visibility is misleading.
+
+## Autoscaling
+
+Competing Consumers works naturally with queue-based autoscaling.
+
+For example:
+
+```text
+if queue depth rises:
+    add workers
+
+if queue drains:
+    remove workers
+```
+
+Scale carefully to avoid stampedes against downstream systems.
+
+## Testing
+
+Test:
+
+```text
+multiple workers do not double-commit one message
+duplicate delivery is safe
+poison messages dead-letter
+ordering guarantees hold where required
+shutdown does not abandon work incorrectly
+```
+
+## When It Helps
+
+Use Competing Consumers when:
+
+- queued work is independently processable;
+- throughput needs horizontal scale;
+- asynchronous latency is acceptable;
+- one worker is a bottleneck.
+
+## When It Hurts
+
+It hurts when:
+
+- strict global ordering is required;
+- handlers are not idempotent;
+- downstream systems cannot absorb parallelism;
+- work items contend on the same shared resource.
+
+## Summary
+
+Competing Consumers turns one queue into a scalable pool of workers.
+
+The gain is throughput and elasticity.
+
+The cost is distributed concurrency: duplicate delivery, ordering boundaries, poison messages, lease behavior, and downstream pressure must all be designed deliberately.

--- a/src/posts/2030-02-10-transactional-outbox.md
+++ b/src/posts/2030-02-10-transactional-outbox.md
@@ -1,0 +1,371 @@
+---
+author: Steve Kaschimer
+date: 2030-02-10
+image: /images/posts/2030-02-10-hero.webp
+image_alt: "A sealed box glyph positioned directly beside a ledger entry mark, both stamped together in one motion."
+image_prompt: "A dark-mode technical editorial illustration on a near-black background with electric teal, amber, and off-white accents. Composition centers on a small sealed amber box glyph positioned directly beside a teal ledger-entry mark, both enclosed by one shared off-white stamp outline, implying a business change and its outbound message committed together in one atomic step. Mood is atomic and reliable. Avoid: vendor logos, brand colors, circuit-board textures, gears, or generic clip art as the dominant motif."
+layout: post.njk
+site_title: Tech Notes
+summary: "Persist integration messages in the same local transaction as business state, then publish them asynchronously with at-least-once delivery and observable retry semantics."
+tags: ["dotnet", "architecture", "design-patterns", "reliability"]
+title: "Transactional Outbox: Making Database Changes and Events Reliable"
+---
+
+One of the most dangerous distributed-system bugs fits in six lines:
+
+```csharp
+db.Orders.Add(order);
+
+await db.SaveChangesAsync(cancellationToken);
+
+await messageBus.PublishAsync(
+    new OrderPlacedIntegrationEvent(...),
+    cancellationToken);
+```
+
+The database write and message publish are two independent operations.
+
+## The Dual-Write Problem
+
+Failure scenario A:
+
+```text
+DB commit succeeds
+Message publish fails
+```
+
+The order exists.
+
+Nobody hears about it.
+
+Failure scenario B:
+
+```text
+Message publish succeeds
+DB commit fails
+```
+
+Consumers react to an order that does not exist.
+
+A local database transaction cannot atomically commit both a relational database and an external broker.
+
+## The Outbox Idea
+
+Write the business state and outbound message into the same database transaction.
+
+```text
+BEGIN TRANSACTION
+
+INSERT Order
+
+INSERT OutboxMessage
+
+COMMIT
+```
+
+Then a separate dispatcher publishes Outbox rows to the broker.
+
+## Outbox Table
+
+Conceptually:
+
+```text
+OutboxMessages
+--------------------------------
+Id
+OccurredAt
+Type
+Payload
+PublishedAt
+AttemptCount
+LastError
+```
+
+The important fact is that the Outbox row is persisted atomically with the business change.
+
+## EF Core Example
+
+```csharp
+order.Place();
+
+db.Orders.Add(order);
+
+db.OutboxMessages.Add(
+    OutboxMessage.Create(
+        new OrderPlacedIntegrationEvent(
+            Guid.NewGuid(),
+            order.Id.Value,
+            order.CustomerId.Value,
+            order.Total.Amount,
+            order.Total.Currency.Code,
+            timeProvider.GetUtcNow())));
+
+await db.SaveChangesAsync(cancellationToken);
+```
+
+EF Core commits both rows together.
+
+No broker call occurs inside the transaction.
+
+## Dispatcher
+
+A background process polls unpublished rows:
+
+```text
+SELECT pending outbox rows
+       |
+publish
+       |
+mark published
+```
+
+Example shape:
+
+```csharp
+public sealed class OutboxPublisher(
+    OrdersDbContext db,
+    IMessageBus bus)
+{
+    public async Task PublishBatchAsync(
+        CancellationToken cancellationToken)
+    {
+        var messages = await db.OutboxMessages
+            .Where(x => x.PublishedAt == null)
+            .OrderBy(x => x.OccurredAt)
+            .Take(100)
+            .ToListAsync(cancellationToken);
+
+        foreach (var message in messages)
+        {
+            await bus.PublishAsync(
+                message.ToEnvelope(),
+                cancellationToken);
+
+            message.MarkPublished(
+                DateTimeOffset.UtcNow);
+        }
+
+        await db.SaveChangesAsync(cancellationToken);
+    }
+}
+```
+
+This is simplified.
+
+Production implementations need stronger concurrency and retry handling.
+
+## At-Least-Once Publication
+
+A subtle failure remains:
+
+```text
+publish succeeds
+dispatcher crashes
+before marking row published
+```
+
+On restart, the same message may publish again.
+
+Therefore Outbox usually provides:
+
+```text
+at-least-once publication
+```
+
+not magical exactly-once delivery.
+
+Consumers must be idempotent.
+
+## Why Not Mark Published First?
+
+If we mark before publishing:
+
+```text
+mark published
+crash
+message never sent
+```
+
+We traded duplication for message loss.
+
+For most business integrations, duplicate-tolerant at-least-once delivery is safer.
+
+## Polling Concurrency
+
+Multiple dispatcher instances may run simultaneously.
+
+Avoid having all of them publish the same row at once.
+
+Strategies include:
+
+- row locking;
+- skip-locked reads;
+- leasing;
+- status transitions;
+- partitioning.
+
+The exact solution is database-specific.
+
+## Ordering
+
+If event order matters for one aggregate:
+
+```text
+OrderCreated
+OrderPaid
+OrderShipped
+```
+
+the dispatcher and broker must preserve the required ordering boundary.
+
+A common approach is to publish with an aggregate/order ID as partition or session key.
+
+Do not assume table order equals distributed processing order.
+
+## Outbox Payload
+
+Options include storing:
+
+```text
+serialized integration event
+```
+
+or:
+
+```text
+event type + structured columns + payload
+```
+
+Store enough information to publish independently of the original aggregate.
+
+The dispatcher should not need to reload domain state to recreate the event later.
+
+## Event Creation Timing
+
+An important sequence:
+
+```text
+domain changes
+domain event raised
+application translates to integration event
+outbox row stored
+same commit
+```
+
+The integration event should represent committed intent, but publication can occur later.
+
+## Cleanup
+
+Outbox tables grow forever unless cleaned.
+
+Use retention:
+
+```text
+delete published rows older than N days
+archive if audit requirements exist
+```
+
+Do cleanup in batches to avoid giant delete transactions.
+
+## Observability
+
+Measure:
+
+```text
+pending outbox count
+oldest pending age
+publish attempts
+publish failures
+dispatcher throughput
+duplicate publication rate
+```
+
+The most important metric is often **oldest unpublished message age**.
+
+A dispatcher that is quietly stuck is an integration outage.
+
+## Transactions and External Calls
+
+Do not keep the database transaction open while calling the broker.
+
+That defeats the pattern and increases lock duration.
+
+The whole point is:
+
+```text
+commit locally first
+publish asynchronously later
+```
+
+## Outbox and CQRS
+
+With separate read stores:
+
+```text
+Write DB
+  |
+Outbox
+  |
+Broker
+  |
+Projection
+  |
+Read DB
+```
+
+Outbox provides the reliable bridge.
+
+This is why CQRS often leads to Outbox once read/write stores separate.
+
+## Testing
+
+Important tests:
+
+```text
+business row and outbox row commit together
+rollback removes both
+dispatcher publishes pending row
+publisher crash can cause duplicate but not loss
+duplicate message is safe downstream
+cleanup removes only old published rows
+```
+
+## When It Helps
+
+Use Transactional Outbox when:
+
+- business state and message publication must not diverge;
+- one local database transaction cannot include the broker;
+- asynchronous integration is important;
+- message loss would be harmful.
+
+## When It Hurts
+
+It adds:
+
+- storage;
+- polling/CDC machinery;
+- duplicate delivery;
+- cleanup;
+- monitoring;
+- operational latency.
+
+Do not add it when there is no dual-write problem.
+
+## Summary
+
+Transactional Outbox solves one specific reliability gap:
+
+```text
+database commit
++
+message publication
+```
+
+cannot usually be one distributed atomic transaction.
+
+Persist the outbound message with the business state, publish it later, and accept at-least-once delivery explicitly.
+
+Outbox gives you reliable publication.
+
+Idempotent Consumer gives you safe reception.

--- a/src/posts/2030-02-17-inbox-idempotent-consumer.md
+++ b/src/posts/2030-02-17-inbox-idempotent-consumer.md
@@ -1,0 +1,293 @@
+---
+author: Steve Kaschimer
+date: 2030-02-17
+image: /images/posts/2030-02-17-hero.webp
+image_alt: "An inbox tray glyph holding one item stamped processed, with a duplicate copy fading beside it, ignored."
+image_prompt: "A dark-mode technical editorial illustration on a near-black background with electric teal, amber, and off-white accents. Composition centers on a single teal inbox-tray glyph holding one solid amber item stamped with a small checkmark, beside which a faint duplicate outline of the same item fades into the background, implying a repeated delivery recognized and safely ignored. Mood is tolerant and safe. Avoid: vendor logos, brand colors, circuit-board textures, gears, or generic clip art as the dominant motif."
+layout: post.njk
+site_title: Tech Notes
+summary: "Detect and safely ignore duplicate message deliveries by persisting consumed message identity with business effects in one local transaction."
+tags: ["dotnet", "architecture", "design-patterns", "reliability"]
+title: "Inbox and Idempotent Consumer: Making Duplicate Messages Harmless"
+---
+
+Transactional Outbox deliberately accepts at-least-once publication.
+
+Brokers may also redeliver messages.
+
+Therefore consumers must assume:
+
+> The same logical message can arrive more than once.
+
+Inbox / Idempotent Consumer makes that safe.
+
+## The Duplicate Delivery Problem
+
+```text
+Broker sends Message 42
+Consumer processes it
+Database commits
+ACK is lost
+Broker sends Message 42 again
+```
+
+If the handler is:
+
+```csharp
+account.Credit(100m);
+```
+
+the customer may receive $200.
+
+The broker did not malfunction.
+
+The consumer was not idempotent.
+
+## Inbox Table
+
+Persist processed message IDs:
+
+```text
+InboxMessages
+-------------------------------
+MessageId   UNIQUE
+ProcessedAt
+Handler
+```
+
+Before processing:
+
+```text
+Has MessageId already committed?
+```
+
+If yes, skip.
+
+## The Atomicity Requirement
+
+This is not enough:
+
+```text
+check inbox
+perform business change
+commit business change
+write inbox
+```
+
+A crash between the two commits can repeat the effect.
+
+Instead:
+
+```text
+BEGIN TRANSACTION
+
+INSERT Inbox(MessageId)
+perform business changes
+
+COMMIT
+```
+
+The deduplication marker and business effect commit together.
+
+## EF Core Shape
+
+```csharp
+await using var transaction =
+    await db.Database.BeginTransactionAsync(
+        cancellationToken);
+
+if (await db.InboxMessages.AnyAsync(
+    x => x.MessageId == message.Id,
+    cancellationToken))
+{
+    return;
+}
+
+var order = await db.Orders
+    .SingleAsync(
+        x => x.Id == message.OrderId,
+        cancellationToken);
+
+order.MarkPaymentAuthorized(
+    message.PaymentId);
+
+db.InboxMessages.Add(
+    InboxMessage.Processed(
+        message.Id,
+        timeProvider.GetUtcNow()));
+
+await db.SaveChangesAsync(cancellationToken);
+
+await transaction.CommitAsync(
+    cancellationToken);
+```
+
+Production code should rely on a unique constraint too, because concurrent duplicate deliveries can race.
+
+## Unique Constraint as Final Arbiter
+
+Two consumers can both observe:
+
+```text
+message not yet processed
+```
+
+A unique constraint on `MessageId` ensures only one transaction can commit the inbox marker.
+
+Treat the database as the concurrency arbiter.
+
+## Idempotency by Business Identity
+
+Sometimes you do not need a generic Inbox table.
+
+If the business operation has natural identity:
+
+```text
+PaymentId
+ShipmentId
+ReservationId
+```
+
+the domain/database can enforce uniqueness directly.
+
+For example:
+
+```text
+OrderPayments.PaymentId UNIQUE
+```
+
+A duplicate message attempting to apply the same payment becomes harmless.
+
+This is often stronger than purely technical message deduplication.
+
+## Inbox Retention
+
+Can processed IDs be deleted?
+
+Eventually, maybe.
+
+But once an ID is deleted, an old redelivery can be processed again.
+
+Choose retention based on broker replay windows, business risk, and archival behavior.
+
+For high-value operations, long-lived business uniqueness may be better than short-lived technical dedupe.
+
+## Message Identity vs. Correlation
+
+Do not deduplicate by correlation ID.
+
+One business workflow may legitimately contain many messages sharing the same correlation ID.
+
+Use:
+
+```text
+MessageId
+```
+
+for delivery identity.
+
+Use:
+
+```text
+CorrelationId
+```
+
+for tracing the broader workflow.
+
+## Side Effects Outside the Database
+
+Suppose the consumer:
+
+```text
+writes DB
+sends email
+```
+
+The Inbox transaction can protect the DB effect.
+
+It cannot atomically protect an external email provider.
+
+Options include:
+
+- make email naturally idempotent;
+- use a separate Outbox for the email command/event;
+- store a durable send record.
+
+Reliable consumers often combine Inbox and Outbox:
+
+```text
+Consume message
+   |
+BEGIN DB transaction
+   |
+Inbox marker
+Business change
+Outbox message
+   |
+COMMIT
+```
+
+This is an extremely powerful pattern composition.
+
+## Poison Messages
+
+Idempotency does not solve permanent failure.
+
+If a valid-but-unprocessable message fails every attempt, it may need dead-letter handling.
+
+That is the next topic.
+
+## Observability
+
+Track:
+
+```text
+duplicate messages skipped
+inbox insert conflicts
+processing latency
+failed processing
+oldest unprocessed message
+replay events
+```
+
+A spike in duplicates may indicate broker retries, worker crashes, or acknowledgement problems.
+
+## Testing
+
+Test:
+
+```text
+same MessageId twice -> one effect
+two concurrent duplicates -> one effect
+business failure -> inbox marker not committed
+success + outbox side effect -> both commit
+```
+
+Use a real database for concurrency tests.
+
+## When It Helps
+
+Use Inbox / Idempotent Consumer when:
+
+- delivery is at least once;
+- duplicate effects are harmful;
+- consumers update local durable state;
+- message replay is possible.
+
+## When It Hurts
+
+Do not create a giant dedupe subsystem when operations are naturally idempotent already.
+
+Prefer business uniqueness where available.
+
+## Summary
+
+At-least-once delivery moves responsibility to the consumer:
+
+duplicates must be safe.
+
+Persist message identity in the same local transaction as the business effect, enforce uniqueness atomically, and prefer business-level identities when they provide stronger guarantees.
+
+Outbox prevents message loss.
+
+Inbox prevents duplicate effects.

--- a/src/posts/2030-02-24-dead-letter-queue.md
+++ b/src/posts/2030-02-24-dead-letter-queue.md
@@ -1,0 +1,258 @@
+---
+author: Steve Kaschimer
+date: 2030-02-24
+image: /images/posts/2030-02-24-hero.webp
+image_alt: "A small quarantine box positioned off the main queue line, holding one flagged item apart from the flowing stream."
+image_prompt: "A dark-mode technical editorial illustration on a near-black background with electric teal, amber, and off-white accents. Composition centers on a horizontal teal queue line flowing left to right, with one small amber quarantine box positioned just off the line holding a single flagged item marked with a small warning notch, implying a message set apart from healthy flow rather than blocking it. Mood is isolating and diagnostic. Avoid: vendor logos, brand colors, circuit-board textures, gears, or generic clip art as the dominant motif."
+layout: post.njk
+site_title: Tech Notes
+summary: "Quarantine permanently failing messages after bounded retries, preserve diagnostics and replayability, and avoid turning dead-letter queues into invisible data graveyards."
+tags: ["dotnet", "architecture", "design-patterns", "messaging"]
+title: "Dead Letter Queue: What To Do With Messages That Never Succeed"
+---
+
+Retries assume failure may be temporary.
+
+Some failures are not.
+
+```text
+Malformed payload
+Unknown contract version
+Missing required reference
+Permanent business rejection
+Poison data
+```
+
+Retrying forever wastes capacity and can block healthier work.
+
+A Dead Letter Queue isolates messages that cannot currently be processed.
+
+## The Pattern
+
+```text
+Main Queue
+   |
+Consumer
+   |
+retry N times
+   |
+still failing?
+   |
+   v
+Dead Letter Queue
+```
+
+The message is removed from the normal processing path and preserved for investigation.
+
+## Bounded Retry
+
+Dead-letter handling depends on a bounded retry policy.
+
+```text
+Attempt 1
+Attempt 2
+Attempt 3
+Dead-letter
+```
+
+The exact number should reflect:
+
+- failure type;
+- retry delay;
+- business urgency;
+- downstream recovery expectations.
+
+Do not use "10 retries" because it sounds robust.
+
+## Preserve Context
+
+A dead-lettered message should retain:
+
+```text
+original message ID
+payload
+headers
+correlation ID
+failure reason
+attempt count
+first failure time
+last failure time
+```
+
+Without context, operators cannot diagnose or replay safely.
+
+## Classify Failures
+
+Useful categories:
+
+```text
+Transient
+Permanent
+Contract
+Data
+Authorization
+Unknown
+```
+
+Some failures should dead-letter immediately.
+
+For example:
+
+```text
+unsupported schema version
+```
+
+may never succeed through retry.
+
+## Do Not Swallow Poison Messages
+
+This is dangerous:
+
+```csharp
+catch (Exception ex)
+{
+    logger.LogError(ex, "Failed");
+    return;
+}
+```
+
+If the broker interprets that as success, the message disappears.
+
+Failure semantics must match the transport.
+
+## Dead Letter Is Not Success
+
+Moving a message to a DLQ means:
+
+```text
+normal processing gave up
+```
+
+not:
+
+```text
+business process succeeded
+```
+
+Alerting and workflow state may need to reflect that distinction.
+
+## Operational Workflow
+
+A DLQ needs a human or automated recovery process.
+
+```text
+Detect
+Diagnose
+Fix root cause
+Replay or discard
+Verify outcome
+```
+
+If no one owns that workflow, the DLQ becomes a quiet data graveyard.
+
+## Replay
+
+Replay can be dangerous.
+
+If the original consumer is not idempotent:
+
+```text
+replay
+```
+
+may duplicate effects.
+
+Inbox / Idempotent Consumer makes replay much safer.
+
+## Replay After Contract Fix
+
+A common scenario:
+
+```text
+new event version arrives
+consumer cannot parse
+message dead-letters
+consumer updated
+messages replayed
+```
+
+This is one reason preserving the original payload and metadata matters.
+
+## DLQ Metrics
+
+Measure:
+
+```text
+dead-letter count
+rate of new dead letters
+oldest dead-letter age
+top failure reason
+top message type
+replay success/failure
+```
+
+Alert on growth, not just total size.
+
+## Automated Reprocessing
+
+Some failures can be retried later automatically.
+
+For example:
+
+```text
+dependency unavailable for hours
+```
+
+A scheduled replay process may requeue selected messages after the dependency recovers.
+
+Be careful to avoid endless loops between main queue and DLQ.
+
+## Security and Privacy
+
+Dead-letter payloads may contain sensitive data.
+
+Apply:
+
+- access controls;
+- retention policies;
+- encryption;
+- redaction in logs.
+
+Do not dump complete message payloads into general-purpose logging.
+
+## Testing
+
+Test:
+
+```text
+transient failure retries
+permanent failure dead-letters
+dead-letter preserves metadata
+replay succeeds after fix
+replayed duplicate remains safe
+```
+
+## When It Helps
+
+Use a DLQ when asynchronous work must continue even when individual messages are unprocessable.
+
+## When It Hurts
+
+It hurts when it becomes:
+
+```text
+catch-all error bucket
+no alerts
+no ownership
+no replay plan
+```
+
+A DLQ without operations is delayed data loss.
+
+## Summary
+
+Dead Letter Queue protects the healthy message stream from poison work while preserving failed messages for diagnosis and recovery.
+
+The pattern is only complete when someone owns the dead-letter lifecycle.
+
+Quarantine is not resolution.

--- a/src/posts/2030-03-03-queue-based-load-leveling.md
+++ b/src/posts/2030-03-03-queue-based-load-leveling.md
@@ -1,0 +1,277 @@
+---
+author: Steve Kaschimer
+date: 2030-03-03
+image: /images/posts/2030-03-03-hero.webp
+image_alt: "A wide funnel narrowing down into a single steady-width stream."
+image_prompt: "A dark-mode technical editorial illustration on a near-black background with electric teal, amber, and off-white accents. Composition centers on a wide amber funnel glyph at the top narrowing smoothly down into a single steady-width teal stream at the bottom, implying a bursty arrival smoothed into a sustainable, level flow. Mood is absorbing and steady. Avoid: vendor logos, brand colors, circuit-board textures, gears, or generic clip art as the dominant motif."
+layout: post.njk
+site_title: Tech Notes
+summary: "Use a queue as a buffer between bursty producers and capacity-limited consumers so work is smoothed over time and downstream systems remain stable."
+tags: ["dotnet", "architecture", "design-patterns", "messaging"]
+title: "Queue-Based Load Leveling: Absorbing Bursts Without Crushing Dependencies"
+---
+
+Traffic rarely arrives at a perfectly steady rate.
+
+A service may normally receive:
+
+```text
+100 requests/sec
+```
+
+then suddenly receive:
+
+```text
+5,000 requests/sec
+```
+
+If every request immediately hits the same database or downstream service, the burst can cause cascading failure.
+
+Queue-Based Load Leveling inserts a buffer.
+
+## The Pattern
+
+```text
+Bursty Producer
+      |
+      v
+     Queue
+      |
+      v
+Steady Consumers
+      |
+      v
+Downstream System
+```
+
+The queue absorbs temporary imbalance between arrival rate and processing capacity.
+
+## The Goal Is Smoothing, Not Speed
+
+Suppose the database safely handles:
+
+```text
+500 writes/sec
+```
+
+A burst creates:
+
+```text
+2,000 writes/sec
+```
+
+Without buffering:
+
+```text
+database overload
+timeouts
+retries
+more load
+collapse
+```
+
+With a queue:
+
+```text
+2,000/sec arrive briefly
+500/sec process steadily
+backlog drains later
+```
+
+Latency increases.
+
+Stability improves.
+
+## Asynchronous Contract
+
+The client can no longer necessarily receive the final result synchronously.
+
+Instead:
+
+```text
+202 Accepted
+operation ID
+```
+
+and later:
+
+```text
+GET /operations/{id}
+```
+
+or notification when complete.
+
+Architecture changes product semantics.
+
+## Queue Depth as Pressure
+
+The queue provides a visible pressure signal.
+
+Track:
+
+```text
+depth
+oldest-message age
+arrival rate
+processing rate
+```
+
+If depth grows indefinitely, the queue is hiding insufficient capacity rather than solving it.
+
+## Competing Consumers
+
+Load leveling pairs naturally with Competing Consumers.
+
+```text
+Queue
+  |
+  +--> Worker
+  +--> Worker
+  +--> Worker
+```
+
+Scale worker count until downstream capacity is reached.
+
+Do not blindly autoscale past the bottleneck.
+
+## Rate-Limited Dependency
+
+Suppose a vendor allows:
+
+```text
+100 requests/minute
+```
+
+A queue can buffer work while consumers honor that rate.
+
+The queue becomes a shock absorber between your traffic and the vendor's capacity.
+
+## Ordering
+
+If strict ordering matters, queue partitioning may constrain concurrency.
+
+```text
+all messages for Account 42
+must process in order
+```
+
+That may reduce throughput.
+
+Choose the partition key around the true ordering requirement.
+
+## Backlog Expiration
+
+Some work becomes useless if delayed too long.
+
+For example:
+
+```text
+recalculate live quote
+```
+
+after 30 minutes may no longer matter.
+
+Use TTL or expiration policies where stale work should be discarded.
+
+## Queue Is Not Infinite Storage
+
+Queues have quotas and operational limits.
+
+A prolonged downstream outage can fill the buffer.
+
+Plan for:
+
+- maximum backlog;
+- overflow behavior;
+- producer throttling;
+- dead-letter policy;
+- capacity alarms.
+
+## Producer Acknowledgement
+
+Be precise about what "accepted" means.
+
+If the producer receives success only after the message is durably enqueued:
+
+```text
+accepted for processing
+```
+
+not:
+
+```text
+business operation completed
+```
+
+That distinction should be explicit in the API.
+
+## Retry Storm Prevention
+
+Without a queue:
+
+```text
+dependency overloaded
+requests timeout
+clients retry
+dependency gets more overloaded
+```
+
+A queue can absorb retries at the boundary and let consumers pace work.
+
+It is not a substitute for idempotency.
+
+Duplicate enqueue still needs safe handling.
+
+## Observability
+
+Measure:
+
+```text
+enqueue latency
+queue depth
+oldest age
+consumer throughput
+success rate
+dead-letter rate
+downstream latency
+```
+
+Oldest-message age is often more meaningful than raw depth because message cost varies.
+
+## Testing
+
+Test:
+
+```text
+burst does not exceed downstream concurrency
+backlog drains
+messages survive worker restart
+expired work behaves correctly
+duplicate delivery is safe
+```
+
+## When It Helps
+
+Use Queue-Based Load Leveling when:
+
+- producers are bursty;
+- downstream capacity is limited;
+- work can be asynchronous;
+- temporary delay is preferable to overload.
+
+## When It Hurts
+
+It hurts when:
+
+- the operation must be synchronous;
+- queue delay violates product requirements;
+- backlog is unbounded;
+- teams use queues to hide chronic under-capacity.
+
+## Summary
+
+Queue-Based Load Leveling trades immediate completion for stability.
+
+A queue absorbs bursts and lets consumers process work at a sustainable rate.
+
+The pattern works best when the system explicitly embraces asynchronous completion and monitors backlog as a first-class operational signal.

--- a/src/posts/2030-03-10-event-sourcing.md
+++ b/src/posts/2030-03-10-event-sourcing.md
@@ -1,0 +1,402 @@
+---
+author: Steve Kaschimer
+date: 2030-03-10
+image: /images/posts/2030-03-10-hero.webp
+image_alt: "A horizontal sequence of small marks forming a timeline, with a single reconstructed shape assembling at its end."
+image_prompt: "A dark-mode technical editorial illustration on a near-black background with electric teal, amber, and off-white accents. Composition centers on a horizontal row of five small amber marks forming a timeline left to right, with one solid teal shape assembling out of faint ghost fragments at the row's right end, implying current state built by replaying a history of facts. Mood is historical and reconstructive. Avoid: vendor logos, brand colors, circuit-board textures, gears, or generic clip art as the dominant motif."
+layout: post.njk
+site_title: Tech Notes
+summary: "Persist domain changes as an append-only stream of events, rebuild state through replay, and understand projections, snapshots, schema evolution, concurrency, and why most systems should not adopt Event Sourcing casually."
+tags: ["dotnet", "architecture", "design-patterns", "event-sourcing"]
+title: "Event Sourcing: Persisting Facts Instead of Current State"
+---
+
+Most applications persist current state.
+
+```text
+Orders
+----------------
+Id
+Status = Shipped
+Total = 125.00
+```
+
+Event Sourcing persists the sequence of facts that produced that state.
+
+```text
+OrderCreated
+ItemAdded
+PaymentAuthorized
+OrderConfirmed
+OrderShipped
+```
+
+Current state becomes a projection of history.
+
+This is a profound architectural shift.
+
+## State-Based Persistence
+
+Traditional persistence says:
+
+```text
+What is true now?
+```
+
+Event Sourcing says:
+
+```text
+What happened?
+```
+
+The event stream is the source of truth.
+
+## Aggregate Stream
+
+For one aggregate:
+
+```text
+Order-42
+
+1 OrderCreated
+2 ItemAdded
+3 ItemAdded
+4 PaymentAuthorized
+5 OrderPlaced
+```
+
+Replaying the stream reconstructs Order 42.
+
+## Event-Sourced Aggregate
+
+```csharp
+public sealed class Order
+{
+    public OrderStatus Status { get; private set; }
+
+    public void Place()
+    {
+        if (Status != OrderStatus.Draft)
+            throw new DomainException(...);
+
+        Raise(new OrderPlaced(...));
+    }
+
+    private void Apply(OrderPlaced @event)
+    {
+        Status = OrderStatus.Placed;
+    }
+}
+```
+
+The important distinction:
+
+```text
+Raise event
+then apply event
+```
+
+All state changes occur through event application.
+
+## Rehydration
+
+```csharp
+public static Order Rehydrate(
+    IEnumerable<IDomainEvent> events)
+{
+    var order = new Order();
+
+    foreach (var @event in events)
+    {
+        order.Apply(@event);
+    }
+
+    return order;
+}
+```
+
+The aggregate can be rebuilt from its history.
+
+## Append-Only Store
+
+The event store writes:
+
+```text
+StreamId
+Version
+EventId
+EventType
+Payload
+OccurredAt
+Metadata
+```
+
+Events are appended.
+
+Existing events are not normally updated.
+
+## Optimistic Concurrency
+
+Suppose the stream version is 7.
+
+Client A and B both load version 7.
+
+A appends version 8.
+
+B tries to append with expected version 7.
+
+The store rejects it.
+
+Event streams therefore provide a natural optimistic concurrency boundary.
+
+## CQRS Partnership
+
+Event Sourcing and CQRS often pair well:
+
+```text
+Event Store
+   |
+   +--> Order Summary Projection
+   +--> Finance Projection
+   +--> Search Projection
+```
+
+Write-side events feed specialized read models.
+
+But:
+
+```text
+CQRS does not require Event Sourcing.
+Event Sourcing does not require separate read databases.
+```
+
+Keep the patterns conceptually separate.
+
+## Projection
+
+A projection transforms event history into queryable state.
+
+```csharp
+public Task HandleAsync(
+    OrderPlaced @event)
+{
+    // update OrderSummary row
+}
+```
+
+Projections are disposable if they can be rebuilt from the event log.
+
+That can be powerful.
+
+It also means projection rebuilds must be operationally feasible.
+
+## Eventual Consistency
+
+Read models often lag behind newly appended events.
+
+```text
+append event ✓
+projection update pending
+query returns old value
+```
+
+This is a product and UX concern, not just implementation detail.
+
+## Snapshots
+
+Long streams can be expensive to replay.
+
+A snapshot stores:
+
+```text
+state at version 10,000
+```
+
+Then rehydration loads:
+
+```text
+snapshot
++ events 10,001 onward
+```
+
+Snapshots are optimization.
+
+The event stream remains the authoritative history.
+
+## Event Schema Evolution
+
+Events live forever.
+
+That means today's code may need to read events written years ago.
+
+Options include:
+
+- upcasters;
+- tolerant readers;
+- versioned event types;
+- migration.
+
+This is one of Event Sourcing's largest long-term costs.
+
+## Never Rewrite History Casually
+
+If an event contains incorrect business data, replacing history can destroy audit meaning.
+
+Often the right approach is a compensating/corrective event:
+
+```text
+CustomerAddressCorrected
+```
+
+not editing the original fact.
+
+Regulatory or privacy requirements may complicate this and require special treatment.
+
+## Event Sourcing Is Not Audit Logging
+
+An audit log says:
+
+```text
+who changed what
+```
+
+Event Sourcing says:
+
+```text
+domain state is derived from this event stream
+```
+
+You can have audit logging without Event Sourcing.
+
+Most systems should.
+
+## Event Sourcing Is Not "Use Kafka"
+
+Kafka can store event streams.
+
+That does not automatically make your domain event-sourced.
+
+Event Sourcing is about the persistence model of domain state.
+
+## Benefits
+
+Event Sourcing can provide:
+
+- complete business history;
+- temporal queries;
+- new projections from old events;
+- explicit behavior transitions;
+- strong auditability;
+- natural optimistic concurrency.
+
+## Costs
+
+It also introduces:
+
+- event schema evolution;
+- projection infrastructure;
+- eventual consistency;
+- replay operations;
+- debugging complexity;
+- tooling requirements;
+- irreversible contract mistakes.
+
+These costs are substantial.
+
+## Good Fits
+
+Event Sourcing shines in domains where history itself is valuable:
+
+```text
+financial ledger
+trading
+workflow history
+inventory movements
+audit-heavy systems
+complex temporal rules
+```
+
+## Poor Fits
+
+A settings screen where users edit:
+
+```text
+DisplayName
+Theme
+PageSize
+```
+
+probably does not need an immutable event log and projection infrastructure.
+
+Do not confuse architectural sophistication with suitability.
+
+## Testing
+
+Event-sourced aggregates are beautifully testable:
+
+```text
+Given:
+  OrderCreated
+  ItemAdded
+
+When:
+  PlaceOrder
+
+Then:
+  OrderPlaced
+```
+
+The test describes behavior as history -> command -> new facts.
+
+Also test projection rebuilds and event compatibility.
+
+## Observability
+
+Monitor:
+
+```text
+append failures
+stream conflicts
+projection lag
+projection failures
+rebuild progress
+unknown event types
+```
+
+Projection lag should have SLOs if user-facing freshness matters.
+
+## When It Helps
+
+Use Event Sourcing when:
+
+- business history is first-class;
+- temporal reconstruction matters;
+- multiple projections provide major value;
+- append-only semantics fit the domain;
+- the team can operate the infrastructure.
+
+## When It Hurts
+
+It hurts when adopted because:
+
+```text
+"events are modern"
+```
+
+or:
+
+```text
+"we might need audit later"
+```
+
+The complexity is too high for speculative benefit.
+
+## Summary
+
+Event Sourcing makes historical facts the source of truth.
+
+That unlocks remarkable capabilities: replay, temporal reasoning, new projections, and auditability.
+
+It also makes event contracts, projection infrastructure, eventual consistency, and operational tooling part of your permanent architecture.
+
+Use it when history is part of the domain—not merely because events are fashionable.

--- a/src/posts/2030-03-17-saga.md
+++ b/src/posts/2030-03-17-saga.md
@@ -1,0 +1,425 @@
+---
+author: Steve Kaschimer
+date: 2030-03-17
+image: /images/posts/2030-03-17-hero.webp
+image_alt: "A chain of connected step nodes with one broken link and a looping arrow reaching back toward earlier links."
+image_prompt: "A dark-mode technical editorial illustration on a near-black background with electric teal, amber, and off-white accents. Composition centers on a horizontal chain of four teal step nodes connected by links, with the third link rendered broken in amber and a curved off-white arrow looping back from that break toward the earlier nodes, implying a workflow coordinating recovery across independent local steps. Mood is coordinated and resilient. Avoid: vendor logos, brand colors, circuit-board textures, gears, or generic clip art as the dominant motif."
+layout: post.njk
+site_title: Tech Notes
+summary: "Coordinate long-running business workflows across independently committed services using choreography or orchestration, explicit state, idempotency, timeouts, and compensating actions."
+tags: ["dotnet", "architecture", "design-patterns", "distributed-systems"]
+title: "Saga: Coordinating a Business Transaction Across Services"
+---
+
+A local database transaction gives us a wonderfully simple promise:
+
+```text
+BEGIN
+change A
+change B
+change C
+COMMIT
+```
+
+Either everything commits or nothing does.
+
+Then we split the operation across services.
+
+```text
+Ordering
+Payment
+Inventory
+Shipping
+```
+
+There is no longer one ordinary ACID transaction covering the whole workflow.
+
+A Saga coordinates the sequence of **local transactions** that together implement the business process.
+
+## The Problem
+
+Imagine placing an order requires:
+
+1. creating the order;
+2. reserving inventory;
+3. authorizing payment;
+4. scheduling fulfillment.
+
+```text
+Order
+  |
+  v
+Inventory
+  |
+  v
+Payment
+  |
+  v
+Fulfillment
+```
+
+Any step can fail after earlier steps have already committed.
+
+That is the central problem.
+
+## A Saga Is Not a Distributed Database Transaction
+
+A Saga does not pretend all services commit atomically.
+
+Instead:
+
+```text
+T1 -> T2 -> T3 -> T4
+```
+
+and failures may trigger compensating actions:
+
+```text
+T1 -> T2 -> T3 fails
+          |
+          v
+       C2 -> C1
+```
+
+Each transaction is local.
+
+The overall workflow is coordinated.
+
+## Choreography
+
+With choreography, services react to events.
+
+```text
+OrderPlaced
+    |
+    v
+Inventory reserves
+    |
+InventoryReserved
+    |
+    v
+Payment authorizes
+    |
+PaymentAuthorized
+    |
+    v
+Fulfillment schedules
+```
+
+There is no central workflow controller.
+
+### Advantages
+
+- loose coupling;
+- services react independently;
+- no central orchestrator dependency.
+
+### Costs
+
+- workflow becomes distributed across handlers;
+- understanding the complete process is harder;
+- event chains can become spaghetti;
+- timeout and failure coordination becomes awkward.
+
+Choreography works well for smaller, naturally event-driven workflows.
+
+## Orchestration
+
+With orchestration, a Saga coordinator owns workflow state.
+
+```text
+           Order Saga
+          /    |     \
+         v     v      v
+    Inventory Payment Fulfillment
+```
+
+The orchestrator sends commands and reacts to replies/events.
+
+```text
+ReserveInventory
+       |
+InventoryReserved
+       |
+AuthorizePayment
+       |
+PaymentAuthorized
+       |
+ScheduleFulfillment
+```
+
+The workflow becomes explicit.
+
+## Saga State
+
+A durable orchestrator needs state.
+
+```csharp
+public sealed class PlaceOrderSaga
+{
+    public Guid SagaId { get; init; }
+    public Guid OrderId { get; init; }
+
+    public SagaStatus Status { get; private set; }
+
+    public bool InventoryReserved { get; private set; }
+    public bool PaymentAuthorized { get; private set; }
+}
+```
+
+That state must survive process restarts.
+
+An in-memory state machine is not sufficient for an important long-running workflow.
+
+## State Machine
+
+Think explicitly:
+
+```text
+Started
+   |
+ReserveInventory
+   |
+InventoryReserved
+   |
+AuthorizePayment
+   |
+PaymentAuthorized
+   |
+ScheduleFulfillment
+   |
+Completed
+```
+
+Failure paths matter just as much:
+
+```text
+PaymentDeclined
+   |
+ReleaseInventory
+   |
+Cancelled
+```
+
+A state machine makes legal transitions visible.
+
+## Compensation
+
+Compensation is not database rollback.
+
+If inventory was reserved:
+
+```text
+ReleaseInventory
+```
+
+may compensate.
+
+If payment was captured:
+
+```text
+RefundPayment
+```
+
+may compensate.
+
+But the world moved forward.
+
+There may be fees, notifications, or irreversible external effects.
+
+Compensation is a **new business action** that attempts to restore an acceptable business state.
+
+## Idempotency
+
+Every Saga command and event can be delivered more than once.
+
+Therefore:
+
+```text
+ReserveInventory
+AuthorizePayment
+ReleaseInventory
+RefundPayment
+```
+
+must be idempotent or carry stable operation identity.
+
+A duplicate compensation can be just as dangerous as a duplicate forward action.
+
+## Timeouts
+
+What happens if Payment never replies?
+
+A Saga needs time semantics:
+
+```text
+AuthorizePayment
+      |
+wait 5 minutes
+      |
+timeout
+      |
+ReleaseInventory
+```
+
+Timeout is itself a workflow event.
+
+Persist scheduled timeout state durably rather than relying on an in-process `Task.Delay` for critical workflows.
+
+## Correlation
+
+Every message needs enough identity to find its Saga instance.
+
+```csharp
+public sealed record PaymentAuthorized(
+    Guid MessageId,
+    Guid SagaId,
+    Guid OrderId,
+    Guid PaymentId);
+```
+
+Correlation ID and Saga ID are related concepts, but the Saga ID identifies the workflow instance.
+
+## Outbox + Saga
+
+When the orchestrator updates its state and sends the next command:
+
+```text
+Update Saga state
+Publish command
+```
+
+we have another dual-write problem.
+
+Use Transactional Outbox:
+
+```text
+BEGIN
+update saga
+insert outbox message
+COMMIT
+```
+
+Reliable workflow coordination is pattern composition.
+
+## Inbox + Saga
+
+Replies can duplicate.
+
+Use Inbox/idempotent handling:
+
+```text
+BEGIN
+insert inbox marker
+update saga
+insert next outbox message
+COMMIT
+```
+
+This gives each Saga step a strong local consistency boundary.
+
+## Concurrency
+
+Two events for the same Saga may arrive simultaneously.
+
+Use optimistic concurrency or another serialization strategy.
+
+```text
+Saga version 7
+event A -> version 8
+event B expected 7 -> conflict
+```
+
+Retry B against the new state.
+
+## Observability
+
+A Saga should be inspectable.
+
+Operators should be able to answer:
+
+```text
+Where is Order 42?
+What step is waiting?
+What failed?
+What compensation ran?
+What message IDs were involved?
+How long has it been stuck?
+```
+
+Track workflow duration, failure rate, compensation rate, timeout count, and stuck Saga age.
+
+## Choreography vs. Orchestration
+
+A practical heuristic:
+
+Use choreography when:
+
+- reactions are few;
+- ownership is obvious;
+- no one needs a global workflow view.
+
+Use orchestration when:
+
+- many steps exist;
+- ordering matters;
+- compensations matter;
+- timeouts matter;
+- operators need workflow visibility.
+
+## Testing
+
+Saga tests should read like workflow specifications:
+
+```text
+Given inventory was reserved
+When payment is declined
+Then release inventory
+And mark order cancelled
+```
+
+Also test:
+
+- duplicate replies;
+- out-of-order messages;
+- timeouts;
+- compensation failure;
+- orchestrator restart;
+- optimistic concurrency conflicts.
+
+## When It Helps
+
+Use a Saga when:
+
+- one business process spans transactional boundaries;
+- each participant commits independently;
+- partial failure must be handled explicitly;
+- eventual consistency is acceptable.
+
+## When It Hurts
+
+Do not use Saga to coordinate operations that belong in one local transaction.
+
+A premature service split can turn:
+
+```text
+one transaction
+```
+
+into:
+
+```text
+Saga + broker + outbox + inbox + compensation + monitoring
+```
+
+That is an architectural tax.
+
+## Summary
+
+Saga coordinates a business transaction that no longer fits inside one ACID boundary.
+
+It does not restore global atomicity.
+
+It replaces atomic rollback with explicit workflow state, durable messages, idempotency, timeouts, and compensation.
+
+That is a much more honest model of distributed business processes.

--- a/src/posts/2030-03-24-compensating-transaction.md
+++ b/src/posts/2030-03-24-compensating-transaction.md
@@ -1,0 +1,315 @@
+---
+author: Steve Kaschimer
+date: 2030-03-24
+image: /images/posts/2030-03-24-hero.webp
+image_alt: "One forward arrow followed by a distinct reverse-curling arrow positioned beneath it, not retracing the same path."
+image_prompt: "A dark-mode technical editorial illustration on a near-black background with electric teal, amber, and off-white accents. Composition centers on a single bold teal arrow moving forward across the top of the frame, with a separate amber arrow curling backward beneath it along a visibly different path, implying a new corrective action rather than a literal rewind. Mood is corrective and forward-moving. Avoid: vendor logos, brand colors, circuit-board textures, gears, or generic clip art as the dominant motif."
+layout: post.njk
+site_title: Tech Notes
+summary: "Design semantic undo operations for distributed workflows where committed steps cannot be atomically rolled back, including irreversible effects, compensation ordering, idempotency, and manual recovery."
+tags: ["dotnet", "architecture", "design-patterns", "distributed-systems"]
+title: "Compensating Transaction: Undoing Business Effects Without Rewinding Time"
+---
+
+In a local transaction, rollback means:
+
+```text
+the changes never became visible
+```
+
+In a distributed workflow, earlier steps may already be committed.
+
+You cannot rewind the world.
+
+A Compensating Transaction performs new actions that attempt to restore an acceptable business state.
+
+## Example
+
+An order workflow:
+
+```text
+Reserve inventory ✓
+Capture payment   ✓
+Book shipment     ✗
+```
+
+A database rollback cannot undo the first two services.
+
+Possible compensations:
+
+```text
+Refund payment
+Release inventory
+```
+
+These are real business operations.
+
+## Compensation Is Semantic Undo
+
+Forward action:
+
+```text
+Reserve 3 units
+```
+
+Compensation:
+
+```text
+Release reservation ABC
+```
+
+Not:
+
+```text
+subtract 3 from some database column
+```
+
+The compensation should refer to the original business operation.
+
+Stable operation identity matters.
+
+## Not Everything Is Reversible
+
+Suppose a workflow:
+
+```text
+Send email ✓
+Ship package ✓
+Charge card ✗
+```
+
+You cannot unsend the email.
+
+You may not be able to recall the shipment.
+
+The compensation may instead be:
+
+```text
+notify customer
+intercept shipment if possible
+create manual review
+```
+
+The goal is not perfect reversal.
+
+The goal is a valid business outcome.
+
+## Compensation Order
+
+Often compensation runs in reverse order:
+
+```text
+T1
+T2
+T3
+
+failure
+
+C3
+C2
+C1
+```
+
+But business semantics may require another order.
+
+Do not blindly implement a stack.
+
+For example, a refund might need to occur before releasing a scarce reservation—or vice versa—depending on risk.
+
+## Compensation Can Fail
+
+This is where toy diagrams stop being useful.
+
+```text
+Payment captured
+Shipment failed
+Refund attempted
+Refund failed
+```
+
+Now what?
+
+You need:
+
+- retry;
+- idempotency;
+- escalation;
+- durable workflow state;
+- operator visibility.
+
+Compensation itself is distributed work.
+
+## Idempotent Compensation
+
+A retry must not produce:
+
+```text
+Refund $100
+Refund $100 again
+```
+
+Prefer:
+
+```text
+Refund PaymentId 123
+for CompensationId XYZ
+```
+
+The payment service can recognize the same logical refund.
+
+## Compensation State
+
+Model it explicitly:
+
+```text
+Forward:
+PaymentAuthorized
+
+Compensation:
+RefundRequested
+RefundSucceeded
+RefundFailed
+```
+
+Do not hide recovery in logs.
+
+If the business cares, recovery state belongs in durable workflow state.
+
+## Human Intervention
+
+Some failures cannot be automated safely.
+
+A valid compensation path may be:
+
+```text
+ManualReviewRequired
+```
+
+with enough context for an operator to act.
+
+Human recovery is not architectural failure.
+
+Pretending every business exception can be automated is.
+
+## Compensation and Saga
+
+Saga is the workflow coordination pattern.
+
+Compensating Transaction is one of the mechanisms a Saga may use when a later step fails.
+
+```text
+Saga
+  |
+  +--> forward transactions
+  |
+  +--> compensating transactions
+```
+
+They are related but not synonymous.
+
+## Forward Recovery
+
+Sometimes compensation is worse than continuing.
+
+Suppose:
+
+```text
+Inventory reserved
+Payment authorized
+Shipping scheduler temporarily unavailable
+```
+
+Instead of:
+
+```text
+release inventory
+void payment
+```
+
+the better strategy may be:
+
+```text
+keep retrying shipping
+```
+
+This is **forward recovery**.
+
+Choose between:
+
+```text
+retry forward
+compensate backward
+manual intervention
+```
+
+based on business semantics.
+
+## Audit Trail
+
+Record:
+
+```text
+original operation
+reason for compensation
+compensation operation
+who/what initiated it
+result
+timestamps
+```
+
+Compensations often matter to customers, finance, and compliance.
+
+## Observability
+
+Measure:
+
+```text
+compensation rate
+compensation failures
+average recovery time
+manual interventions
+stuck compensations
+```
+
+A high compensation rate may indicate an unhealthy workflow design or dependency.
+
+## Testing
+
+Test the ugly paths:
+
+```text
+forward step succeeds
+later step fails
+compensation succeeds
+
+compensation times out
+compensation retries
+duplicate compensation arrives
+manual intervention required
+```
+
+The happy path is not where this pattern earns its keep.
+
+## When It Helps
+
+Use compensating transactions when:
+
+- committed distributed effects cannot be rolled back atomically;
+- the business has meaningful corrective actions;
+- workflows must recover from partial success.
+
+## When It Hurts
+
+It hurts when developers invent fake "undo" operations for effects that are actually irreversible.
+
+Model reality.
+
+Sometimes the correct compensation is a new business process, not reversal.
+
+## Summary
+
+Compensating Transaction does not rewind time.
+
+It acknowledges that part of the workflow already happened and performs new, explicit business actions to restore an acceptable state.
+
+That distinction is fundamental to reliable distributed workflows.

--- a/src/posts/2030-03-31-backend-for-frontend.md
+++ b/src/posts/2030-03-31-backend-for-frontend.md
@@ -1,0 +1,334 @@
+---
+author: Steve Kaschimer
+date: 2030-03-31
+image: /images/posts/2030-03-31-hero.webp
+image_alt: "Several distinct client-shaped glyphs, each with its own dedicated funnel, converging toward shared core services."
+image_prompt: "A dark-mode technical editorial illustration on a near-black background with electric teal, amber, and off-white accents. Composition centers on three small distinct client-shaped teal glyphs at the top, each feeding into its own small amber funnel, all three funnels converging toward one shared off-white core-services shape at the bottom, implying tailored boundaries in front of common capability. Mood is tailored and converging. Avoid: vendor logos, brand colors, circuit-board textures, gears, or generic clip art as the dominant motif."
+layout: post.njk
+site_title: Tech Notes
+summary: "Give materially different client experiences their own backend boundary for aggregation, orchestration, security, and client-specific contracts without duplicating core business logic."
+tags: ["dotnet", "architecture", "design-patterns", "api-design"]
+title: "Backend for Frontend: APIs Shaped Around Client Needs"
+---
+
+A mobile app, browser application, partner integration, and smart display may all consume the same business capabilities.
+
+They rarely need the same API shape.
+
+Backend for Frontend—BFF—creates a backend boundary tailored to a specific frontend or client class.
+
+```text
+Web App    -> Web BFF
+Mobile App -> Mobile BFF
+                   |
+                   v
+             Core Services
+```
+
+## The Problem
+
+A universal API often accumulates endpoints like:
+
+```text
+/orders?includeCustomer=true
+       &includeShipment=true
+       &mobile=true
+       &compact=true
+       &version=7
+```
+
+Every client negotiates with the same generic contract.
+
+BFF says:
+
+> Let the client-facing backend speak the client's language.
+
+## Aggregation
+
+A mobile order screen may need data from:
+
+```text
+Orders
+Customers
+Shipping
+Recommendations
+```
+
+Without a BFF, the phone makes four network calls.
+
+With a BFF:
+
+```text
+Mobile
+  |
+GET /home
+  |
+Mobile BFF
+  +--> Orders
+  +--> Customers
+  +--> Shipping
+  +--> Recommendations
+```
+
+The BFF returns one client-oriented model.
+
+## Client-Specific DTOs
+
+```csharp
+public sealed record MobileOrderCard(
+    string OrderNumber,
+    string StatusText,
+    string PrimaryAction,
+    DateTimeOffset? ExpectedDelivery);
+```
+
+This DTO does not need to become a universal enterprise contract.
+
+It exists for the mobile experience.
+
+## Minimal API Example
+
+```csharp
+app.MapGet(
+    "/orders/{id:guid}",
+    async (
+        Guid id,
+        IOrdersClient orders,
+        IShippingClient shipping,
+        CancellationToken ct) =>
+    {
+        var orderTask =
+            orders.GetAsync(id, ct);
+
+        var shippingTask =
+            shipping.GetForOrderAsync(id, ct);
+
+        await Task.WhenAll(
+            orderTask,
+            shippingTask);
+
+        return Results.Ok(
+            MobileOrderDetails.From(
+                await orderTask,
+                await shippingTask));
+    });
+```
+
+The BFF aggregates downstream capabilities.
+
+## What Belongs in a BFF?
+
+Good responsibilities:
+
+- client-specific aggregation;
+- response shaping;
+- authentication/session adaptation;
+- protocol adaptation;
+- coarse orchestration;
+- caching of client-facing reads.
+
+Dangerous responsibilities:
+
+- core pricing rules;
+- inventory invariants;
+- payment policy;
+- domain ownership.
+
+Business logic should remain in the owning domain/service.
+
+## One BFF Per Client?
+
+Not mechanically.
+
+Create separate BFFs when clients have materially different needs.
+
+```text
+Web + tablet
+```
+
+may share one.
+
+```text
+Public partner API
+```
+
+may deserve another.
+
+Do not create five services because there are five screen sizes.
+
+## BFF and API Gateway
+
+They are related but different.
+
+```text
+API Gateway
+  -> cross-cutting edge concerns
+     routing
+     authentication
+     rate limiting
+
+BFF
+  -> client-specific API behavior
+     aggregation
+     shaping
+     orchestration
+```
+
+A request may flow:
+
+```text
+Mobile
+  |
+API Gateway
+  |
+Mobile BFF
+  |
+Services
+```
+
+## BFF and GraphQL
+
+GraphQL can solve some client-specific query-shaping problems.
+
+It does not automatically replace BFF responsibilities such as:
+
+- session handling;
+- client-specific orchestration;
+- protocol translation;
+- backend security policy.
+
+Likewise, a BFF does not require REST.
+
+It can expose GraphQL.
+
+## Failure Handling
+
+Aggregation introduces partial failure.
+
+```text
+Orders succeeds
+Recommendations fails
+```
+
+Should the whole page fail?
+
+Maybe not.
+
+A BFF can define client-specific degradation:
+
+```text
+return order
+omit recommendations
+```
+
+That is a user-experience decision.
+
+## Latency
+
+Aggregation can reduce client round trips while increasing server fan-out.
+
+Parallelize independent calls.
+
+Set timeouts.
+
+Avoid turning the BFF into a sequential waterfall:
+
+```text
+A -> B -> C -> D
+```
+
+Measure the critical path.
+
+## Security
+
+The BFF is often a valuable security boundary.
+
+Browser-based architectures can keep sensitive tokens server-side and use secure cookies between browser and BFF.
+
+But authentication design depends on client type and threat model.
+
+Do not treat "BFF" as a magic security label.
+
+## Ownership
+
+A BFF works best when owned close to the client team.
+
+If every BFF change requires approval from a centralized API team, much of the organizational benefit disappears.
+
+Conway's Law matters.
+
+## Duplication
+
+Some duplication between BFFs is intentional.
+
+Two clients may each map order status differently.
+
+That is fine.
+
+Duplicating **domain logic** is not.
+
+The distinction is:
+
+```text
+presentation/client behavior duplication
+    often acceptable
+
+business invariant duplication
+    dangerous
+```
+
+## Observability
+
+Track:
+
+```text
+client endpoint latency
+downstream fan-out latency
+partial failures
+cache hit rate
+downstream dependency failures
+payload size
+```
+
+Distributed tracing is particularly valuable because one client call may fan out to several services.
+
+## Testing
+
+Test:
+
+```text
+client contract
+aggregation behavior
+partial dependency failure
+authorization
+timeout behavior
+response compatibility
+```
+
+Contract tests with the frontend can be highly valuable.
+
+## When It Helps
+
+Use BFF when:
+
+- clients have materially different API needs;
+- client round trips are expensive;
+- client-specific aggregation is common;
+- teams need independent client-facing evolution.
+
+## When It Hurts
+
+It hurts when:
+
+- every frontend gets a BFF by policy;
+- core business logic moves into BFFs;
+- BFFs become giant monoliths over all services;
+- duplicated client APIs provide no actual benefit.
+
+## Summary
+
+Backend for Frontend creates an API boundary around a client experience.
+
+It gives the frontend a contract designed for its own needs while keeping core business rules in the systems that own them.
+
+Use it to reduce client/backend impedance—not to duplicate the domain.

--- a/src/posts/2030-04-07-api-gateway.md
+++ b/src/posts/2030-04-07-api-gateway.md
@@ -1,0 +1,323 @@
+---
+author: Steve Kaschimer
+date: 2030-04-07
+image: /images/posts/2030-04-07-hero.webp
+image_alt: "A single gate glyph at a boundary line with several distinct lanes fanning out behind it to separate service shapes."
+image_prompt: "A dark-mode technical editorial illustration on a near-black background with electric teal, amber, and off-white accents. Composition centers on one amber gate glyph positioned on a vertical off-white boundary line, with three thin teal lanes fanning out behind it to three small distinct service shapes, implying one deliberate edge in front of many independently deployed services. Mood is centralized and thin. Avoid: vendor logos, brand colors, circuit-board textures, gears, or generic clip art as the dominant motif."
+layout: post.njk
+site_title: Tech Notes
+summary: "Use an API Gateway as a shared edge for routing, authentication, rate limiting, policy, and selective aggregation while avoiding a centralized business-logic bottleneck."
+tags: ["dotnet", "architecture", "design-patterns", "api-design"]
+title: "API Gateway: A Deliberate Edge for Distributed APIs"
+---
+
+Once an application exposes many independently deployed services, clients face a messy question:
+
+```text
+Which service do I call?
+Where do I authenticate?
+How do rate limits work?
+Which host is current?
+```
+
+An API Gateway creates a deliberate external edge.
+
+```text
+Clients
+   |
+   v
+API Gateway
+   |
+   +--> Orders
+   +--> Payments
+   +--> Customers
+```
+
+## Reverse Proxy as the Foundation
+
+At its simplest, the gateway routes:
+
+```text
+/api/orders/*   -> Orders service
+/api/payments/* -> Payments service
+```
+
+In modern .NET, YARP can provide a highly customizable reverse-proxy foundation.
+
+But routing alone is not the whole architectural pattern.
+
+## Cross-Cutting Edge Concerns
+
+A gateway is a natural location for concerns that apply consistently across external APIs:
+
+- authentication enforcement;
+- TLS termination;
+- rate limiting;
+- routing;
+- request/response limits;
+- header normalization;
+- observability;
+- API version routing.
+
+Centralizing these can reduce duplication across services.
+
+## Authentication vs. Authorization
+
+The gateway can validate identity and coarse access.
+
+But domain authorization often belongs deeper.
+
+```text
+Gateway:
+Is this token valid?
+
+Order service:
+May this user refund Order 42?
+```
+
+Do not centralize every business permission in the gateway.
+
+## Rate Limiting
+
+The edge is an excellent place to protect systems from abusive or accidental load.
+
+Policies might apply by:
+
+```text
+API key
+tenant
+user
+IP
+route
+```
+
+But downstream services may still need their own protection because internal traffic can bypass the external gateway.
+
+## Aggregation
+
+A gateway can aggregate a small number of downstream calls.
+
+But if aggregation becomes heavily client-specific, a BFF may be a cleaner home.
+
+```text
+Gateway -> shared edge policy
+BFF     -> client experience
+```
+
+Keep the distinction intentional.
+
+## Gateway as Single Point of Failure
+
+Every external request may pass through it.
+
+Therefore:
+
+```text
+gateway unavailable
+=
+system appears unavailable
+```
+
+Design for:
+
+- multiple instances;
+- health checks;
+- load balancing;
+- safe configuration rollout;
+- capacity headroom.
+
+The gateway must be boringly reliable.
+
+## Avoid Business Logic
+
+This is the classic failure mode:
+
+```text
+API Gateway
+  |
+  + 20,000 lines of workflow logic
+  + database access
+  + pricing rules
+  + customer policy
+```
+
+Now every service is "independent" except all business changes require redeploying the gateway.
+
+The edge becomes a distributed monolith's central brain.
+
+Keep it thin.
+
+## Timeouts
+
+The gateway should not wait forever for downstream services.
+
+Define:
+
+```text
+connection timeout
+request timeout
+maximum body size
+```
+
+But be careful with retries at the gateway.
+
+Retrying a non-idempotent POST can duplicate effects.
+
+Retry policy must understand operation semantics.
+
+## Circuit Breaking
+
+A gateway may temporarily stop forwarding to a failing dependency.
+
+That can reduce cascading failure.
+
+But circuit breaking at the gateway does not remove the need for resilience inside service-to-service calls.
+
+We will cover Circuit Breaker as its own pattern.
+
+## Service Discovery
+
+In dynamic environments, service locations change.
+
+The gateway may integrate with:
+
+- container orchestration;
+- cloud routing;
+- service discovery;
+- configuration.
+
+Clients should not need to know individual service topology.
+
+## API Versioning
+
+A gateway can route:
+
+```text
+/v1/orders -> old service/version
+/v2/orders -> new service/version
+```
+
+This can support migrations.
+
+Do not use routing tricks as a substitute for a deliberate compatibility strategy.
+
+## Observability
+
+The gateway is an excellent observation point.
+
+Track:
+
+```text
+request rate
+status code
+latency
+route
+tenant/client
+rate-limit rejection
+downstream latency
+gateway overhead
+```
+
+Propagate trace context downstream.
+
+Avoid logging secrets or sensitive payloads.
+
+## Security Boundary
+
+Because the gateway is internet-facing, harden it aggressively.
+
+Use:
+
+- minimal exposed surface;
+- request size limits;
+- header sanitation;
+- authentication;
+- rate limiting;
+- patched dependencies;
+- strict administrative access.
+
+Do not assume downstream services are safe merely because they sit behind the gateway.
+
+Defense in depth still matters.
+
+## Gateway vs. Service Mesh
+
+Roughly:
+
+```text
+API Gateway
+  north-south traffic
+  external clients -> services
+
+Service Mesh
+  east-west traffic
+  service -> service
+```
+
+There can be overlap, but the operational boundaries differ.
+
+Do not deploy both merely to complete an architecture diagram.
+
+## Gateway vs. BFF
+
+A useful composition:
+
+```text
+Internet
+   |
+API Gateway
+   |
+   +--> Web BFF
+   +--> Mobile BFF
+   +--> Public API
+```
+
+Gateway handles shared edge policy.
+
+BFFs handle client-specific behavior.
+
+## Testing
+
+Test:
+
+```text
+route correctness
+authentication enforcement
+rate limits
+header propagation
+timeouts
+failure behavior
+configuration rollout
+```
+
+Load-test the gateway itself.
+
+It sits on the critical path.
+
+## When It Helps
+
+Use an API Gateway when:
+
+- many services need one external entry point;
+- edge policies should be consistent;
+- internal topology should be hidden;
+- routing and version migration need centralized control.
+
+## When It Hurts
+
+It hurts when:
+
+- a simple monolith has one API anyway;
+- business logic accumulates at the edge;
+- every internal call is unnecessarily routed through it;
+- gateway ownership becomes an organizational bottleneck.
+
+## Summary
+
+API Gateway gives a distributed API a deliberate external edge.
+
+Centralize cross-cutting edge policy there.
+
+Do not centralize the business.
+
+The best gateway is powerful operationally and boring semantically.

--- a/src/posts/2030-04-14-retry.md
+++ b/src/posts/2030-04-14-retry.md
@@ -1,0 +1,287 @@
+---
+author: Steve Kaschimer
+date: 2030-04-14
+image: /images/posts/2030-04-14-hero.webp
+image_alt: "A looping arrow with three progressively spaced pulses, implying spaced, bounded repeated attempts."
+image_prompt: "A dark-mode technical editorial illustration on a near-black background with electric teal, amber, and off-white accents. Composition centers on a single curved teal arrow looping back on itself, marked along its path by three small amber pulse marks spaced progressively farther apart, implying bounded retries with increasing delay rather than an unbounded hot loop. Mood is patient and bounded. Avoid: vendor logos, brand colors, circuit-board textures, gears, or generic clip art as the dominant motif."
+layout: post.njk
+site_title: Tech Notes
+summary: "Use bounded retries for genuinely transient failures, with backoff, jitter, idempotency, retry budgets, cancellation, and careful placement in modern .NET applications."
+tags: ["dotnet", "architecture", "design-patterns", "resilience"]
+title: "Retry: Recovering From Transient Failure Without Making Things Worse"
+---
+
+Networks fail.
+
+Services restart.
+
+Connections reset.
+
+A dependency may reject a request for two seconds and work perfectly on the next attempt.
+
+Retry exists for these **transient failures**.
+
+The dangerous misconception is:
+
+> If something fails, try it again.
+
+That is not a resilience strategy.
+
+## Classify the Failure First
+
+Potentially transient:
+
+```text
+connection reset
+temporary service unavailable
+rate limit with retry guidance
+brief lock/contention failure
+```
+
+Usually not transient:
+
+```text
+400 Bad Request
+authentication failure
+validation failure
+card declined
+resource does not exist
+```
+
+Retrying permanent failure simply repeats failure while adding load.
+
+## Bounded Retry
+
+Never retry forever.
+
+```text
+attempt 1
+wait
+attempt 2
+wait longer
+attempt 3
+give up
+```
+
+A bounded policy protects both caller and dependency.
+
+## Backoff
+
+Immediate retry can create a hot loop:
+
+```text
+fail -> retry -> fail -> retry
+```
+
+Use delay.
+
+Exponential backoff increases that delay between attempts.
+
+```text
+100 ms
+200 ms
+400 ms
+```
+
+The exact numbers should come from dependency behavior and latency objectives, not folklore.
+
+## Jitter
+
+If 10,000 clients fail at the same moment and all retry after exactly one second:
+
+```text
+dependency recovers
+10,000 retries arrive
+dependency fails again
+```
+
+Add randomness—jitter—to spread retries over time.
+
+## Modern .NET Resilience
+
+Modern .NET applications can compose resilience policies around outbound calls rather than hand-writing loops in every service.
+
+Conceptually:
+
+```csharp
+await resiliencePipeline.ExecuteAsync(
+    async cancellationToken =>
+    {
+        await dependency.CallAsync(
+            cancellationToken);
+    },
+    cancellationToken);
+```
+
+The important architecture is the policy:
+
+```text
+which failures?
+how many attempts?
+what delay?
+what timeout?
+is the operation safe to repeat?
+```
+
+## Idempotency Comes First
+
+Retrying:
+
+```text
+GET /products/42
+```
+
+is usually less dangerous than retrying:
+
+```text
+POST /payments
+```
+
+If the first request succeeded but the response was lost, retrying a non-idempotent command can duplicate the effect.
+
+Before enabling retries on writes, establish operation identity or another idempotency guarantee.
+
+## Respect Server Guidance
+
+If a dependency returns retry guidance such as a `Retry-After` value, respect it where appropriate.
+
+The dependency often knows its recovery or throttling window better than your arbitrary delay.
+
+## Retry Budgets
+
+Retries multiply traffic.
+
+If every request gets three retries:
+
+```text
+1,000 failing calls
+can become
+4,000 total attempts
+```
+
+during an outage.
+
+A retry budget limits how much additional traffic the resilience system is allowed to create.
+
+## Retry Placement
+
+Avoid retrying the same failure at every layer:
+
+```text
+API retries 3x
+service retries 3x
+SDK retries 3x
+```
+
+One logical operation can explode into dozens of attempts.
+
+Choose the layer that has enough semantic knowledge to retry safely.
+
+## Timeout + Retry
+
+Each attempt needs a timeout.
+
+The entire operation also needs a time budget.
+
+```text
+overall budget: 3 seconds
+
+attempt 1: 700 ms
+backoff
+attempt 2: 700 ms
+backoff
+attempt 3: remaining budget
+```
+
+Do not let retry quietly violate the caller's latency objective.
+
+## Cancellation
+
+Respect `CancellationToken`.
+
+If the caller disconnects or the operation deadline expires, continuing retries may waste resources.
+
+## Database Retry
+
+Some database failures are transient.
+
+But replaying a transaction safely requires care.
+
+If the operation performed an external side effect inside the transaction flow, automatic retry can duplicate that effect.
+
+Keep external calls out of database retry scopes where possible.
+
+## Messaging Retry
+
+Message consumers often retry transient handler failures.
+
+But repeated immediate delivery of a poison message can monopolize a consumer.
+
+Use:
+
+```text
+bounded retry
+then dead-letter
+```
+
+and keep handlers idempotent.
+
+## Observability
+
+Record:
+
+```text
+initial attempts
+retry attempts
+retry success
+retry exhaustion
+delay
+failure classification
+dependency
+```
+
+A service that "looks healthy" only because 40% of requests succeed on their third attempt is not healthy.
+
+## Testing
+
+Test:
+
+```text
+transient failure then success
+permanent failure is not retried
+retry exhaustion
+cancellation
+non-idempotent operation is protected
+retry-after behavior
+```
+
+## When It Helps
+
+Use Retry when:
+
+- failures are genuinely transient;
+- another attempt has a reasonable chance of success;
+- the operation is safe to repeat;
+- added latency is acceptable.
+
+## When It Hurts
+
+Retry hurts when:
+
+- failure is permanent;
+- the dependency is overloaded;
+- the operation is not idempotent;
+- retries exist at several layers;
+- retry delays exceed the caller's time budget.
+
+## Summary
+
+Retry is not "try harder."
+
+It is a controlled response to transient failure.
+
+Classify errors, bound attempts, back off with jitter, respect time budgets, and prove that repeating the operation is safe.
+
+When a dependency is persistently unhealthy, stop retrying it.
+
+That is where Circuit Breaker begins.

--- a/src/posts/2030-04-21-circuit-breaker.md
+++ b/src/posts/2030-04-21-circuit-breaker.md
@@ -1,0 +1,274 @@
+---
+author: Steve Kaschimer
+date: 2030-04-21
+image: /images/posts/2030-04-21-hero.webp
+image_alt: "A switch glyph shown mid-open with a visible gap in the connecting line, implying calls deliberately interrupted."
+image_prompt: "A dark-mode technical editorial illustration on a near-black background with electric teal, amber, and off-white accents. Composition centers on a single amber switch glyph shown mid-open with a clear gap breaking its connecting line, a faint teal dependency shape visible but unreachable on the far side of the gap, implying calls deliberately stopped rather than continuing to fail. Mood is protective and decisive. Avoid: vendor logos, brand colors, circuit-board textures, gears, or generic clip art as the dominant motif."
+layout: post.njk
+site_title: Tech Notes
+summary: "Fail fast when a dependency is persistently unhealthy, allowing recovery while preventing cascading latency, retry storms, and resource exhaustion."
+tags: ["dotnet", "architecture", "design-patterns", "resilience"]
+title: "Circuit Breaker: Stop Calling a Dependency That Is Already Failing"
+---
+
+Retry assumes another attempt may succeed.
+
+What if the dependency is down for ten minutes?
+
+Continuing to call it creates:
+
+```text
+timeouts
+blocked resources
+retry storms
+higher latency
+cascading failure
+```
+
+Circuit Breaker temporarily stops calls to a dependency that appears unhealthy.
+
+## The Electrical Analogy
+
+A circuit breaker protects a system by opening the circuit when failure exceeds a threshold.
+
+Software follows the same state model:
+
+```text
+Closed
+  |
+failures exceed threshold
+  |
+  v
+Open
+  |
+cool-down
+  |
+  v
+Half-Open
+  |
+probe succeeds
+  |
+  v
+Closed
+```
+
+## Closed
+
+Calls flow normally.
+
+The breaker observes failures.
+
+## Open
+
+Calls fail immediately without contacting the dependency.
+
+```text
+dependency call
+     X
+fail fast
+```
+
+This protects:
+
+- threads/tasks;
+- sockets;
+- connection pools;
+- latency budgets;
+- the failing dependency itself.
+
+## Half-Open
+
+After a recovery interval, allow limited probe traffic.
+
+If probes succeed:
+
+```text
+close circuit
+```
+
+If they fail:
+
+```text
+open again
+```
+
+Do not unleash full production traffic on the first sign of recovery.
+
+## What Counts as Failure?
+
+Not every unsuccessful business result should trip the circuit.
+
+Examples:
+
+```text
+HTTP 503 -> probably dependency failure
+timeout  -> probably dependency failure
+HTTP 400 -> caller problem
+card declined -> business outcome
+```
+
+Failure classification matters.
+
+## Circuit Breaker + Retry
+
+A common composition:
+
+```text
+Request
+  |
+Retry
+  |
+Circuit Breaker
+  |
+Dependency
+```
+
+But ordering and implementation details matter.
+
+The goal is:
+
+- retry brief transient failures;
+- stop hammering sustained failures.
+
+Do not let retries bypass the breaker.
+
+## Fallback
+
+When the circuit is open, the caller needs a policy.
+
+Possible outcomes:
+
+```text
+return cached data
+degrade optional feature
+queue work
+return unavailable
+```
+
+Fallback must be semantically valid.
+
+Never return stale or fabricated data merely to make dashboards green.
+
+## Example: Recommendations
+
+If Recommendations is unavailable:
+
+```text
+Product page
+  |
+recommendations circuit open
+  |
+show page without recommendations
+```
+
+Excellent graceful degradation.
+
+## Example: Payment
+
+If Payment is unavailable:
+
+```text
+pretend payment succeeded
+```
+
+is obviously unacceptable.
+
+Return a clear unavailable/pending state or queue only if the business supports it.
+
+## Per-Dependency Isolation
+
+Do not use one global circuit:
+
+```text
+one vendor fails
+everything opens
+```
+
+Circuit state should align with the dependency/failure boundary.
+
+Sometimes even separate operations on one dependency deserve different breakers.
+
+## Distributed Instances
+
+Each application instance may maintain its own circuit state.
+
+That is usually fine.
+
+A shared global breaker adds coordination complexity and may create its own failure mode.
+
+## Health Checks Are Different
+
+Health checks answer:
+
+```text
+is dependency healthy right now?
+```
+
+Circuit breakers answer:
+
+```text
+should this caller currently attempt requests?
+```
+
+Do not poll health endpoints on every request as a substitute for a breaker.
+
+## Observability
+
+Track:
+
+```text
+state transitions
+open duration
+rejected calls
+probe success/failure
+underlying failure rate
+dependency latency
+```
+
+An open circuit should be operationally visible.
+
+## Testing
+
+Test:
+
+```text
+threshold opens circuit
+open circuit fails fast
+half-open allows limited probes
+success closes
+failure reopens
+business rejection does not trip breaker
+```
+
+Time abstraction such as `TimeProvider` can make timing behavior easier to test.
+
+## When It Helps
+
+Use Circuit Breaker when:
+
+- a remote dependency can fail for meaningful periods;
+- repeated calls consume scarce resources;
+- callers can fail fast or degrade;
+- cascading failure is a concern.
+
+## When It Hurts
+
+It adds state and tuning.
+
+For a local in-memory method call, it is nonsense.
+
+For a dependency whose every request is independent and cheap, it may add little.
+
+## Summary
+
+Circuit Breaker protects the caller and the dependency from sustained failure.
+
+Retry says:
+
+> try again carefully.
+
+Circuit Breaker says:
+
+> stop trying for now.
+
+Together, they let the system distinguish a brief glitch from an outage.

--- a/src/posts/2030-04-28-bulkhead.md
+++ b/src/posts/2030-04-28-bulkhead.md
@@ -1,0 +1,262 @@
+---
+author: Steve Kaschimer
+date: 2030-04-28
+image: /images/posts/2030-04-28-hero.webp
+image_alt: "A rectangle divided into separate walled compartments, one compartment shown full while the others remain unaffected."
+image_prompt: "A dark-mode technical editorial illustration on a near-black background with electric teal, amber, and off-white accents. Composition centers on a single teal rectangle divided by amber wall lines into four separate compartments, one compartment on the left shown solid and full while the other three remain open and empty, implying one overloaded workload contained without spreading. Mood is contained and fair. Avoid: vendor logos, brand colors, circuit-board textures, gears, or generic clip art as the dominant motif."
+layout: post.njk
+site_title: Tech Notes
+summary: "Partition concurrency and resources so overload or failure in one dependency or workload cannot exhaust the entire application."
+tags: ["dotnet", "architecture", "design-patterns", "resilience"]
+title: "Bulkhead: Preventing One Failure From Consuming Everything"
+---
+
+Ships are divided into watertight compartments.
+
+If one compartment floods, the entire ship does not have to sink.
+
+Software Bulkhead applies the same principle:
+
+> Partition limited resources so one failing workload cannot consume all of them.
+
+## The Failure Pattern
+
+Suppose an API calls:
+
+```text
+Payments
+Recommendations
+Search
+```
+
+All outbound work shares the same unconstrained concurrency.
+
+Recommendations slows dramatically.
+
+Requests accumulate.
+
+Eventually it consumes:
+
+- sockets;
+- tasks;
+- memory;
+- connection pool capacity.
+
+Now Payments also fails even though Payment itself is healthy.
+
+That is resource coupling.
+
+## Concurrency Isolation
+
+Give Recommendations a bounded concurrency budget:
+
+```text
+Recommendations
+  max concurrent = 20
+  queue = 50
+```
+
+When the boundary is full:
+
+```text
+reject/degrade
+```
+
+instead of consuming the rest of the application.
+
+## Semaphore Shape
+
+Conceptually:
+
+```csharp
+private readonly SemaphoreSlim _gate =
+    new(initialCount: 20);
+
+public async Task<T> ExecuteAsync<T>(
+    Func<CancellationToken, Task<T>> action,
+    CancellationToken cancellationToken)
+{
+    await _gate.WaitAsync(cancellationToken);
+
+    try
+    {
+        return await action(cancellationToken);
+    }
+    finally
+    {
+        _gate.Release();
+    }
+}
+```
+
+Production resilience libraries provide richer concurrency limiting and queue behavior.
+
+The architectural idea is resource isolation.
+
+## Thread Pools Are Not the Boundary
+
+Modern async .NET avoids tying every request to a dedicated thread.
+
+But async systems can still exhaust:
+
+- sockets;
+- DB connections;
+- memory;
+- downstream capacity;
+- queued work.
+
+Bulkheads remain relevant.
+
+## Connection Pools
+
+Separate connection pools can act as bulkheads.
+
+For example:
+
+```text
+critical transactional DB work
+```
+
+should not necessarily compete for every connection with:
+
+```text
+slow reporting queries
+```
+
+Sometimes separate databases or replicas provide an even stronger boundary.
+
+## Workload Isolation
+
+Bulkheads can separate:
+
+```text
+interactive traffic
+background jobs
+batch imports
+```
+
+A massive import should not make checkout unusable.
+
+Different worker pools or queues can enforce that separation.
+
+## Tenant Isolation
+
+In multi-tenant systems, one noisy tenant can consume shared capacity.
+
+Per-tenant limits can act as a bulkhead:
+
+```text
+Tenant A cannot consume 100% of worker concurrency.
+```
+
+Be careful with fairness and unused-capacity policies.
+
+## Bulkhead + Circuit Breaker
+
+They solve different problems.
+
+```text
+Circuit Breaker
+  dependency is failing
+  stop calls temporarily
+
+Bulkhead
+  dependency/workload may consume too much
+  limit its resource share
+```
+
+They often work together.
+
+## Bulkhead + Rate Limiting
+
+Rate limiting controls arrival rate.
+
+Bulkhead controls concurrent resource usage.
+
+A service may need both.
+
+```text
+100 requests/sec
+```
+
+can still be dangerous if each request lasts 30 seconds.
+
+Concurrency is the critical resource then.
+
+## Queue Size
+
+A bulkhead with an enormous waiting queue can simply move the outage into memory.
+
+Bound the queue.
+
+When full, reject quickly or degrade.
+
+Backpressure is healthier than infinite waiting.
+
+## Critical vs. Optional Dependencies
+
+Give critical work protected capacity.
+
+```text
+Checkout
+  payment capacity protected
+
+Homepage
+  recommendations capacity bounded
+```
+
+Optional functionality should not be allowed to starve core business operations.
+
+## Observability
+
+Track:
+
+```text
+active concurrency
+queue depth
+queue wait time
+rejections
+execution duration
+dependency
+tenant/workload
+```
+
+Bulkhead rejection is a capacity signal.
+
+## Testing
+
+Load-test isolation.
+
+```text
+saturate Recommendations
+verify Checkout remains healthy
+```
+
+Unit tests alone cannot prove resource isolation under pressure.
+
+## When It Helps
+
+Use Bulkhead when:
+
+- workloads share finite resources;
+- one dependency can become slow;
+- optional work must not starve critical work;
+- multi-tenant fairness matters.
+
+## When It Hurts
+
+Too many tiny partitions can waste capacity and create configuration overhead.
+
+Isolation should correspond to meaningful failure domains.
+
+## Summary
+
+Bulkhead limits the blast radius of overload.
+
+Circuit Breaker isolates a failing dependency over time.
+
+Bulkhead isolates resource consumption at the same time.
+
+The goal is not to prevent every failure.
+
+It is to prevent one failure from becoming everyone's failure.

--- a/src/posts/2030-05-05-cache-aside.md
+++ b/src/posts/2030-05-05-cache-aside.md
@@ -1,0 +1,390 @@
+---
+author: Steve Kaschimer
+date: 2030-05-05
+image: /images/posts/2030-05-05-hero.webp
+image_alt: "A layered disc glyph positioned in front of a database cylinder, with a small lightning accent implying an intercepted fast path."
+image_prompt: "A dark-mode technical editorial illustration on a near-black background with electric teal, amber, and off-white accents. Composition centers on a small amber layered-disc glyph positioned in front of a teal database-cylinder shape behind it, with one small off-white lightning-bolt accent between them, implying a fast intercepted path checked before the slower source is reached. Mood is fast but provisional. Avoid: vendor logos, brand colors, circuit-board textures, gears, or generic clip art as the dominant motif."
+layout: post.njk
+site_title: Tech Notes
+summary: "Load frequently read data into a cache on demand while explicitly handling misses, invalidation, staleness, stampedes, expiration, and multi-instance behavior."
+tags: ["dotnet", "architecture", "design-patterns", "caching"]
+title: "Cache-Aside: Faster Reads Without Pretending Caches Are Simple"
+---
+
+Caching is often introduced as:
+
+```text
+put data in Redis
+application gets faster
+```
+
+The hard part is not storing data.
+
+The hard part is deciding when cached data is valid.
+
+Cache-Aside is a common pattern where the application explicitly manages cache population.
+
+## Read Flow
+
+```text
+Request
+  |
+Cache lookup
+  |
+  +-- hit --> return
+  |
+  +-- miss
+        |
+        v
+     Database
+        |
+        v
+   Populate cache
+        |
+        v
+      Return
+```
+
+The cache is populated only when data is requested.
+
+## Example
+
+```csharp
+public async Task<ProductDto?> GetAsync(
+    ProductId id,
+    CancellationToken cancellationToken)
+{
+    var key = $"product:{id.Value}";
+
+    var cached = await cache.GetAsync<ProductDto>(
+        key,
+        cancellationToken);
+
+    if (cached is not null)
+        return cached;
+
+    var product = await database.Products
+        .AsNoTracking()
+        .Where(x => x.Id == id)
+        .Select(x => new ProductDto(
+            x.Id.Value,
+            x.Name,
+            x.Price))
+        .SingleOrDefaultAsync(cancellationToken);
+
+    if (product is not null)
+    {
+        await cache.SetAsync(
+            key,
+            product,
+            TimeSpan.FromMinutes(5),
+            cancellationToken);
+    }
+
+    return product;
+}
+```
+
+This is the happy path.
+
+Now the real architecture begins.
+
+## Staleness
+
+Suppose:
+
+```text
+cache: price = $100
+database updated: price = $80
+```
+
+Until expiration or invalidation:
+
+```text
+reader sees $100
+```
+
+Is that acceptable?
+
+For a marketing description, maybe.
+
+For available bank balance, probably not.
+
+Cache strategy is a consistency decision.
+
+## Invalidation
+
+The famous hard problem.
+
+Common approaches:
+
+```text
+TTL expiration
+explicit invalidation on write
+versioned keys
+event-driven invalidation
+```
+
+Each has trade-offs.
+
+## Invalidate on Write
+
+```text
+Update database
+Delete cache key
+```
+
+But this is another dual-write sequence.
+
+What if:
+
+```text
+DB update succeeds
+cache delete fails
+```
+
+Stale data remains.
+
+For strict correctness, caching may not be appropriate for that data.
+
+For tolerant use cases, TTL bounds the stale period.
+
+## Expiration
+
+TTL is simple and powerful.
+
+```text
+product metadata: 10 minutes
+feature configuration: 1 minute
+```
+
+Choose TTL from business tolerance for staleness, not arbitrary round numbers.
+
+## Cache Stampede
+
+A popular key expires.
+
+```text
+10,000 requests
+all miss
+all hit database
+```
+
+The cache protected the database until the exact moment it became most dangerous.
+
+Mitigations include:
+
+- request coalescing;
+- per-key locking;
+- stale-while-revalidate;
+- randomized expiration;
+- background refresh.
+
+## Negative Caching
+
+If a missing resource is repeatedly requested:
+
+```text
+cache "not found"
+```
+
+for a short period.
+
+But be careful: if the resource is created moments later, the negative cache can hide it.
+
+Use shorter TTLs for negative entries.
+
+## Local vs. Distributed Cache
+
+In-memory cache:
+
+```text
+fast
+simple
+per-instance
+```
+
+Distributed cache:
+
+```text
+shared across instances
+network hop
+operational dependency
+serialization
+```
+
+Do not deploy Redis merely because the application has more than one endpoint.
+
+Use it when shared caching provides meaningful value.
+
+## Cache Failure
+
+Ask:
+
+> What happens if the cache is unavailable?
+
+Often the application should fall back to the database.
+
+But if every instance suddenly bypasses cache:
+
+```text
+cache outage
+   |
+database receives full load
+   |
+database outage
+```
+
+That is a cascading-failure risk.
+
+Capacity planning must account for cache loss.
+
+## Cache Penetration
+
+Attackers or accidental clients can request huge numbers of nonexistent keys:
+
+```text
+product:random-1
+product:random-2
+...
+```
+
+Every miss reaches the database.
+
+Negative caching, request validation, rate limiting, and probabilistic structures can help in extreme cases.
+
+## Cache Key Design
+
+Keys are contracts too.
+
+Include dimensions that affect the value:
+
+```text
+tenant
+locale
+currency
+user permissions
+version
+```
+
+A missing dimension can become a data-isolation bug.
+
+## Security
+
+Never accidentally serve one user's cached private data to another.
+
+A key such as:
+
+```text
+/dashboard
+```
+
+is dangerous if the response depends on user identity.
+
+Cache only data whose scope is explicit.
+
+## Serialization
+
+Distributed caches store serialized data.
+
+Schema changes matter.
+
+Version cache entries or tolerate old representations during rolling deployments.
+
+## Cache-Aside and CQRS
+
+Read models are natural cache candidates.
+
+```text
+Query
+  |
+Cache
+  |
+Read Model
+```
+
+The write model remains authoritative.
+
+This keeps cache concerns away from domain invariants.
+
+## Observability
+
+Track:
+
+```text
+hit rate
+miss rate
+load latency
+cache latency
+evictions
+memory usage
+stampede/coalescing rate
+fallback rate
+```
+
+Hit rate alone is insufficient.
+
+A 99% hit rate can still overload the database if the remaining 1% represents enormous traffic.
+
+## Testing
+
+Test:
+
+```text
+hit
+miss
+expiration
+invalidation
+cache unavailable
+concurrent miss
+tenant/user isolation
+serialization compatibility
+```
+
+Load-test stampede scenarios.
+
+## When It Helps
+
+Use Cache-Aside when:
+
+- reads are repeated;
+- source access is expensive;
+- some staleness is acceptable;
+- data has a useful reuse window.
+
+## When It Hurts
+
+Caching hurts when:
+
+- data must always be current;
+- access is rarely repeated;
+- invalidation complexity exceeds the performance benefit;
+- the cache becomes an unplanned source of truth.
+
+## Summary
+
+Cache-Aside is simple to draw and difficult to operate well.
+
+The algorithm is:
+
+```text
+look in cache
+miss -> load source
+populate cache
+```
+
+The architecture is:
+
+```text
+staleness
+invalidation
+expiration
+stampedes
+security
+failure behavior
+capacity
+```
+
+Use caching when you can state the consistency trade explicitly.
+
+If you cannot explain how stale the data may be, you do not yet have a cache design.

--- a/src/posts/2030-05-12-modular-monolith.md
+++ b/src/posts/2030-05-12-modular-monolith.md
@@ -1,0 +1,134 @@
+---
+author: Steve Kaschimer
+date: 2030-05-12
+image: /images/posts/2030-05-12-hero.webp
+image_alt: "One bounded rectangle with several internal partitions of different shapes, all inside one unbroken outer boundary."
+image_prompt: "A dark-mode technical editorial illustration on a near-black background with electric teal, amber, and off-white accents. Composition centers on a single unbroken teal outer boundary rectangle containing four small distinctly shaped amber partitions inside it, implying strong internal boundaries preserved without splitting the deployment itself. Mood is bounded and unified. Avoid: vendor logos, brand colors, circuit-board textures, gears, or generic clip art as the dominant motif."
+layout: post.njk
+site_title: Tech Notes
+summary: "A modular monolith keeps one deployable application while dividing it into explicit business modules with controlled dependencies."
+tags: ["dotnet", "architecture", "design-patterns", "microservices"]
+title: "Modular Monolith: Strong Boundaries Without a Distributed System"
+---
+
+A modular monolith keeps one deployable application while dividing it into explicit business modules with controlled dependencies.
+
+```text
+Application
+├── Orders
+├── Payments
+├── Catalog
+└── Identity
+```
+
+The important word is **modular**, not monolith.
+
+## Why It Exists
+
+A traditional monolith can decay into one shared object graph:
+
+```text
+Orders -> Payments internals
+Payments -> Catalog tables
+Catalog -> Identity implementation
+```
+
+A modular monolith keeps the operational simplicity of one process while making those boundaries intentional.
+
+## Module Shape
+
+A module can own its application, domain, and infrastructure concerns:
+
+```text
+Modules/
+  Orders/
+    Application/
+    Domain/
+    Infrastructure/
+    Contracts/
+```
+
+Other modules should depend on its public contract, not its implementation.
+
+```csharp
+public interface IOrdersModule
+{
+    Task<OrderSummary?> GetSummaryAsync(
+        OrderId id,
+        CancellationToken cancellationToken);
+}
+```
+
+## Data Ownership
+
+One database is fine.
+
+Shared ownership is the danger.
+
+```text
+Orders schema
+Payments schema
+Catalog schema
+```
+
+Separate schemas are one useful technique. The stronger rule is semantic: one module owns writes to its data.
+
+Avoid cross-module joins becoming the default integration mechanism.
+
+## Communication
+
+Start with the simplest mechanism that preserves the boundary:
+
+```text
+direct in-process contract
+```
+
+Use module events when decoupled reactions help.
+
+Do not introduce a broker merely to simulate microservices inside one process.
+
+## Transactions Are a Superpower
+
+A modular monolith can still use a local ACID transaction when the business genuinely requires it.
+
+That is a major advantage over premature service decomposition.
+
+Do not throw away local transactions merely to look distributed.
+
+## Enforce the Architecture
+
+A folder is not a boundary.
+
+Use project references, internal visibility, architecture tests, and dependency rules to prevent accidental coupling.
+
+For example, tests can assert that `Orders.Domain` never references `Payments.Infrastructure`.
+
+## Extraction Path
+
+A well-designed module is a candidate—not a promise—for future extraction.
+
+```text
+Modular Monolith
+      |
+clear boundary
+      |
+business/scale reason appears
+      |
+extract service
+```
+
+The goal is not to make extraction inevitable. It is to make it possible without rewriting the whole system.
+
+## When It Helps
+
+Use a modular monolith when the domain benefits from strong boundaries but independent deployment and distributed failure are not yet worth their cost.
+
+## When It Hurts
+
+It fails when "module" means only folders while every module shares tables, internal classes, and implementation details.
+
+## Summary
+
+A modular monolith is often the best default for a substantial business application: strong boundaries, one deployment, simple debugging, and local transactions.
+
+Microservices should be an answer to a problem—not the starting architecture.

--- a/src/posts/2030-05-19-strangler-fig.md
+++ b/src/posts/2030-05-19-strangler-fig.md
@@ -1,0 +1,137 @@
+---
+author: Steve Kaschimer
+date: 2030-05-19
+image: /images/posts/2030-05-19-hero.webp
+image_alt: "A thin vine shape gradually overtaking and replacing a solid trunk shape beside it."
+image_prompt: "A dark-mode technical editorial illustration on a near-black background with electric teal, amber, and off-white accents. Composition centers on one solid amber trunk shape on the left gradually being overtaken by a thin teal vine shape wrapping around and extending past it on the right, implying incremental replacement growing around an existing system rather than a single cutover. Mood is incremental and organic. Avoid: vendor logos, brand colors, circuit-board textures, gears, or generic clip art as the dominant motif."
+layout: post.njk
+site_title: Tech Notes
+summary: "The Strangler Fig pattern replaces an existing system incrementally."
+tags: ["dotnet", "architecture", "design-patterns", "microservices"]
+title: "Strangler Fig: Modernizing Systems Without the Big-Bang Rewrite"
+---
+
+The Strangler Fig pattern replaces an existing system incrementally.
+
+```text
+Clients
+   |
+Routing Boundary
+  / Old  New
+```
+
+New behavior grows around the old system until the old implementation can be retired.
+
+## Why Not Rewrite Everything?
+
+Big-bang rewrites combine several risks:
+
+- requirements rediscovery;
+- feature parity;
+- migration;
+- operational cutover;
+- years of accumulated edge cases.
+
+The old system continues changing while the replacement is being built.
+
+Strangler Fig reduces the size of each bet.
+
+## Choose a Slice
+
+Do not begin with:
+
+```text
+rewrite database
+```
+
+Begin with a business capability:
+
+```text
+Customer Search
+Invoice Generation
+Order History
+```
+
+Route that capability to the new implementation while everything else remains old.
+
+## Routing
+
+The interception point might be:
+
+- reverse proxy;
+- API gateway;
+- facade;
+- message router;
+- application adapter.
+
+```text
+/orders/history -> New
+/orders/create  -> Legacy
+```
+
+## Data Is Usually Harder Than Routing
+
+Code can be strangled endpoint by endpoint.
+
+Data ownership is harder.
+
+Migration strategies include:
+
+```text
+new module reads legacy data
+new system owns new records
+CDC replicates selected data
+explicit migration
+```
+
+Avoid indefinite dual writes if possible. They create synchronization ambiguity.
+
+## Anti-Corruption Layer
+
+The new model should not become a prettier wrapper around the legacy model.
+
+Use an ACL:
+
+```text
+New Domain
+   |
+Translation
+   |
+Legacy Model
+```
+
+This lets modernization improve the model rather than preserve every historical accident.
+
+## Measure Progress
+
+Track capabilities, traffic, and data ownership moved to the new system.
+
+A strangler program without deletion becomes:
+
+```text
+Legacy + New + Integration Forever
+```
+
+Retirement is part of the pattern.
+
+## Rollback
+
+Incremental routing makes rollback easier.
+
+If a new slice fails, route traffic back while fixing it—provided data semantics still permit that.
+
+## When It Helps
+
+Use Strangler Fig for systems too important or complex to replace safely in one cutover.
+
+## When It Hurts
+
+It adds temporary architecture: routing, translation, duplicated capability, and migration machinery.
+
+For a small replaceable application, a clean replacement may be cheaper.
+
+## Summary
+
+Strangler Fig turns modernization into a sequence of reversible capability migrations.
+
+The destination matters, but so does creating a safe path from here to there.

--- a/src/posts/2030-05-26-feature-flags.md
+++ b/src/posts/2030-05-26-feature-flags.md
@@ -1,0 +1,141 @@
+---
+author: Steve Kaschimer
+date: 2030-05-26
+image: /images/posts/2030-05-26-hero.webp
+image_alt: "A toggle switch glyph shown in an intermediate position, implying gradual, controlled activation."
+image_prompt: "A dark-mode technical editorial illustration on a near-black background with electric teal, amber, and off-white accents. Composition centers on a single amber toggle-switch glyph rendered in an intermediate position between fully off and fully on, with a faint teal gradient trailing behind the toggle implying gradual, controlled activation rather than an instant flip. Mood is gradual and controlled. Avoid: vendor logos, brand colors, circuit-board textures, gears, or generic clip art as the dominant motif."
+layout: post.njk
+site_title: Tech Notes
+summary: "A feature flag lets deployed code exist without making the behavior available to everyone."
+tags: ["dotnet", "architecture", "design-patterns", "software-design"]
+title: "Feature Flags: Separating Deployment From Release"
+---
+
+A feature flag lets deployed code exist without making the behavior available to everyone.
+
+```text
+Deploy code
+   |
+flag OFF
+   |
+enable gradually
+```
+
+This separates **deployment** from **release**.
+
+## Basic Example
+
+```csharp
+if (await features.IsEnabledAsync(
+    "NewCheckout",
+    cancellationToken))
+{
+    return await newCheckout.ExecuteAsync(...);
+}
+
+return await oldCheckout.ExecuteAsync(...);
+```
+
+The conditional is easy.
+
+The lifecycle is the pattern.
+
+## Types of Flags
+
+Useful categories include:
+
+```text
+release flag
+experiment flag
+operations/kill-switch flag
+permission/entitlement flag
+```
+
+They have different expected lifetimes.
+
+A release flag should usually disappear after rollout.
+
+## Progressive Delivery
+
+A flag can target:
+
+```text
+internal users
+1% of customers
+one tenant
+one region
+50%
+100%
+```
+
+This reduces blast radius.
+
+## Kill Switch
+
+Some flags exist specifically to disable optional or risky behavior quickly:
+
+```text
+recommendation engine causing failures
+-> disable recommendations
+```
+
+That can be faster and safer than an emergency deployment.
+
+## Flags and Domain Logic
+
+Avoid scattering:
+
+```csharp
+if (flag) ...
+```
+
+through every layer.
+
+Evaluate the flag near the decision boundary and choose one coherent behavior path.
+
+Otherwise two implementations become interleaved and difficult to remove.
+
+## Flag Debt
+
+Every temporary flag creates two possible systems.
+
+Ten boolean flags can theoretically create 1,024 combinations.
+
+Remove obsolete flags aggressively.
+
+Store metadata such as:
+
+```text
+owner
+purpose
+created date
+expiration date
+```
+
+## Testing
+
+Test both meaningful paths while the flag exists.
+
+For targeted rollouts, test evaluation rules too.
+
+## Security
+
+A feature flag is not authorization.
+
+If a user is forbidden from an operation, enforce authorization even when the feature is enabled.
+
+## When It Helps
+
+Feature flags are excellent for progressive rollout, experiments, operational kill switches, and separating deployment from customer release.
+
+## When It Hurts
+
+Long-lived unmanaged flags create hidden configuration complexity and dead code.
+
+## Summary
+
+Feature flags make release a runtime decision.
+
+Their power comes from reversibility and controlled exposure.
+
+Their cost is combinatorial complexity, so every temporary flag should have a retirement plan.

--- a/src/posts/2030-06-02-health-checks.md
+++ b/src/posts/2030-06-02-health-checks.md
@@ -1,0 +1,142 @@
+---
+author: Steve Kaschimer
+date: 2030-06-02
+image: /images/posts/2030-06-02-hero.webp
+image_alt: "A heartbeat line crossing through two small distinct gate glyphs labeled differently, implying separate liveness and readiness signals."
+image_prompt: "A dark-mode technical editorial illustration on a near-black background with electric teal, amber, and off-white accents. Composition centers on a single amber heartbeat-pulse line crossing left to right through two small distinct teal gate glyphs positioned along its path, implying two separate operational questions answered by the same running process. Mood is vigilant and precise. Avoid: vendor logos, brand colors, circuit-board textures, gears, or generic clip art as the dominant motif."
+layout: post.njk
+site_title: Tech Notes
+summary: "A health endpoint answers an operational question about a running application."
+tags: ["dotnet", "architecture", "design-patterns", "observability"]
+title: "Health Checks: Liveness, Readiness, and Knowing What 'Healthy' Means"
+---
+
+A health endpoint answers an operational question about a running application.
+
+The hard part is deciding **which question**.
+
+```text
+Is the process alive?
+Can it receive traffic?
+Are important dependencies usable?
+```
+
+Those are different questions.
+
+## Liveness
+
+Liveness asks:
+
+> Is this process functioning enough that restarting it might help?
+
+Keep liveness conservative.
+
+If a remote dependency fails, restarting every application instance may make the outage worse.
+
+## Readiness
+
+Readiness asks:
+
+> Should this instance receive new traffic?
+
+An application can be alive but temporarily not ready.
+
+Examples:
+
+```text
+startup initialization incomplete
+required local state unavailable
+instance draining for shutdown
+```
+
+## Dependency Health
+
+You may also expose detailed dependency diagnostics for operators.
+
+Do not automatically make every optional dependency a readiness requirement.
+
+If Recommendations fails but Checkout can still work, taking Checkout out of rotation reduces availability unnecessarily.
+
+## ASP.NET Core
+
+ASP.NET Core supports health-check registration and mapped endpoints.
+
+Conceptually:
+
+```csharp
+builder.Services
+    .AddHealthChecks()
+    .AddCheck<DatabaseHealthCheck>("database");
+
+app.MapHealthChecks("/health/live");
+app.MapHealthChecks("/health/ready");
+```
+
+Use tags or separate registrations to give endpoints distinct semantics.
+
+## Deep Checks Can Cause Load
+
+A health probe that performs an expensive query every few seconds across hundreds of instances can become production traffic.
+
+Health checks should be cheap and bounded.
+
+## Startup
+
+Readiness is useful during startup:
+
+```text
+process started
+   |
+warm required state
+   |
+ready
+```
+
+Traffic begins only after the application can serve it correctly.
+
+## Graceful Shutdown
+
+During shutdown:
+
+```text
+mark not ready
+stop accepting new work
+finish in-flight work
+exit
+```
+
+This reduces dropped requests during deployments.
+
+## Health vs. Observability
+
+A green `/health` endpoint does not prove the application is healthy for users.
+
+You still need:
+
+- metrics;
+- logs;
+- traces;
+- SLOs;
+- synthetic tests.
+
+Health checks are machine-oriented routing/recovery signals.
+
+## Security
+
+Detailed health output can reveal topology, versions, or dependency names.
+
+Keep public responses minimal and restrict diagnostic details appropriately.
+
+## When It Helps
+
+Health checks are essential in orchestrated and load-balanced environments where machines need a safe signal for restart and traffic routing.
+
+## When It Hurts
+
+Poorly designed checks cause restart storms, remove healthy capacity, or create dependency load.
+
+## Summary
+
+Do not build one endpoint called `/health` and ask it to mean everything.
+
+Separate liveness from readiness, classify dependencies by business criticality, and make probe behavior cheap enough to remain safe during an outage.

--- a/src/posts/2030-06-09-rate-limiting.md
+++ b/src/posts/2030-06-09-rate-limiting.md
@@ -1,0 +1,162 @@
+---
+author: Steve Kaschimer
+date: 2030-06-09
+image: /images/posts/2030-06-09-hero.webp
+image_alt: "A gauge glyph with a needle positioned just before a hard ceiling mark."
+image_prompt: "A dark-mode technical editorial illustration on a near-black background with electric teal, amber, and off-white accents. Composition centers on a single amber gauge-meter glyph with a teal needle positioned just short of a bold off-white ceiling mark at the gauge's edge, implying deliberate admission control rather than unlimited throughput. Mood is measured and fair. Avoid: vendor logos, brand colors, circuit-board textures, gears, or generic clip art as the dominant motif."
+layout: post.njk
+site_title: Tech Notes
+summary: "Rate limiting controls how much work a caller may introduce over time."
+tags: ["dotnet", "architecture", "design-patterns", "resilience"]
+title: "Rate Limiting: Protecting Capacity and Fairness at the Boundary"
+---
+
+Rate limiting controls how much work a caller may introduce over time.
+
+It protects capacity, fairness, cost, and downstream dependencies.
+
+## Why It Exists
+
+Without limits:
+
+```text
+one client
+   |
+100,000 requests/sec
+   |
+shared service
+```
+
+one noisy or malicious caller can consume capacity needed by everyone else.
+
+## Partition by the Right Identity
+
+Limits may be scoped by:
+
+```text
+tenant
+API key
+user
+IP address
+route
+```
+
+The partition should reflect the resource or fairness boundary.
+
+IP-only limiting can be problematic when many legitimate users share one address.
+
+## Algorithms
+
+Common strategies include:
+
+### Fixed window
+
+```text
+100 requests per minute
+```
+
+Simple, but bursts can occur around window boundaries.
+
+### Sliding window
+
+Smooths the boundary by considering recent windows.
+
+### Token bucket
+
+Tokens accumulate at a configured rate and requests consume them.
+
+This allows controlled bursts.
+
+### Concurrency limiter
+
+Limits simultaneous work rather than requests per unit time.
+
+This is especially useful when duration is the scarce resource.
+
+## ASP.NET Core
+
+ASP.NET Core includes rate-limiting middleware that can apply policies to endpoints.
+
+Conceptually:
+
+```csharp
+builder.Services.AddRateLimiter(options =>
+{
+    // register named or partitioned policies
+});
+
+app.UseRateLimiter();
+```
+
+The architecture decision is more important than the API syntax: choose the right partition and resource model.
+
+## Return Clear Rejection
+
+HTTP APIs commonly use:
+
+```text
+429 Too Many Requests
+```
+
+and may provide retry guidance.
+
+Clients should distinguish throttling from arbitrary server failure.
+
+## Rate Limit vs. Bulkhead
+
+```text
+Rate Limit
+  controls arrival over time
+
+Bulkhead
+  controls concurrent resource consumption
+```
+
+Use both when both dimensions matter.
+
+## Distributed Limits
+
+In a multi-instance service, per-instance limits are not necessarily global limits.
+
+If a strict tenant-wide quota matters, coordinated state may be required.
+
+That coordination has latency and availability costs.
+
+Decide whether approximate or exact enforcement is needed.
+
+## Fairness
+
+A global limit can allow one tenant to consume all capacity.
+
+Partitioned limits preserve fairness.
+
+You may also reserve capacity for high-priority workloads.
+
+## Observability
+
+Measure:
+
+```text
+accepted requests
+rejected requests
+partition
+route
+queue time
+concurrency
+```
+
+Rate-limit rejection should be visible as a capacity/product signal, not hidden as generic errors.
+
+## When It Helps
+
+Use rate limiting at public boundaries, expensive operations, multi-tenant services, and dependencies with finite quotas.
+
+## When It Hurts
+
+Bad limits reject healthy traffic, create confusing client behavior, or move bottlenecks without understanding them.
+
+## Summary
+
+Rate limiting is admission control.
+
+It should encode a deliberate capacity and fairness policy—not merely a number copied from a configuration example.

--- a/src/posts/2030-06-16-timeouts-deadlines.md
+++ b/src/posts/2030-06-16-timeouts-deadlines.md
@@ -1,0 +1,146 @@
+---
+author: Steve Kaschimer
+date: 2030-06-16
+image: /images/posts/2030-06-16-hero.webp
+image_alt: "An hourglass glyph positioned along a chain of connected nodes, implying a shared time budget passed along a call chain."
+image_prompt: "A dark-mode technical editorial illustration on a near-black background with electric teal, amber, and off-white accents. Composition centers on a small amber hourglass glyph positioned at the first node of a horizontal chain of four teal nodes connected by a line, with the hourglass motif faintly echoed and shrinking at each subsequent node, implying one time budget consumed as it passes through a distributed call chain. Mood is finite and propagating. Avoid: vendor logos, brand colors, circuit-board textures, gears, or generic clip art as the dominant motif."
+layout: post.njk
+site_title: Tech Notes
+summary: "Every remote call can wait forever unless something decides otherwise."
+tags: ["dotnet", "architecture", "design-patterns", "resilience"]
+title: "Timeouts and Deadline Propagation: Giving Distributed Work a Time Budget"
+---
+
+Every remote call can wait forever unless something decides otherwise.
+
+A timeout says:
+
+> This operation is no longer worth waiting for.
+
+A deadline makes that decision propagate through a distributed call chain.
+
+## The Latency Amplification Problem
+
+```text
+Client -> API -> Service A -> Service B -> Database
+```
+
+If every layer independently allows 30 seconds, the original request's latency objective is meaningless.
+
+The caller needs one overall time budget.
+
+## Timeout vs. Deadline
+
+Timeout:
+
+```text
+wait at most 2 seconds from now
+```
+
+Deadline:
+
+```text
+this entire operation must finish by 14:03:17.250
+```
+
+Deadlines compose better across services because each hop can calculate remaining time.
+
+## Cancellation in .NET
+
+Propagate `CancellationToken`:
+
+```csharp
+app.MapGet("/orders/{id}", async (
+    Guid id,
+    IOrderQueries queries,
+    CancellationToken cancellationToken) =>
+{
+    return await queries.GetAsync(
+        id,
+        cancellationToken);
+});
+```
+
+Pass it through database and HTTP calls.
+
+Ignoring cancellation keeps doing work nobody is waiting for.
+
+## Child Budgets
+
+A service should reserve enough time to return a response.
+
+If 800 ms remains:
+
+```text
+downstream timeout = 750 ms
+```
+
+may leave almost no response budget.
+
+Budget downstream work intentionally.
+
+## Timeout + Retry
+
+Three 2-second attempts do not fit inside a 3-second request budget.
+
+Retry must consume the same overall deadline.
+
+```text
+overall deadline
+  |
+attempt
+backoff
+attempt
+```
+
+Stop when insufficient time remains.
+
+## Queue Boundaries
+
+A synchronous deadline does not automatically make sense for asynchronous work.
+
+A queued command may instead carry:
+
+```text
+ExpiresAt
+```
+
+or business SLA metadata.
+
+Consumers can reject work that is no longer useful.
+
+## Timeouts Are Not Cancellation Guarantees
+
+Your caller may stop waiting while the remote service continues executing.
+
+That is why a timed-out write can have an ambiguous outcome.
+
+Idempotency remains necessary.
+
+## Observability
+
+Record:
+
+```text
+configured timeout
+remaining deadline
+timeout source
+dependency
+operation duration
+```
+
+Distinguish caller cancellation from dependency timeout where possible.
+
+## When It Helps
+
+Every distributed call needs a bounded wait. Deadline propagation is especially valuable in multi-hop synchronous systems.
+
+## When It Hurts
+
+Timeouts become harmful when arbitrarily short values cause self-inflicted failure or when each layer resets the clock and ignores the original budget.
+
+## Summary
+
+Latency is a finite resource.
+
+Propagate a time budget through the call chain, cancel work that has lost its caller, and make Retry, Circuit Breaker, and downstream calls respect the same deadline.

--- a/src/posts/2030-06-23-optimistic-concurrency.md
+++ b/src/posts/2030-06-23-optimistic-concurrency.md
@@ -1,0 +1,157 @@
+---
+author: Steve Kaschimer
+date: 2030-06-23
+image: /images/posts/2030-06-23-hero.webp
+image_alt: "A shape with a small version tag, and one faint duplicate ghost outline slightly offset behind it."
+image_prompt: "A dark-mode technical editorial illustration on a near-black background with electric teal, amber, and off-white accents. Composition centers on one solid teal shape with a small amber version-tag glyph attached to its corner, and one faint offset ghost outline of the same shape rendered behind it in off-white, implying a staleness check performed only at the moment of commit rather than a held lock. Mood is watchful but permissive. Avoid: vendor logos, brand colors, circuit-board textures, gears, or generic clip art as the dominant motif."
+layout: post.njk
+site_title: Tech Notes
+summary: "Optimistic concurrency assumes conflicts are uncommon enough that work can proceed without holding a long-lived lock."
+tags: ["dotnet", "architecture", "design-patterns", "concurrency"]
+title: "Optimistic Concurrency: Detecting Conflicting Changes Without Holding Locks"
+---
+
+Optimistic concurrency assumes conflicts are uncommon enough that work can proceed without holding a long-lived lock.
+
+At commit time, the system asks:
+
+> Has this state changed since I read it?
+
+If yes, the write is rejected or reconciled.
+
+## Version Token
+
+```text
+Order 42
+Version = 7
+```
+
+A client loads version 7.
+
+Another request updates the order to version 8.
+
+The original client tries:
+
+```text
+UPDATE ... WHERE Id = 42 AND Version = 7
+```
+
+Zero rows are updated.
+
+A conflict occurred.
+
+## EF Core
+
+EF Core supports concurrency tokens.
+
+```csharp
+public sealed class Order
+{
+    public Guid Id { get; private set; }
+
+    [Timestamp]
+    public byte[] Version { get; private set; } = [];
+}
+```
+
+On conflict, `SaveChangesAsync` can throw `DbUpdateConcurrencyException`.
+
+The application decides what the conflict means.
+
+## Conflict Strategies
+
+Possible responses:
+
+```text
+reject and ask user to reload
+retry command against new state
+merge non-conflicting fields
+apply domain-specific reconciliation
+```
+
+Do not automatically retry every conflict.
+
+If two humans edited the same meaningful field, silent last-writer-wins may lose business intent.
+
+## Aggregate Boundary
+
+Optimistic concurrency fits naturally around a DDD Aggregate.
+
+```text
+load Aggregate v7
+perform domain behavior
+save expected v7
+```
+
+The aggregate's consistency boundary becomes the concurrency boundary.
+
+## HTTP ETags
+
+The same concept can cross HTTP.
+
+Server:
+
+```text
+ETag: "7"
+```
+
+Client update:
+
+```text
+If-Match: "7"
+```
+
+If the resource changed, return a precondition/conflict response instead of overwriting newer state.
+
+## Commands
+
+A command can carry an expected version:
+
+```csharp
+public sealed record ChangeShippingAddress(
+    OrderId OrderId,
+    long ExpectedVersion,
+    Address Address);
+```
+
+This makes concurrency intent explicit.
+
+## When Optimism Works
+
+It works well when:
+
+- conflicts are relatively rare;
+- transactions should remain short;
+- users/processes can retry or reconcile.
+
+## When It Does Not
+
+If hundreds of workers constantly update the same record, optimistic retries may become contention loops.
+
+The real design may need:
+
+- partitioning;
+- serialization through a queue;
+- a different aggregate boundary.
+
+## Testing
+
+Test:
+
+```text
+two readers load same version
+first update succeeds
+second detects conflict
+```
+
+Also test the chosen recovery semantics.
+
+## Summary
+
+Optimistic concurrency does not prevent simultaneous work.
+
+It prevents one writer from unknowingly overwriting state that changed since it was read.
+
+Detection is easy.
+
+The business decision about what to do after detection is the real pattern.

--- a/src/posts/2030-06-30-distributed-lock-lease.md
+++ b/src/posts/2030-06-30-distributed-lock-lease.md
@@ -1,0 +1,150 @@
+---
+author: Steve Kaschimer
+date: 2030-06-30
+image: /images/posts/2030-06-30-hero.webp
+image_alt: "A padlock glyph with a small clock ring around it, implying an expiring, renewable hold rather than permanent ownership."
+image_prompt: "A dark-mode technical editorial illustration on a near-black background with electric teal, amber, and off-white accents. Composition centers on a single amber padlock glyph encircled by a thin teal clock-ring with one small tick mark, implying temporary, renewable exclusive ownership rather than a permanent lock. Mood is temporary and accountable. Avoid: vendor logos, brand colors, circuit-board textures, gears, or generic clip art as the dominant motif."
+layout: post.njk
+site_title: Tech Notes
+summary: "Sometimes multiple processes must coordinate so that only one performs a piece of work at a time."
+tags: ["dotnet", "architecture", "design-patterns", "concurrency"]
+title: "Distributed Lock and Lease: Coordinating Exclusive Work Across Processes"
+---
+
+Sometimes multiple processes must coordinate so that only one performs a piece of work at a time.
+
+A distributed lock sounds like the obvious solution.
+
+It is also one of the easiest primitives to misuse.
+
+## Why Local Locks Fail
+
+```csharp
+lock (_gate)
+{
+}
+```
+
+coordinates threads inside one process.
+
+With five service instances, there are five different locks.
+
+Distributed coordination requires shared state.
+
+## Prefer Avoiding the Lock
+
+Before creating a distributed lock, ask whether the problem can be solved with:
+
+- unique constraints;
+- optimistic concurrency;
+- idempotency;
+- queue partitioning;
+- atomic database operations.
+
+Those mechanisms often provide stronger, simpler correctness.
+
+## Lease Instead of Eternal Lock
+
+Distributed systems cannot reliably know whether a process is dead or merely unreachable.
+
+A **lease** expires.
+
+```text
+Owner A
+Lease until 12:00:30
+```
+
+A healthy owner renews it.
+
+If it disappears, another owner can eventually acquire the lease.
+
+## The Paused Owner Problem
+
+Owner A acquires a lease.
+
+A pauses for 60 seconds.
+
+The lease expires.
+
+Owner B acquires it.
+
+A wakes up and continues believing it owns the resource.
+
+Now two owners can act.
+
+Expiration alone does not guarantee safety.
+
+## Fencing Tokens
+
+Each successful acquisition receives a monotonically increasing token:
+
+```text
+A -> token 41
+B -> token 42
+```
+
+The protected resource rejects operations using an older token.
+
+```text
+42 accepted
+41 rejected
+```
+
+Fencing protects against stale owners continuing after lease loss.
+
+## Database Example
+
+For some workloads, a database row can store:
+
+```text
+Resource
+Owner
+LeaseUntil
+FencingToken
+```
+
+Acquisition must be atomic.
+
+The exact SQL depends on the database.
+
+## Do Not Hold Leases Across Human Time
+
+A distributed lease is a poor fit for:
+
+```text
+user opens edit page
+goes to lunch
+returns
+```
+
+Use optimistic concurrency for human editing.
+
+## Failure Semantics
+
+Define:
+
+```text
+How long is the lease?
+How often renew?
+What if renewal fails?
+Can work stop safely?
+Does protected resource honor fencing?
+```
+
+Without answers, the "lock" may be wishful thinking.
+
+## When It Helps
+
+Use leases for rare workloads that truly require temporary exclusive ownership across processes.
+
+## When It Hurts
+
+It hurts when used as a universal substitute for transaction design or idempotency.
+
+Distributed locks add a failure-prone coordination dependency.
+
+## Summary
+
+Prefer designs that do not require distributed locks.
+
+When exclusivity is genuinely necessary, use leases with explicit expiration and consider fencing tokens so a stale owner cannot keep acting after ownership has moved on.

--- a/src/posts/2030-07-07-leader-election.md
+++ b/src/posts/2030-07-07-leader-election.md
@@ -1,0 +1,123 @@
+---
+author: Steve Kaschimer
+date: 2030-07-07
+image: /images/posts/2030-07-07-hero.webp
+image_alt: "A small beacon mark positioned above one node among several otherwise identical nodes."
+image_prompt: "A dark-mode technical editorial illustration on a near-black background with electric teal, amber, and off-white accents. Composition centers on four small identical teal nodes arranged in a loose group, with one small amber beacon mark positioned directly above a single one of them, implying one coordinator chosen among equals rather than a permanently distinct role. Mood is provisional and coordinated. Avoid: vendor logos, brand colors, circuit-board textures, gears, or generic clip art as the dominant motif."
+layout: post.njk
+site_title: Tech Notes
+summary: "Some workloads need many application instances for availability but exactly one active coordinator for a particular responsibility."
+tags: ["dotnet", "architecture", "design-patterns", "distributed-systems"]
+title: "Leader Election: Choosing One Active Coordinator"
+---
+
+Some workloads need many application instances for availability but exactly one active coordinator for a particular responsibility.
+
+Leader Election chooses that coordinator.
+
+```text
+Instance A  <- leader
+Instance B
+Instance C
+```
+
+If A disappears, another instance takes over.
+
+## Example Workloads
+
+```text
+periodic reconciliation
+singleton scheduler
+partition assignment
+coordination loop
+```
+
+Do not use leader election for ordinary horizontally scalable request handling.
+
+## Lease-Based Election
+
+A common model uses a renewable lease.
+
+```text
+try acquire leadership
+   |
+success
+   |
+perform leader work
+   |
+renew lease
+```
+
+Followers periodically attempt acquisition.
+
+## Leadership Is Temporary
+
+A process must assume leadership can be lost at any time.
+
+```csharp
+while (leadership.IsHeld &&
+       !cancellationToken.IsCancellationRequested)
+{
+    await RunCoordinationCycleAsync(
+        cancellationToken);
+}
+```
+
+Long-running work should react promptly to loss.
+
+## Split Brain
+
+The dangerous state is:
+
+```text
+A thinks it is leader
+B thinks it is leader
+```
+
+Lease expiry, network partitions, or paused processes can cause stale leadership.
+
+For work with destructive side effects, combine leadership with fencing or downstream idempotency.
+
+## Do You Need a Leader?
+
+If every scheduled job can safely run multiple times, idempotency may eliminate the need for election.
+
+That is often simpler.
+
+Likewise, a queue can distribute work without a global leader.
+
+## Platform Capabilities
+
+Managed schedulers, orchestrators, and databases may already provide singleton execution or lease primitives.
+
+Prefer a proven platform mechanism over inventing a consensus algorithm in application code.
+
+## Observability
+
+Track:
+
+```text
+current leader
+leadership changes
+lease renewal failures
+time without leader
+duplicate coordinator detection
+```
+
+Frequent churn may indicate infrastructure instability.
+
+## When It Helps
+
+Use Leader Election when one active coordinator is genuinely required and automatic failover matters.
+
+## When It Hurts
+
+It adds coordination and split-brain risk to work that may have been safely parallelizable or idempotent.
+
+## Summary
+
+Leader Election provides singleton behavior over a redundant set of processes.
+
+The leader is never permanent.
+
+Design every leader to lose leadership safely.

--- a/src/posts/2030-07-14-observability-context-propagation.md
+++ b/src/posts/2030-07-14-observability-context-propagation.md
@@ -1,0 +1,165 @@
+---
+author: Steve Kaschimer
+date: 2030-07-14
+image: /images/posts/2030-07-14-hero.webp
+image_alt: "A single connecting thread passing consistently through several distinct nodes across a process boundary."
+image_prompt: "A dark-mode technical editorial illustration on a near-black background with electric teal, amber, and off-white accents. Composition centers on one continuous amber thread passing through four small distinct teal nodes positioned across a faint vertical boundary line, implying one causal story followed consistently across separate processes. Mood is continuous and traceable. Avoid: vendor logos, brand colors, circuit-board textures, gears, or generic clip art as the dominant motif."
+layout: post.njk
+site_title: Tech Notes
+summary: "A distributed operation may cross:"
+tags: ["dotnet", "architecture", "design-patterns", "observability"]
+title: "Observability Context Propagation: Following One Operation Across the System"
+---
+
+A distributed operation may cross:
+
+```text
+HTTP
+service
+database
+message broker
+worker
+another service
+```
+
+Without shared context, every component produces isolated telemetry.
+
+Context propagation connects those observations into one causal story.
+
+## Trace Context
+
+Modern distributed tracing associates operations with a trace and spans.
+
+```text
+Trace
+  |
+  +-- HTTP request
+  +-- SQL query
+  +-- broker publish
+  +-- consumer processing
+```
+
+W3C Trace Context provides interoperable propagation across process boundaries.
+
+## .NET Activity
+
+.NET's tracing model centers on `Activity`.
+
+```csharp
+using var activity =
+    activitySource.StartActivity(
+        "CalculateQuote");
+```
+
+Instrumentation libraries and OpenTelemetry can create and export spans without business code manually building tracing infrastructure everywhere.
+
+## Correlation ID Is Not Everything
+
+A correlation ID is useful for grouping related work.
+
+Trace context additionally models parent/child relationships and sampling.
+
+Idempotency keys and message IDs solve different problems.
+
+```text
+Trace ID       -> observability
+Correlation ID -> workflow grouping
+Message ID     -> delivery identity
+Idempotency Key-> logical operation identity
+```
+
+Do not collapse all four into one magic GUID.
+
+## Messaging
+
+HTTP libraries commonly propagate trace headers automatically.
+
+Messaging requires context in message metadata.
+
+```text
+publish span
+   |
+message headers
+   |
+consumer span
+```
+
+Do not require the domain event payload itself to carry tracing infrastructure.
+
+## Baggage
+
+Baggage can propagate small contextual values through a trace.
+
+Use it sparingly.
+
+Never treat baggage as a safe place for secrets, tokens, or large business payloads.
+
+## Logs
+
+Structured logs can include trace/span identifiers so operators can move from a log entry to the distributed trace.
+
+```text
+OrderId=42
+TraceId=...
+MessageId=...
+```
+
+Business identifiers are often useful alongside technical trace context.
+
+## Metrics
+
+Metrics answer aggregate questions:
+
+```text
+How often?
+How slow?
+How many failures?
+```
+
+Traces answer:
+
+```text
+What happened to this operation?
+```
+
+Logs provide detailed events.
+
+Good observability uses all three intentionally.
+
+## Sampling
+
+At high volume, retaining every trace may be expensive.
+
+Sampling reduces volume.
+
+But aggressive sampling can hide rare failures.
+
+Use strategies appropriate to traffic and incident needs.
+
+## OpenTelemetry
+
+OpenTelemetry provides vendor-neutral APIs, SDKs, semantic conventions, and exporters for traces, metrics, and logs.
+
+That reduces coupling between application instrumentation and a specific observability backend.
+
+## Cardinality
+
+Do not put unbounded values such as `OrderId` into metric dimensions.
+
+High-cardinality metrics can become expensive or unusable.
+
+Those identifiers belong more naturally in traces and logs.
+
+## When It Helps
+
+Context propagation is essential once a request or workflow crosses process boundaries.
+
+## When It Hurts
+
+It becomes noise when teams collect enormous telemetry without defining operational questions, retention, sampling, or privacy rules.
+
+## Summary
+
+Observability context turns distributed telemetry from isolated breadcrumbs into a causal story.
+
+Propagate standard trace context automatically, keep business and delivery identities distinct, and use OpenTelemetry to avoid binding instrumentation to one backend.

--- a/src/posts/2030-07-21-consumer-driven-contract-testing.md
+++ b/src/posts/2030-07-21-consumer-driven-contract-testing.md
@@ -1,0 +1,136 @@
+---
+author: Steve Kaschimer
+date: 2030-07-21
+image: /images/posts/2030-07-21-hero.webp
+image_alt: "Two puzzle-piece-like shapes on either side of a boundary, one clearly defining the exact notch the other must fit."
+image_prompt: "A dark-mode technical editorial illustration on a near-black background with electric teal, amber, and off-white accents. Composition centers on two interlocking amber and teal puzzle-piece-shaped glyphs positioned on either side of a thin off-white boundary line, not yet joined, one shape's notch clearly defining the exact profile the other must match, implying an explicit expectation verified before deployment. Mood is precise and mutually accountable. Avoid: vendor logos, brand colors, circuit-board textures, gears, or generic clip art as the dominant motif."
+layout: post.njk
+site_title: Tech Notes
+summary: "Independent deployment creates a dangerous possibility:"
+tags: ["dotnet", "architecture", "design-patterns", "testing"]
+title: "Consumer-Driven Contract Testing: Catching Integration Breakage Before Deployment"
+---
+
+Independent deployment creates a dangerous possibility:
+
+```text
+Provider deploys
+Provider tests pass
+Consumer deploys
+Consumer tests pass
+Integration breaks
+```
+
+Consumer-Driven Contract Testing verifies that a provider still satisfies the interactions its consumers actually depend on.
+
+## The Contract
+
+A consumer records expectations such as:
+
+```text
+GET /customers/42
+
+expects:
+200
+id
+displayName
+status
+```
+
+The provider verifies those expectations against its implementation.
+
+## Why Not Share DTO Packages?
+
+A shared assembly can keep compile-time types aligned.
+
+It can also tightly couple release cycles and still miss runtime behavior:
+
+```text
+status codes
+headers
+serialization
+optional fields
+semantic meaning
+```
+
+Contracts should test the actual boundary.
+
+## Consumer Ownership
+
+The consumer defines what it needs.
+
+That is important.
+
+Provider-only tests tend to verify what the provider intends to expose, not necessarily what consumers rely on.
+
+## HTTP and Messaging
+
+The same principle applies to event contracts.
+
+Consumer expectation:
+
+```text
+OrderPlaced contains
+eventId
+orderId
+total
+currency
+```
+
+Provider verification ensures new publisher code still produces compatible messages.
+
+## Contract Broker / Registry
+
+At scale, teams need somewhere to publish and discover contract versions and verification results.
+
+CI can then answer:
+
+```text
+Can this provider version safely deploy
+against known consumers?
+```
+
+## Contracts Are Not End-to-End Tests
+
+Contract tests prove boundary compatibility.
+
+They do not prove the entire production workflow works.
+
+Use a testing portfolio:
+
+```text
+unit
+integration
+contract
+small number of end-to-end tests
+```
+
+## Avoid Overspecification
+
+A consumer should not contract-test every field in a response if it uses only three.
+
+Overspecified contracts freeze irrelevant provider details.
+
+Test the dependency that actually exists.
+
+## Versioning
+
+Contract verification helps teams evolve APIs additively and detect breaking changes before rollout.
+
+It complements—not replaces—a versioning strategy.
+
+## When It Helps
+
+Use consumer-driven contracts when services or teams deploy independently and integration breakage is costly.
+
+## When It Hurts
+
+For one codebase deployed atomically, contract infrastructure may cost more than it saves.
+
+## Summary
+
+Consumer-Driven Contract Testing moves integration compatibility into CI.
+
+The consumer declares the boundary it depends on, and the provider continuously proves that boundary still works.
+
+That is much faster feedback than discovering incompatibility after independent deployments meet in production.

--- a/src/posts/2030-07-28-sidecar.md
+++ b/src/posts/2030-07-28-sidecar.md
@@ -1,0 +1,163 @@
+---
+author: Steve Kaschimer
+date: 2030-07-28
+image: /images/posts/2030-07-28-hero.webp
+image_alt: "One large primary box with a smaller satellite box attached flush beside it, sharing one boundary edge."
+image_prompt: "A dark-mode technical editorial illustration on a near-black background with electric teal, amber, and off-white accents. Composition centers on one large teal primary-process box with a smaller amber satellite box attached flush against one of its edges, sharing a visible seam, implying a supporting capability running beside the application rather than inside it. Mood is adjacent and supportive. Avoid: vendor logos, brand colors, circuit-board textures, gears, or generic clip art as the dominant motif."
+layout: post.njk
+site_title: Tech Notes
+summary: "A Sidecar runs a supporting process beside an application instance."
+tags: ["dotnet", "architecture", "design-patterns", "microservices"]
+title: "Sidecar: Moving Cross-Cutting Runtime Capabilities Beside the Application"
+---
+
+A Sidecar runs a supporting process beside an application instance.
+
+```text
+Pod / Host
++----------------------+
+| Application          |
+| Sidecar              |
++----------------------+
+```
+
+The two share a lifecycle or local environment while remaining separate processes.
+
+## Why Use One?
+
+Some capabilities are useful across applications but do not belong in business code:
+
+```text
+proxying
+telemetry collection
+secret/config refresh
+protocol adaptation
+service-mesh networking
+```
+
+A sidecar can provide them without embedding the implementation into every application.
+
+## Local Communication
+
+The application may communicate with the sidecar through:
+
+```text
+localhost HTTP/gRPC
+shared volume
+local socket
+```
+
+Locality reduces some network complexity, but the sidecar is still another process that can fail.
+
+## Example: Proxy Sidecar
+
+```text
+Application
+   |
+localhost
+   |
+Proxy Sidecar
+   |
+Remote Services
+```
+
+The proxy may handle transport-level concerns such as mutual TLS or telemetry.
+
+The application remains focused on business behavior.
+
+## Deployment Coupling
+
+Sidecars are usually deployed with each application instance.
+
+Scale from:
+
+```text
+10 application instances
+```
+
+to:
+
+```text
+10 application + 10 sidecar instances
+```
+
+Resource cost matters.
+
+## Sidecar vs. Library
+
+Library:
+
+```text
+same process
+lower network overhead
+language-specific
+```
+
+Sidecar:
+
+```text
+separate process
+language-neutral
+independent runtime
+operational overhead
+```
+
+Use a sidecar when process isolation or language-neutral reuse provides real value.
+
+## Sidecar vs. Service
+
+A shared remote service scales independently and has one network endpoint.
+
+A sidecar is local to each application instance.
+
+Choose based on ownership, latency, isolation, and scaling requirements.
+
+## Failure Semantics
+
+Ask:
+
+```text
+What if sidecar is unavailable?
+Can app start?
+Can it stay ready?
+Does traffic fail open or closed?
+```
+
+Do not accidentally make optional telemetry a hard availability dependency.
+
+## Kubernetes
+
+Sidecars are especially common in pod-based deployments because containers in a pod share networking and lifecycle context.
+
+But the pattern is not Kubernetes-specific.
+
+## Sidecar Explosion
+
+If every concern becomes another container:
+
+```text
+app
+proxy
+telemetry
+secrets
+policy
+adapter
+```
+
+operational cost and resource usage can become significant.
+
+Use platform-native capabilities when they solve the problem more simply.
+
+## When It Helps
+
+Use Sidecar when a cross-cutting runtime capability benefits from process isolation, local proximity, or language-neutral reuse.
+
+## When It Hurts
+
+It hurts when a simple library or platform feature would do, or when critical application behavior becomes dependent on a fragile collection of helper processes.
+
+## Summary
+
+Sidecar moves selected infrastructure capabilities beside the application rather than inside it.
+
+That can improve separation and reuse, but every sidecar is another runtime component with lifecycle, resource, security, and failure semantics.

--- a/src/posts/2030-08-04-architecture-complexity-ladder-revisited.md
+++ b/src/posts/2030-08-04-architecture-complexity-ladder-revisited.md
@@ -1,0 +1,629 @@
+---
+author: Steve Kaschimer
+date: 2030-08-04
+image: /images/posts/2030-08-04-hero.webp
+image_alt: "The same eight-rung ladder from earlier in the series, fully visible, with a small marker standing partway up rather than reaching for the top."
+image_prompt: "A dark-mode technical editorial illustration on a near-black background with electric teal, amber, and off-white accents. Composition centers on the same vertical teal eight-rung ladder glyph used earlier in this series, now shown fully assembled top to bottom, with one small amber marker glyph standing deliberately partway up rather than climbing toward the highest rung, implying informed restraint rather than unclimbed ambition. Mood is reflective and deliberate. Avoid: vendor logos, brand colors, circuit-board textures, gears, or generic clip art as the dominant motif."
+layout: post.njk
+site_title: Tech Notes
+summary: "We have spent two volumes learning patterns."
+tags: ["dotnet", "architecture", "design-patterns", "software-design"]
+title: "The Architecture Complexity Ladder: Knowing When Not to Use a Pattern"
+---
+
+We have spent two volumes learning patterns.
+
+The final lesson is more important:
+
+> **A pattern is not free.**
+
+Every pattern buys a capability by introducing a cost.
+
+Good architecture is not the architecture containing the most patterns.
+
+It is the simplest architecture that reliably satisfies the forces acting on the system.
+
+## Start With the Problem
+
+Architecture discussions often begin with solutions:
+
+```text
+Should we use microservices?
+Should we use CQRS?
+Should we use Event Sourcing?
+Should we add Kafka?
+```
+
+Reverse the conversation:
+
+```text
+What is failing?
+What cannot scale?
+Which invariant is difficult to protect?
+Which teams are blocked?
+Which recovery guarantee is missing?
+```
+
+Only then choose a pattern.
+
+## The Ladder
+
+A useful mental model is a complexity ladder.
+
+```text
+Simple CRUD
+    |
+Transaction Script
+    |
+Vertical Slice
+    |
+Domain Model
+    |
+Aggregate
+    |
+CQRS
+    |
+Asynchronous Messaging
+    |
+Outbox + Inbox
+    |
+Saga
+    |
+Event Sourcing
+```
+
+This is not a maturity model.
+
+Higher is not better.
+
+Every rung exists because a new force can make the rung below insufficient.
+
+## Rung 0: Simple CRUD
+
+Start here when the problem is fundamentally data maintenance.
+
+```text
+Create
+Read
+Update
+Delete
+```
+
+Use framework capabilities directly.
+
+If this solves the business problem cleanly, stop.
+
+Do not apologize for CRUD.
+
+## Climb When
+
+Business operations become more meaningful than generic record updates.
+
+## Rung 1: Transaction Script
+
+Organize each use case as an explicit operation.
+
+```text
+PlaceOrder
+CancelOrder
+ApproveInvoice
+```
+
+The script coordinates validation, data access, and transaction behavior.
+
+This is often enough for surprisingly large systems.
+
+## Cost
+
+Some business rules may begin to duplicate across scripts.
+
+## Climb When
+
+The domain contains rich behavior and invariants shared across operations.
+
+## Rung 2: Vertical Slice
+
+Organize code around use cases rather than technical layers.
+
+```text
+Orders/
+  Place/
+  Cancel/
+  Search/
+```
+
+This reduces horizontal ceremony and keeps changes localized.
+
+Vertical Slice is often compatible with either simple scripts or rich domain models.
+
+## Cost
+
+Without discipline, shared business behavior can duplicate across slices.
+
+## Climb When
+
+The business model itself needs first-class representation.
+
+## Rung 3: Domain Model
+
+Move important business behavior into explicit domain concepts.
+
+```text
+Order
+Money
+PricingPolicy
+```
+
+Now code speaks the business language.
+
+## Cost
+
+Mapping, persistence boundaries, and model design require more thought.
+
+## Climb When
+
+Some groups of state must remain consistent through every write.
+
+## Rung 4: Aggregate
+
+Define a transactional consistency boundary.
+
+```text
+Order
+  |
+OrderItems
+```
+
+The Aggregate Root protects invariants.
+
+## Cost
+
+Aggregate design constrains transaction and reference patterns.
+
+Large aggregates create contention.
+
+Small aggregates create coordination needs.
+
+## Climb When
+
+Read and write requirements begin pulling the model in incompatible directions.
+
+## Rung 5: CQRS
+
+Separate write behavior from read projection.
+
+```text
+Commands -> Domain Model
+Queries  -> Read Model
+```
+
+Start with one database.
+
+## Cost
+
+Two conceptual models must now be understood and maintained.
+
+## Do Not Automatically Climb
+
+CQRS does **not** imply separate databases.
+
+Stay here if independent persistence provides no value.
+
+## Climb When
+
+Reads and writes genuinely need different stores, scaling, schemas, or deployment paths.
+
+## Rung 6: Asynchronous Messaging
+
+Once work crosses an asynchronous boundary:
+
+```text
+Producer
+   |
+Broker
+   |
+Consumer
+```
+
+you gain decoupling, buffering, and independent processing.
+
+You also inherit:
+
+```text
+duplicates
+ordering questions
+delayed work
+poison messages
+partial failure
+```
+
+## Cost
+
+Debugging and operational reasoning become distributed.
+
+## Climb When
+
+Database state and message publication must not diverge.
+
+## Rung 7: Outbox + Inbox
+
+Outbox solves:
+
+```text
+commit state
+but lose event
+```
+
+Inbox solves:
+
+```text
+receive event twice
+and duplicate effect
+```
+
+Together they provide reliable local boundaries around at-least-once messaging.
+
+## Cost
+
+Tables, dispatchers, retention, retries, deduplication, and monitoring.
+
+## Climb When
+
+One business workflow must span several independently committed participants.
+
+## Rung 8: Saga
+
+Saga makes distributed workflow state explicit.
+
+```text
+Reserve
+Authorize
+Fulfill
+```
+
+with timeouts and compensation.
+
+## Cost
+
+You no longer have global rollback.
+
+Recovery becomes domain behavior.
+
+Operations must understand workflow state.
+
+## Ask a Hard Question
+
+Did the business truly require independent services?
+
+Or did architecture turn one easy transaction into a Saga?
+
+Sometimes the correct move is **down the ladder**.
+
+## Rung 9: Event Sourcing
+
+Event Sourcing changes persistence itself:
+
+```text
+current state
+```
+
+becomes:
+
+```text
+history of facts
+```
+
+This unlocks temporal reconstruction and powerful projections.
+
+## Cost
+
+You now own permanent event contracts, replay, projection lag, schema evolution, and specialized operational tooling.
+
+## Climb Only When
+
+History itself is part of the domain and those capabilities justify permanent complexity.
+
+Never adopt Event Sourcing merely because you already use events.
+
+## Complexity Is Multidimensional
+
+The ladder is not the only axis.
+
+A system can also acquire complexity through:
+
+```text
+deployment topology
+data distribution
+team topology
+security boundaries
+availability requirements
+traffic scale
+multi-region operation
+```
+
+A modular monolith with sophisticated domain logic may be more appropriate than five CRUD microservices.
+
+## Microservices Are a Trade, Not a Destination
+
+Splitting a process creates capabilities:
+
+```text
+independent deployment
+independent scaling
+technology autonomy
+fault isolation
+team ownership
+```
+
+It also destroys capabilities you previously had for free:
+
+```text
+local calls
+local transactions
+simple debugging
+one deployment
+strong consistency
+```
+
+You then buy replacements:
+
+```text
+local call
+ -> network call + timeout + retry
+
+local transaction
+ -> Saga + compensation
+
+method parameter
+ -> versioned contract
+
+stack trace
+ -> distributed trace
+
+single commit
+ -> Outbox + Inbox
+```
+
+That does not make microservices bad.
+
+It makes their price visible.
+
+## The Pattern Tax
+
+Every pattern introduces some combination of:
+
+```text
+code
+concepts
+runtime components
+failure modes
+configuration
+testing
+monitoring
+on-call knowledge
+```
+
+Call this the **pattern tax**.
+
+A pattern is justified when the value it creates exceeds that tax.
+
+## Reversibility Matters
+
+Prefer decisions that are cheap to change.
+
+Examples:
+
+```text
+direct handler call
+ -> mediator later
+
+single database CQRS
+ -> separate read store later
+
+modular monolith
+ -> extract service later
+
+ordinary persistence
+ -> do NOT assume Event Sourcing later is cheap
+```
+
+Some choices are more reversible than others.
+
+Architecture should spend irreversible complexity carefully.
+
+## Localize Complexity
+
+If only one workflow needs a Saga, do not make the whole application "Saga architecture."
+
+If one query needs Dapper, do not replace every EF Core query.
+
+If one integration needs an ACL, put it at that boundary.
+
+```text
+complexity belongs
+where the problem lives
+```
+
+This is one of the strongest principles in the entire series.
+
+## Architecture Fitness Questions
+
+Before adding a pattern, ask:
+
+1. What concrete problem exists today?
+2. What evidence shows the current design is insufficient?
+3. What guarantee does the new pattern provide?
+4. What new failure modes does it introduce?
+5. Who will operate it at 2:00 AM?
+6. How will we know it is working?
+7. Can we solve the problem more locally?
+8. Can we defer the decision?
+9. What is the exit strategy?
+10. What would make us remove the pattern later?
+
+If the answers are vague, the architecture probably is too.
+
+## A Practical Decision Example
+
+Suppose an ordering system begins as:
+
+```text
+ASP.NET Core
+EF Core
+PostgreSQL
+```
+
+Perfectly reasonable.
+
+Business rules grow.
+
+Add:
+
+```text
+Order Aggregate
+```
+
+Reporting becomes awkward.
+
+Add:
+
+```text
+direct read projections
+```
+
+No separate database required.
+
+Email sending slows checkout.
+
+Add:
+
+```text
+Outbox
+Queue
+Email Consumer
+```
+
+No need to make Orders a microservice.
+
+Traffic grows and Recommendations overloads the page.
+
+Add:
+
+```text
+Bulkhead
+Circuit Breaker
+```
+
+only around Recommendations.
+
+Later, a dedicated fulfillment team needs independent deployment and scaling.
+
+Now perhaps extract:
+
+```text
+Fulfillment Module
+    ->
+Fulfillment Service
+```
+
+The architecture evolved because forces appeared.
+
+That is healthy architecture.
+
+## Going Down the Ladder
+
+Patterns can be removed.
+
+If an asynchronous workflow no longer needs independent scaling:
+
+```text
+broker -> direct call
+```
+
+may be an improvement.
+
+If a microservice creates more coordination than autonomy:
+
+```text
+service -> module
+```
+
+may be an improvement.
+
+Architecture is not a one-way migration toward more infrastructure.
+
+Simplification is architectural work.
+
+## The Senior Engineering Skill
+
+Knowing how to implement a pattern is useful.
+
+Knowing when to implement it is better.
+
+Knowing when **not** to implement it is architecture.
+
+The expert does not look at a simple system and ask:
+
+> Which patterns are missing?
+
+The expert asks:
+
+> Which forces are not yet handled well?
+
+Sometimes the answer is:
+
+```text
+none
+```
+
+and the correct architectural decision is to leave the system alone.
+
+## Where Volume III Begins
+
+Volume II focused on application and service architecture.
+
+The next frontier is what happens when scale and distribution become architectural forces of their own:
+
+```text
+partitioning
+sharding
+consistent hashing
+load shedding
+backpressure
+multi-region systems
+replication
+distributed consensus
+cell-based architecture
+deployment patterns
+cloud-native coordination
+```
+
+Those patterns deserve their own volume because the question changes.
+
+Volume II asked:
+
+> How should a modern application be structured?
+
+Volume III will ask:
+
+> How does that application remain correct and available when the system itself becomes distributed?
+
+## Final Summary
+
+Patterns are vocabulary.
+
+They are not a checklist.
+
+Start simple.
+
+Observe the forces acting on the system.
+
+Add the smallest pattern that supplies the missing capability.
+
+Understand the new failure modes you purchased.
+
+Measure whether the trade was worthwhile.
+
+And always preserve the option to simplify again.
+
+That is the real pattern behind all the others.


### PR DESCRIPTION
## Summary
- Schedules and publishes 49 posts continuing the *Modern Application Architecture Patterns in .NET* series past Volume I's Fowler-catalog foundation: dependency injection, Clean/Hexagonal/Vertical Slice architecture, Domain-Driven Design building blocks, CQRS, messaging and event-driven patterns, distributed workflow coordination, resilience patterns, and architecture-at-scale concerns (feature flags, health checks, rate limiting, leader election, etc.)
- Runs weekly on Sundays immediately following Volume I as a standing series alongside the Tuesday .NET tracks, 2029-09-02 through 2030-08-04
- Source content (fully drafted in `docs/article-ideas/01` through `49`) is unchanged aside from: frontmatter converted to house style (author/date/image/image_alt/image_prompt/layout/site_title/summary/tags/title), duplicate H1 titles stripped from post bodies where present (articles 37 onward in this volume don't open with one), and literal em-dash artifacts (`word---word`) fixed to the house ` - ` convention
- Article 49's source draft had a broken heading hierarchy (major sections marked as a second H1 instead of H2, unlike every other post in both volumes); those headings were demoted one level in the generated post so the page has a single H1 from the hero title
- Source articles 3 and 49 both cover "The Architecture Complexity Ladder" under the same `architecture-complexity-ladder` slug (the series' opening framework and its closing retrospective); article 49's destination file and URL use `architecture-complexity-ladder-revisited` to avoid colliding with article 3's published post
- Sequencing follows each source file's own `order:` field (1-49), matching its numeric filename prefix
- `editorial-plan.md` updated with the new Sunday Track section, inserted immediately after Volume I's section

## Test plan
- [x] `npm run deploy` builds successfully
- [x] `node scripts/a11y-check.js` reports zero accessibility violations (home, a post, about, privacy, terms, 404 - light and dark)
- [x] Verified no leftover `word---word` dash artifacts, duplicate tags, bad image paths, or stray H1s across all 49 generated posts
- [x] All code-fence languages used (`csharp`, `json`, `text`) already covered by the site's existing Prism setup

Co-authored-by: Claude <noreply@anthropic.com>

---
_Generated by [Claude Code](https://claude.ai/code/session_01WKyNF7L5qzrfct8cec6A32)_